### PR TITLE
fixes: deployment update repeatedly

### DIFF
--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -433,6 +434,7 @@ func makeSpecForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOperat
 		prometheusConfigReloaderResources.Requests[corev1.ResourceMemory] = resource.MustParse(c.VMAgentDefault.ConfigReloaderMemory)
 	}
 
+	sort.Strings(args)
 	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "vmagent",

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -496,6 +497,7 @@ func vmAlertSpecGen(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOperatorCo
 	var ports []corev1.ContainerPort
 	ports = append(ports, corev1.ContainerPort{Name: "http", Protocol: "TCP", ContainerPort: intstr.Parse(cr.Spec.Port).IntVal})
 
+	sort.Strings(args)
 	defaultContainers := []corev1.Container{
 		{
 			Args:                     args,

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -656,6 +657,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 
 	var additionalContainers []corev1.Container
 
+	sort.Strings(args)
 	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "vmselect",
@@ -922,6 +924,7 @@ func makePodSpecForVMInsert(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 
 	var additionalContainers []corev1.Container
 
+	sort.Strings(args)
 	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "vminsert",
@@ -1254,6 +1257,7 @@ func makePodSpecForVMStorage(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) 
 
 	var additionalContainers []corev1.Container
 
+	sort.Strings(args)
 	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "vmstorage",

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sort"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -314,6 +315,7 @@ func makeSpecForVMSingle(cr *victoriametricsv1beta1.VMSingle, c *config.BaseOper
 
 	var additionalContainers []corev1.Container
 
+	sort.Strings(args)
 	operatorContainers := append([]corev1.Container{
 		{
 			Name:                     "vmsingle",
@@ -544,6 +546,7 @@ func makeSpecForVMBackuper(
 		FailureThreshold: 10,
 	}
 
+	sort.Strings(args)
 	vmBackuper := &corev1.Container{
 		Name:                     "vmbackuper",
 		Image:                    fmt.Sprintf("%s:%s", cr.Image.Repository, cr.Image.Tag),


### PR DESCRIPTION
# Version
k8s: 1.18.2
victoria-operator: v0.3.0

# Describe the bug
If create crd VMAlert, VMAgent, VMcluster with multiple elements in spec.extraArgs, deployment will be updated repeatedly by operator，again and again....
Though without applying new version, order of args will be changed after reconcile, cause of vm-operator generated args by looping unordered map extraArgs.

# To Reproduce
```yaml
apiVersion: operator.victoriametrics.com/v1beta1
kind: VMSelect
...
spec:
  extraArgs:
    evaluationInternal: 10s
    datasource.lookback: 1m
```

# Fixes
I fixed it by sorting the args array before return.