### PR TITLE
adds faster sync for vmalert rules

### DIFF
--- a/controllers/factory/rulescm.go
+++ b/controllers/factory/rulescm.go
@@ -126,6 +126,11 @@ func CreateOrUpdateRuleConfigMaps(ctx context.Context, cr *victoriametricsv1beta
 		}
 	}
 
+	// trigger sync for configmap
+	err = updatePodAnnotations(ctx, rclient, cr.PodLabels(), cr.Namespace)
+	if err != nil {
+		l.Error(err, "failed to update pod cm-sync annotation", "ns", cr.Namespace)
+	}
 	return newConfigMapNames, nil
 }
 

--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -5,16 +5,16 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
+
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var invalidDNS1123Characters = regexp.MustCompile("[^-a-z0-9]+")


### PR DESCRIPTION
https://github.com/VictoriaMetrics/operator/issues/86

after rules changes were detected,
operator updates vmalert pods annotation with current time
it triggers kubelet action to update mounted configmap