### PR TITLE
#66 wrong mount path fix

### DIFF
--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -29,12 +29,12 @@ type VMAgentSpec struct {
 	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// Secrets is a list of Secrets in the same namespace as the vmagent
 	// object, which shall be mounted into the vmagent Pods.
-	// will be mounted at path /etc/vmagent/secrets
+	// will be mounted at path /etc/vm/secrets
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the vmagent
 	// object, which shall be mounted into the vmagent Pods.
-	// will be mounted at path  /etc/vmagent/configs
+	// will be mounted at path  /etc/vm/configs
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// LogLevel for VMAgent to be configured with.

--- a/api/v1beta1/vmalert_types.go
+++ b/api/v1beta1/vmalert_types.go
@@ -29,12 +29,12 @@ type VMAlertSpec struct {
 
 	// Secrets is a list of Secrets in the same namespace as the VMAlert
 	// object, which shall be mounted into the VMAlert Pods.
-	// The Secrets are mounted into /etc/vmalert/secrets/<secret-name>.
+	// The Secrets are mounted into /etc/vm/secrets/<secret-name>.
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMAlert
 	// object, which shall be mounted into the VMAlert Pods.
-	// The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>.
+	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// LogFormat for VMAlert to be configured with.

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -114,7 +114,7 @@ type VMSelect struct {
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
 	// object, which shall be mounted into the VMSelect Pods.
-	// The ConfigMaps are mounted into /etc/vm/configmaps/<configmap-name>.
+	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// LogFormat for VMSelect to be configured with.
@@ -235,12 +235,12 @@ type VMInsert struct {
 	Image Image `json:"image,omitempty"`
 	// Secrets is a list of Secrets in the same namespace as the VMSelect
 	// object, which shall be mounted into the VMSelect Pods.
-	// The Secrets are mounted into /etc/vmalert/secrets/<secret-name>.
+	// The Secrets are mounted into /etc/vm/secrets/<secret-name>.
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
 	// object, which shall be mounted into the VMSelect Pods.
-	// The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>.
+	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// LogFormat for VMSelect to be configured with.
@@ -346,12 +346,12 @@ type VMStorage struct {
 
 	// Secrets is a list of Secrets in the same namespace as the VMSelect
 	// object, which shall be mounted into the VMSelect Pods.
-	// The Secrets are mounted into /etc/vmalert/secrets/<secret-name>.
+	// The Secrets are mounted into /etc/vm/secrets/<secret-name>.
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
 	// object, which shall be mounted into the VMSelect Pods.
-	// The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>.
+	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
 	// LogFormat for VMSelect to be configured with.

--- a/config/examples/vmagent-full.yaml
+++ b/config/examples/vmagent-full.yaml
@@ -56,7 +56,7 @@ spec:
       cpu: "50m"
       memory: "50Mi"
   serviceAccountName: vmagent
-  additionalArgs:
+  extraArgs:
     memory.allowedPercent: "40"
   relabelConfig:
     name: "vm-agent-global-relabel-config"

--- a/config/examples/vmagent_tls.yaml
+++ b/config/examples/vmagent_tls.yaml
@@ -16,7 +16,7 @@ spec:
   serviceAccountName: vmagent
   secrets:
     - remote-tls
-  additionalArgs:
+  extraArgs:
     memory.allowedPercent: "40"
   remoteWrite:
     - url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429/api/v1/write"

--- a/config/examples/vmalertmanager.yaml
+++ b/config/examples/vmalertmanager.yaml
@@ -26,8 +26,6 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
   name: example-alertmanager
-  labels:
-    ns: op
 spec:
-  # Add fields here
   replicaCount: 1
+  configSecret: vmalertmanager-example-alertmanager

--- a/controllers/converter/apis.go
+++ b/controllers/converter/apis.go
@@ -2,8 +2,15 @@ package converter
 
 import (
 	v1beta1vm "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory"
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+const (
+	prometheusSecretDir    = "/etc/prometheus/secrets"
+	prometheusConfigmapDir = "/etc/prometheus/configmaps"
 )
 
 func ConvertPromRule(prom *v1.PrometheusRule) *v1beta1vm.VMRule {
@@ -61,6 +68,16 @@ func ConvertServiceMonitor(serviceMon *v1.ServiceMonitor) *v1beta1vm.VMServiceSc
 	}
 }
 
+func replacePromDirPath(origin string) string {
+	if strings.HasPrefix(origin, prometheusSecretDir) {
+		return strings.Replace(origin, prometheusSecretDir, factory.SecretsDir, 1)
+	}
+	if strings.HasPrefix(origin, prometheusConfigmapDir) {
+		return strings.Replace(origin, prometheusConfigmapDir, factory.ConfigMapsDir, 1)
+	}
+	return origin
+}
+
 func ConvertEndpoint(promEndpoint []v1.Endpoint) []v1beta1vm.Endpoint {
 	endpoints := []v1beta1vm.Endpoint{}
 	for _, endpoint := range promEndpoint {
@@ -72,7 +89,7 @@ func ConvertEndpoint(promEndpoint []v1.Endpoint) []v1beta1vm.Endpoint {
 			Params:               endpoint.Params,
 			Interval:             endpoint.Interval,
 			ScrapeTimeout:        endpoint.ScrapeTimeout,
-			BearerTokenFile:      endpoint.BearerTokenFile,
+			BearerTokenFile:      replacePromDirPath(endpoint.BearerTokenFile),
 			BearerTokenSecret:    endpoint.BearerTokenSecret,
 			HonorLabels:          endpoint.HonorLabels,
 			BasicAuth:            ConvertBasicAuth(endpoint.BasicAuth),
@@ -101,11 +118,11 @@ func ConvertTlsConfig(tlsConf *v1.TLSConfig) *v1beta1vm.TLSConfig {
 		return nil
 	}
 	return &v1beta1vm.TLSConfig{
-		CAFile:             tlsConf.CAFile,
+		CAFile:             replacePromDirPath(tlsConf.CAFile),
 		CA:                 ConvertSecretOrConfigmap(tlsConf.CA),
-		CertFile:           tlsConf.CertFile,
+		CertFile:           replacePromDirPath(tlsConf.CertFile),
 		Cert:               ConvertSecretOrConfigmap(tlsConf.Cert),
-		KeyFile:            tlsConf.KeyFile,
+		KeyFile:            replacePromDirPath(tlsConf.KeyFile),
 		KeySecret:          tlsConf.KeySecret,
 		InsecureSkipVerify: tlsConf.InsecureSkipVerify,
 	}

--- a/controllers/converter/apis_test.go
+++ b/controllers/converter/apis_test.go
@@ -1,0 +1,42 @@
+package converter
+
+import (
+	v1beta1vm "github.com/VictoriaMetrics/operator/api/v1beta1"
+	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"testing"
+)
+
+func TestConvertTlsConfig(t *testing.T) {
+	type args struct {
+		tlsConf *v1.TLSConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1beta1vm.TLSConfig
+	}{
+		{
+			name: "replace prom secret path",
+			args: args{
+				tlsConf: &v1.TLSConfig{
+					CAFile:   "/etc/prom_add/ca",
+					CertFile: "/etc/prometheus/secrets/cert.crt",
+					KeyFile:  "/etc/prometheus/configmaps/key.pem",
+				},
+			},
+			want: &v1beta1vm.TLSConfig{
+				CAFile:   "/etc/prom_add/ca",
+				CertFile: "/etc/vm/secrets/cert.crt",
+				KeyFile:  "/etc/vm/configs/key.pem",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertTlsConfig(tt.args.tlsConf)
+			if got.KeyFile != tt.want.KeyFile || got.CertFile != tt.want.CertFile || got.CAFile != tt.want.CAFile {
+				t.Errorf("ConvertTlsConfig() = \n%v, \nwant \n%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/api.MD
+++ b/docs/api.MD
@@ -193,8 +193,8 @@ VMAgentSpec defines the desired state of VMAgent
 | podMetadata | PodMetadata configures Labels and Annotations which are propagated to the vmagent pods. | *[EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
 | image | Image - docker image settings for VMAgent if no specified operator uses default config version | [Image](#image) | false |
 | imagePullSecrets | ImagePullSecrets An optional list of references to secrets in the same namespace to use for pulling images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core) | false |
-| secrets | Secrets is a list of Secrets in the same namespace as the vmagent object, which shall be mounted into the vmagent Pods. will be mounted at path /etc/vmagent/secrets | []string | false |
-| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the vmagent object, which shall be mounted into the vmagent Pods. will be mounted at path  /etc/vmagent/configs | []string | false |
+| secrets | Secrets is a list of Secrets in the same namespace as the vmagent object, which shall be mounted into the vmagent Pods. will be mounted at path /etc/vm/secrets | []string | false |
+| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the vmagent object, which shall be mounted into the vmagent Pods. will be mounted at path  /etc/vm/configs | []string | false |
 | logLevel | LogLevel for VMAgent to be configured with. INFO, WARN, ERROR, FATAL, PANIC | string | false |
 | logFormat | LogFormat for VMAgent to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMAgent cluster. The controller will eventually make the size of the running cluster equal to the expected size. NOTE enable VMSingle deduplication for replica usage | *int32 | false |
@@ -377,8 +377,8 @@ VMAlertSpec defines the desired state of VMAlert
 | podMetadata | PodMetadata configures Labels and Annotations which are propagated to the VMAlert pods. | *[EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
 | image | Image - docker image settings for VMAlert if no specified operator uses default config version | [Image](#image) | false |
 | imagePullSecrets | ImagePullSecrets An optional list of references to secrets in the same namespace to use for pulling images from registries see http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod | [][v1.LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core) | false |
-| secrets | Secrets is a list of Secrets in the same namespace as the VMAlert object, which shall be mounted into the VMAlert Pods. The Secrets are mounted into /etc/vmalert/secrets/<secret-name>. | []string | false |
-| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMAlert object, which shall be mounted into the VMAlert Pods. The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>. | []string | false |
+| secrets | Secrets is a list of Secrets in the same namespace as the VMAlert object, which shall be mounted into the VMAlert Pods. The Secrets are mounted into /etc/vm/secrets/<secret-name>. | []string | false |
+| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMAlert object, which shall be mounted into the VMAlert Pods. The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>. | []string | false |
 | logFormat | LogFormat for VMAlert to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMAlert to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMAlert cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
@@ -887,8 +887,8 @@ VMClusterStatus defines the observed state of VMCluster
 | name |  | string | false |
 | podMetadata | PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods. | *[EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
 | image | Image - docker image settings for VMInsert | [Image](#image) | false |
-| secrets | Secrets is a list of Secrets in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The Secrets are mounted into /etc/vmalert/secrets/<secret-name>. | []string | false |
-| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>. | []string | false |
+| secrets | Secrets is a list of Secrets in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The Secrets are mounted into /etc/vm/secrets/<secret-name>. | []string | false |
+| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>. | []string | false |
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |
@@ -921,7 +921,7 @@ VMClusterStatus defines the observed state of VMCluster
 | podMetadata | PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods. | *[EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
 | image | Image - docker image settings for VMSelect | [Image](#image) | false |
 | secrets | Secrets is a list of Secrets in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The Secrets are mounted into /etc/vm/secrets/<secret-name>. | []string | false |
-| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vm/configmaps/<configmap-name>. | []string | false |
+| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>. | []string | false |
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |
@@ -955,8 +955,8 @@ VMClusterStatus defines the observed state of VMCluster
 | name |  | string | false |
 | podMetadata | PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods. | *[EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
 | image | Image - docker image settings for VMStorage | [Image](#image) | false |
-| secrets | Secrets is a list of Secrets in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The Secrets are mounted into /etc/vmalert/secrets/<secret-name>. | []string | false |
-| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vmalert/configmaps/<configmap-name>. | []string | false |
+| secrets | Secrets is a list of Secrets in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The Secrets are mounted into /etc/vm/secrets/<secret-name>. | []string | false |
+| configMaps | ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect object, which shall be mounted into the VMSelect Pods. The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>. | []string | false |
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |


### PR DESCRIPTION
added replacement for prometheus secrets and configmaps mount path at objects conversion,

updated docs with proper mount name paths for secrets and configmaps,
update typo at examples