### PR TITLE
In PrometheusConverter in created objects include ownerReferences

### DIFF
--- a/controllers/converter/apis.go
+++ b/controllers/converter/apis.go
@@ -7,6 +7,7 @@ import (
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -45,6 +46,16 @@ func ConvertPromRule(prom *v1.PrometheusRule) *v1beta1vm.VMRule {
 			Name:        prom.Name,
 			Labels:      prom.Labels,
 			Annotations: prom.Annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               v1.PrometheusRuleKind,
+					Name:               prom.Name,
+					UID:                prom.UID,
+					Controller:         pointer.BoolPtr(true),
+					BlockOwnerDeletion: pointer.BoolPtr(true),
+				},
+			},
 		},
 		Spec: v1beta1vm.VMRuleSpec{
 			Groups: ruleGroups,
@@ -60,6 +71,16 @@ func ConvertServiceMonitor(serviceMon *v1.ServiceMonitor) *v1beta1vm.VMServiceSc
 			Namespace:   serviceMon.Namespace,
 			Annotations: serviceMon.Annotations,
 			Labels:      serviceMon.Labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               v1.ServiceMonitorsKind,
+					Name:               serviceMon.Name,
+					UID:                serviceMon.UID,
+					Controller:         pointer.BoolPtr(true),
+					BlockOwnerDeletion: pointer.BoolPtr(true),
+				},
+			},
 		},
 		Spec: v1beta1vm.VMServiceScrapeSpec{
 			JobLabel:        serviceMon.Spec.JobLabel,
@@ -194,6 +215,16 @@ func ConvertPodMonitor(podMon *v1.PodMonitor) *v1beta1vm.VMPodScrape {
 			Namespace:   podMon.Namespace,
 			Labels:      podMon.Labels,
 			Annotations: podMon.Annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               v1.PodMonitorsKind,
+					Name:               podMon.Name,
+					UID:                podMon.UID,
+					Controller:         pointer.BoolPtr(true),
+					BlockOwnerDeletion: pointer.BoolPtr(true),
+				},
+			},
 		},
 		Spec: v1beta1vm.VMPodScrapeSpec{
 			JobLabel:        podMon.Spec.JobLabel,
@@ -234,6 +265,16 @@ func ConvertProbe(probe *v1.Probe) *v1beta1vm.VMProbe {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      probe.Name,
 			Namespace: probe.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               v1.ProbesKind,
+					Name:               probe.Name,
+					UID:                probe.UID,
+					Controller:         pointer.BoolPtr(true),
+					BlockOwnerDeletion: pointer.BoolPtr(true),
+				},
+			},
 		},
 		Spec: v1beta1vm.VMProbeSpec{
 			JobName: probe.Spec.JobName,

--- a/controllers/converter/apis.go
+++ b/controllers/converter/apis.go
@@ -18,8 +18,7 @@ const (
 
 var log = ctrl.Log.WithValues("controller", "prometheus.converter")
 
-func ConvertPromRule(prom *v1.PrometheusRule) *v1beta1vm.VMRule {
-
+func ConvertPromRule(prom *v1.PrometheusRule, enableObjectRef bool) *v1beta1vm.VMRule {
 	ruleGroups := []v1beta1vm.RuleGroup{}
 	for _, promGroup := range prom.Spec.Groups {
 		ruleItems := []v1beta1vm.Rule{}
@@ -46,41 +45,33 @@ func ConvertPromRule(prom *v1.PrometheusRule) *v1beta1vm.VMRule {
 			Name:        prom.Name,
 			Labels:      prom.Labels,
 			Annotations: prom.Annotations,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         v1.SchemeGroupVersion.String(),
-					Kind:               v1.PrometheusRuleKind,
-					Name:               prom.Name,
-					UID:                prom.UID,
-					Controller:         pointer.BoolPtr(true),
-					BlockOwnerDeletion: pointer.BoolPtr(true),
-				},
-			},
 		},
 		Spec: v1beta1vm.VMRuleSpec{
 			Groups: ruleGroups,
 		},
 	}
+	if enableObjectRef {
+		cr.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         v1.SchemeGroupVersion.String(),
+				Kind:               v1.PrometheusRuleKind,
+				Name:               prom.Name,
+				UID:                prom.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			},
+		}
+	}
 	return cr
 }
 
-func ConvertServiceMonitor(serviceMon *v1.ServiceMonitor) *v1beta1vm.VMServiceScrape {
-	return &v1beta1vm.VMServiceScrape{
+func ConvertServiceMonitor(serviceMon *v1.ServiceMonitor, enableObjectRef bool) *v1beta1vm.VMServiceScrape {
+	cs := &v1beta1vm.VMServiceScrape{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        serviceMon.Name,
 			Namespace:   serviceMon.Namespace,
 			Annotations: serviceMon.Annotations,
 			Labels:      serviceMon.Labels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         v1.SchemeGroupVersion.String(),
-					Kind:               v1.ServiceMonitorsKind,
-					Name:               serviceMon.Name,
-					UID:                serviceMon.UID,
-					Controller:         pointer.BoolPtr(true),
-					BlockOwnerDeletion: pointer.BoolPtr(true),
-				},
-			},
 		},
 		Spec: v1beta1vm.VMServiceScrapeSpec{
 			JobLabel:        serviceMon.Spec.JobLabel,
@@ -95,6 +86,19 @@ func ConvertServiceMonitor(serviceMon *v1.ServiceMonitor) *v1beta1vm.VMServiceSc
 			},
 		},
 	}
+	if enableObjectRef {
+		cs.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         v1.SchemeGroupVersion.String(),
+				Kind:               v1.ServiceMonitorsKind,
+				Name:               serviceMon.Name,
+				UID:                serviceMon.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			},
+		}
+	}
+	return cs
 }
 
 func replacePromDirPath(origin string) string {
@@ -207,24 +211,13 @@ func ConvertPodEndpoints(promPodEnpoints []v1.PodMetricsEndpoint) []v1beta1vm.Po
 	return endPoints
 }
 
-func ConvertPodMonitor(podMon *v1.PodMonitor) *v1beta1vm.VMPodScrape {
-
-	return &v1beta1vm.VMPodScrape{
+func ConvertPodMonitor(podMon *v1.PodMonitor, enableObjectRef bool) *v1beta1vm.VMPodScrape {
+	cs := &v1beta1vm.VMPodScrape{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podMon.Name,
 			Namespace:   podMon.Namespace,
 			Labels:      podMon.Labels,
 			Annotations: podMon.Annotations,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         v1.SchemeGroupVersion.String(),
-					Kind:               v1.PodMonitorsKind,
-					Name:               podMon.Name,
-					UID:                podMon.UID,
-					Controller:         pointer.BoolPtr(true),
-					BlockOwnerDeletion: pointer.BoolPtr(true),
-				},
-			},
 		},
 		Spec: v1beta1vm.VMPodScrapeSpec{
 			JobLabel:        podMon.Spec.JobLabel,
@@ -238,9 +231,22 @@ func ConvertPodMonitor(podMon *v1.PodMonitor) *v1beta1vm.VMPodScrape {
 			PodMetricsEndpoints: ConvertPodEndpoints(podMon.Spec.PodMetricsEndpoints),
 		},
 	}
+	if enableObjectRef {
+		cs.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         v1.SchemeGroupVersion.String(),
+				Kind:               v1.PodMonitorsKind,
+				Name:               podMon.Name,
+				UID:                podMon.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			},
+		}
+	}
+	return cs
 }
 
-func ConvertProbe(probe *v1.Probe) *v1beta1vm.VMProbe {
+func ConvertProbe(probe *v1.Probe, enableObjectRef bool) *v1beta1vm.VMProbe {
 	var (
 		ingressTarget *v1beta1vm.ProbeTargetIngress
 		staticTargets *v1beta1vm.VMProbeTargetStaticConfig
@@ -261,20 +267,10 @@ func ConvertProbe(probe *v1.Probe) *v1beta1vm.VMProbe {
 			Labels:  probe.Spec.Targets.StaticConfig.Labels,
 		}
 	}
-	return &v1beta1vm.VMProbe{
+	cp := &v1beta1vm.VMProbe{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      probe.Name,
 			Namespace: probe.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         v1.SchemeGroupVersion.String(),
-					Kind:               v1.ProbesKind,
-					Name:               probe.Name,
-					UID:                probe.UID,
-					Controller:         pointer.BoolPtr(true),
-					BlockOwnerDeletion: pointer.BoolPtr(true),
-				},
-			},
 		},
 		Spec: v1beta1vm.VMProbeSpec{
 			JobName: probe.Spec.JobName,
@@ -292,6 +288,19 @@ func ConvertProbe(probe *v1.Probe) *v1beta1vm.VMProbe {
 			ScrapeTimeout: probe.Spec.ScrapeTimeout,
 		},
 	}
+	if enableObjectRef {
+		cp.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         v1.SchemeGroupVersion.String(),
+				Kind:               v1.ProbesKind,
+				Name:               probe.Name,
+				UID:                probe.UID,
+				Controller:         pointer.BoolPtr(true),
+				BlockOwnerDeletion: pointer.BoolPtr(true),
+			},
+		}
+	}
+	return cp
 }
 
 func filterUnsupportedRelabelCfg(relabelCfgs []*v1beta1vm.RelabelConfig) []*v1beta1vm.RelabelConfig {

--- a/controllers/converter/apis_test.go
+++ b/controllers/converter/apis_test.go
@@ -206,8 +206,7 @@ func TestConvertServiceMonitor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ConvertServiceMonitor(tt.args.serviceMon)
-			got.ObjectMeta.OwnerReferences = nil
+			got := ConvertServiceMonitor(tt.args.serviceMon, false)
 			if !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("ConvertServiceMonitor() = %v, want %v", got, tt.want)
 			}

--- a/controllers/converter/apis_test.go
+++ b/controllers/converter/apis_test.go
@@ -206,7 +206,9 @@ func TestConvertServiceMonitor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ConvertServiceMonitor(tt.args.serviceMon); !reflect.DeepEqual(*got, tt.want) {
+			got := ConvertServiceMonitor(tt.args.serviceMon)
+			got.ObjectMeta.OwnerReferences = nil
+			if !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("ConvertServiceMonitor() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -251,6 +251,7 @@ func (c *ConverterController) UpdatePrometheusRule(old, new interface{}) {
 	metaMergeStrategy := getMetaMergeStrategy(existingVMRule.Annotations)
 	existingVMRule.Annotations = mergeLabelsWithStrategy(existingVMRule.Annotations, VMRule.Annotations, metaMergeStrategy)
 	existingVMRule.Labels = mergeLabelsWithStrategy(existingVMRule.Labels, VMRule.Labels, metaMergeStrategy)
+	existingVMRule.OwnerReferences = VMRule.OwnerReferences
 
 	err = c.vclient.Update(ctx, existingVMRule)
 	if err != nil {
@@ -303,6 +304,8 @@ func (c *ConverterController) UpdateServiceMonitor(_, new interface{}) {
 	metaMergeStrategy := getMetaMergeStrategy(existingVMServiceScrape.Annotations)
 	existingVMServiceScrape.Annotations = mergeLabelsWithStrategy(existingVMServiceScrape.Annotations, vmServiceScrape.Annotations, metaMergeStrategy)
 	existingVMServiceScrape.Labels = mergeLabelsWithStrategy(existingVMServiceScrape.Labels, vmServiceScrape.Labels, metaMergeStrategy)
+	existingVMServiceScrape.OwnerReferences = vmServiceScrape.OwnerReferences
+
 	err = c.vclient.Update(ctx, existingVMServiceScrape)
 	if err != nil {
 		l.Error(err, "cannot update")
@@ -352,6 +355,7 @@ func (c *ConverterController) UpdatePodMonitor(_, new interface{}) {
 	mergeStrategy := getMetaMergeStrategy(existingVMPodScrape.Annotations)
 	existingVMPodScrape.Annotations = mergeLabelsWithStrategy(existingVMPodScrape.Annotations, podScrape.Annotations, mergeStrategy)
 	existingVMPodScrape.Labels = mergeLabelsWithStrategy(existingVMPodScrape.Labels, podScrape.Labels, mergeStrategy)
+	existingVMPodScrape.OwnerReferences = podScrape.OwnerReferences
 
 	err = c.vclient.Update(ctx, existingVMPodScrape)
 	if err != nil {
@@ -442,6 +446,7 @@ func (c *ConverterController) UpdateProbe(_, new interface{}) {
 	mergeStrategy := getMetaMergeStrategy(existingVMProbe.Annotations)
 	existingVMProbe.Annotations = mergeLabelsWithStrategy(existingVMProbe.Annotations, probeNew.Annotations, mergeStrategy)
 	existingVMProbe.Labels = mergeLabelsWithStrategy(existingVMProbe.Labels, probeNew.Labels, mergeStrategy)
+	existingVMProbe.OwnerReferences = vmProbe.OwnerReferences
 
 	existingVMProbe.Spec = vmProbe.Spec
 	err = c.vclient.Update(ctx, existingVMProbe)

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -58,13 +58,15 @@ type ConverterController struct {
 	podInf     cache.SharedInformer
 	serviceInf cache.SharedInformer
 	probeInf   cache.SharedIndexInformer
+	baseConf   *config.BaseOperatorConf
 }
 
 // NewConverterController builder for vmprometheusconverter service
-func NewConverterController(promCl versioned.Interface, vclient client.Client) *ConverterController {
+func NewConverterController(promCl versioned.Interface, vclient client.Client, baseConf *config.BaseOperatorConf) *ConverterController {
 	c := &ConverterController{
 		promClient: promCl,
 		vclient:    vclient,
+		baseConf:   baseConf,
 	}
 	c.ruleInf = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
@@ -179,27 +181,27 @@ func (c *ConverterController) runInformerWithDiscovery(ctx context.Context, grou
 }
 
 // Run - starts vmprometheusconverter with background discovery process for each prometheus api object
-func (c *ConverterController) Run(ctx context.Context, group *errgroup.Group, cfg *config.BaseOperatorConf) {
+func (c *ConverterController) Run(ctx context.Context, group *errgroup.Group) {
 
-	if cfg.EnabledPrometheusConverter.ServiceScrape {
+	if c.baseConf.EnabledPrometheusConverter.ServiceScrape {
 		group.Go(func() error {
 			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.ServiceMonitorsKind, c.serviceInf.Run)
 		})
 
 	}
-	if cfg.EnabledPrometheusConverter.PodMonitor {
+	if c.baseConf.EnabledPrometheusConverter.PodMonitor {
 		group.Go(func() error {
 			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.PodMonitorsKind, c.podInf.Run)
 		})
 
 	}
-	if cfg.EnabledPrometheusConverter.PrometheusRule {
+	if c.baseConf.EnabledPrometheusConverter.PrometheusRule {
 		group.Go(func() error {
 			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.PrometheusRuleKind, c.ruleInf.Run)
 		})
 
 	}
-	if cfg.EnabledPrometheusConverter.Probe {
+	if c.baseConf.EnabledPrometheusConverter.Probe {
 		group.Go(func() error {
 			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.ProbesKind, c.probeInf.Run)
 		})
@@ -213,7 +215,7 @@ func (c *ConverterController) CreatePrometheusRule(rule interface{}) {
 	promRule := rule.(*v1.PrometheusRule)
 	l := log.WithValues("kind", "alertRule", "name", promRule.Name, "ns", promRule.Namespace)
 	l.Info("syncing prom rule with VMRule")
-	cr := converter.ConvertPromRule(promRule)
+	cr := converter.ConvertPromRule(promRule, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 
 	err := c.vclient.Create(context.Background(), cr)
 	if err != nil {
@@ -233,7 +235,7 @@ func (c *ConverterController) UpdatePrometheusRule(old, new interface{}) {
 	promRuleNew := new.(*v1.PrometheusRule)
 	l := log.WithValues("kind", "VMRule", "name", promRuleNew.Name, "ns", promRuleNew.Namespace)
 	l.Info("updating VMRule")
-	VMRule := converter.ConvertPromRule(promRuleNew)
+	VMRule := converter.ConvertPromRule(promRuleNew, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	ctx := context.Background()
 	existingVMRule := &v1beta1.VMRule{}
 	err := c.vclient.Get(ctx, types.NamespacedName{Name: VMRule.Name, Namespace: VMRule.Namespace}, existingVMRule)
@@ -264,7 +266,7 @@ func (c *ConverterController) CreateServiceMonitor(service interface{}) {
 	serviceMon := service.(*v1.ServiceMonitor)
 	l := log.WithValues("kind", "vmServiceScrape", "name", serviceMon.Name, "ns", serviceMon.Namespace)
 	l.Info("syncing vmServiceScrape")
-	vmServiceScrape := converter.ConvertServiceMonitor(serviceMon)
+	vmServiceScrape := converter.ConvertServiceMonitor(serviceMon, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	err := c.vclient.Create(context.Background(), vmServiceScrape)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
@@ -283,7 +285,7 @@ func (c *ConverterController) UpdateServiceMonitor(_, new interface{}) {
 	serviceMonNew := new.(*v1.ServiceMonitor)
 	l := log.WithValues("kind", "vmServiceScrape", "name", serviceMonNew.Name, "ns", serviceMonNew.Namespace)
 	l.Info("updating vmServiceScrape")
-	vmServiceScrape := converter.ConvertServiceMonitor(serviceMonNew)
+	vmServiceScrape := converter.ConvertServiceMonitor(serviceMonNew, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	existingVMServiceScrape := &v1beta1.VMServiceScrape{}
 	ctx := context.Background()
 	err := c.vclient.Get(ctx, types.NamespacedName{Name: vmServiceScrape.Name, Namespace: vmServiceScrape.Namespace}, existingVMServiceScrape)
@@ -314,7 +316,7 @@ func (c *ConverterController) CreatePodMonitor(pod interface{}) {
 	podMonitor := pod.(*v1.PodMonitor)
 	l := log.WithValues("kind", "podScrape", "name", podMonitor.Name, "ns", podMonitor.Namespace)
 	l.Info("syncing podScrape")
-	podScrape := converter.ConvertPodMonitor(podMonitor)
+	podScrape := converter.ConvertPodMonitor(podMonitor, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	err := c.vclient.Create(context.TODO(), podScrape)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
@@ -333,7 +335,7 @@ func (c *ConverterController) CreatePodMonitor(pod interface{}) {
 func (c *ConverterController) UpdatePodMonitor(_, new interface{}) {
 	podMonitorNew := new.(*v1.PodMonitor)
 	l := log.WithValues("kind", "podScrape", "name", podMonitorNew.Name, "ns", podMonitorNew.Namespace)
-	podScrape := converter.ConvertPodMonitor(podMonitorNew)
+	podScrape := converter.ConvertPodMonitor(podMonitorNew, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	ctx := context.Background()
 	existingVMPodScrape := &v1beta1.VMPodScrape{}
 	err := c.vclient.Get(ctx, types.NamespacedName{Name: podScrape.Name, Namespace: podScrape.Namespace}, existingVMPodScrape)
@@ -405,7 +407,7 @@ func (c *ConverterController) CreateProbe(obj interface{}) {
 	probe := obj.(*v1.Probe)
 	l := log.WithValues("kind", "vmProbe", "name", probe.Name, "ns", probe.Namespace)
 	l.Info("syncing probes")
-	vmProbe := converter.ConvertProbe(probe)
+	vmProbe := converter.ConvertProbe(probe, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	err := c.vclient.Create(context.TODO(), vmProbe)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
@@ -424,7 +426,7 @@ func (c *ConverterController) CreateProbe(obj interface{}) {
 func (c *ConverterController) UpdateProbe(_, new interface{}) {
 	probeNew := new.(*v1.Probe)
 	l := log.WithValues("kind", "vmProbe", "name", probeNew.Name, "ns", probeNew.Namespace)
-	vmProbe := converter.ConvertProbe(probeNew)
+	vmProbe := converter.ConvertProbe(probeNew, c.baseConf.EnabledPrometheusConverterOwnerReferences)
 	ctx := context.Background()
 	existingVMProbe := &v1beta1.VMProbe{}
 	err := c.vclient.Get(ctx, types.NamespacedName{Name: vmProbe.Name, Namespace: vmProbe.Namespace}, existingVMProbe)

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -201,7 +201,7 @@ func (c *ConverterController) Run(ctx context.Context, group *errgroup.Group, cf
 	}
 	if cfg.EnabledPrometheusConverter.Probe {
 		group.Go(func() error {
-			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.ProbeKindKey, c.probeInf.Run)
+			return c.runInformerWithDiscovery(ctx, v1.SchemeGroupVersion.String(), v1.ProbesKind, c.probeInf.Run)
 		})
 
 	}

--- a/docs/quick-start.MD
+++ b/docs/quick-start.MD
@@ -1193,7 +1193,14 @@ spec:
   endpoints: []
 ```
 
-### prometheus Rule duplcation
+By default the operator doesn't make converted objects disappear after original ones are deleted. To change this behaviour
+configure adding `OwnerReferences` to converted objects:
+```bash
+VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES=true
+```
+Converted objects will be linked to the original ones and will be deleted by kubernetes after the orignal ones are deleted.
+
+### prometheus Rule duplication
  `Prometheus` allows to specify rules with the same content with-in one group at Rule spec, but its forbidden by vmalert.
  You can tell operator to deduplicate this rules by adding annotation to the `VMAlert` crd definition. In this case operator
  skips rule with the same values, see example below.

--- a/docs/quick-start.MD
+++ b/docs/quick-start.MD
@@ -1198,7 +1198,7 @@ configure adding `OwnerReferences` to converted objects:
 ```bash
 VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES=true
 ```
-Converted objects will be linked to the original ones and will be deleted by kubernetes after the orignal ones are deleted.
+Converted objects will be linked to the original ones and will be deleted by kubernetes after the original ones are deleted.
 
 ### prometheus Rule duplication
  `Prometheus` allows to specify rules with the same content with-in one group at Rule spec, but its forbidden by vmalert.

--- a/e2e/manager_test.go
+++ b/e2e/manager_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -68,6 +69,10 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
+
+	// operator settings
+	os.Setenv("VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES", "true")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	go func(ctx context.Context) {
 		err := manager.RunManager(ctx)

--- a/e2e/prometheus_converter_test.go
+++ b/e2e/prometheus_converter_test.go
@@ -252,7 +252,23 @@ var _ = Describe("test  prometheusConverter Controller", func() {
 					}, 60, 1).Should(Succeed())
 				})
 
+				It("Should delete the converted object", func() {
+					source := testCase.source.DeepCopyObject().(controllerutil.Object)
 
+					Expect(k8sClient.Create(context.TODO(), source)).To(Succeed())
+					Eventually(func() error {
+						_, err := getObject(testCase.targetTpl)
+						return err
+					}, 60, 1).Should(Succeed())
+					Expect(k8sClient.Delete(context.TODO(), source)).To(Succeed())
+					Eventually(func() error {
+						_, err := getObject(testCase.targetTpl)
+						if err == nil {
+							return fmt.Errorf("expected %s to disappear", testCase.name)
+						}
+						return nil
+					}, 60, 1).Should(Succeed())
+				})
 			})
 		}
 	})

--- a/e2e/prometheus_converter_test.go
+++ b/e2e/prometheus_converter_test.go
@@ -11,102 +11,249 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+type testCase struct {
+	name            string
+	source          controllerutil.Object
+	targetTpl       controllerutil.Object
+	targetValidator func(controllerutil.Object) error
+}
+
+var (
+	namespace = "default"
+
+	testCases = []testCase{
+		testCase{
+			name: "ServiceMonitor",
+			source: &monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-servicemonitor",
+				},
+				Spec: monitoringv1.ServiceMonitorSpec{
+					Endpoints: []monitoringv1.Endpoint{
+						{Port: "8081",
+							RelabelConfigs: []*monitoringv1.RelabelConfig{
+								{
+									Action: "keep",
+								},
+								{
+									Action:       "drop",
+									SourceLabels: []string{"__address__"},
+								},
+							},
+						},
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"managed-by": "vm-operator"},
+					},
+				},
+			},
+			targetTpl: &victoriametricsv1beta1.VMServiceScrape{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-servicemonitor",
+				},
+			},
+			targetValidator: func(obj controllerutil.Object) error {
+				ss := obj.(*victoriametricsv1beta1.VMServiceScrape)
+				if len(ss.Spec.Endpoints) != 1 {
+					return fmt.Errorf("unexpected number of endpoints, want 1, got: %d", len(ss.Spec.Endpoints))
+				}
+				endpoint := ss.Spec.Endpoints[0]
+				if len(endpoint.RelabelConfigs) != 1 {
+					return fmt.Errorf("unexpected relabelConfig for vmservice scrape, want len 1, got endpoint: %v", endpoint)
+				}
+				return nil
+			},
+		},
+		testCase{
+			name: "PodMonitor",
+			source: &monitoringv1.PodMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-podmonitor",
+				},
+				Spec: monitoringv1.PodMonitorSpec{
+					PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+						{
+							Port: "8081",
+						},
+					},
+				},
+			},
+			targetTpl: &victoriametricsv1beta1.VMPodScrape{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-podmonitor",
+				},
+			},
+			targetValidator: func(obj controllerutil.Object) error {
+				ps := obj.(*victoriametricsv1beta1.VMPodScrape)
+				if len(ps.Spec.PodMetricsEndpoints) != 1 {
+					return fmt.Errorf("unexpected number of endpoints, want 1, got: %d", len(ps.Spec.PodMetricsEndpoints))
+				}
+				endpoint := ps.Spec.PodMetricsEndpoints[0]
+				if endpoint.Port != "8081" {
+					return fmt.Errorf("unexpected endpoint port, want 8081, got: %s", endpoint.Port)
+				}
+				return nil
+			},
+		},
+		testCase{
+			name: "PrometheusRule",
+			source: &monitoringv1.PrometheusRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-prometheusrule",
+				},
+				Spec: monitoringv1.PrometheusRuleSpec{
+					Groups: []monitoringv1.RuleGroup{
+						{
+							Name: "groupName",
+							Rules: []monitoringv1.Rule{
+								{
+									Expr:   intstr.FromString("up{job=\"job_name\"}"),
+									Record: "job_name_up",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetTpl: &victoriametricsv1beta1.VMRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-prometheusrule",
+				},
+			},
+			targetValidator: func(obj controllerutil.Object) error {
+				vr := obj.(*victoriametricsv1beta1.VMRule)
+				if len(vr.Spec.Groups) != 1 {
+					return fmt.Errorf("unexpected number of groups, want 1, got: %d", len(vr.Spec.Groups))
+				}
+				group := vr.Spec.Groups[0]
+				if group.Name != "groupName" {
+					return fmt.Errorf("unexpected group name, want 'groupName', got: %s", group.Name)
+				}
+				if len(group.Rules) != 1 {
+					return fmt.Errorf("unexpected number of rules, want 1, got: %d", len(group.Rules))
+				}
+				rule := group.Rules[0]
+				if rule.Record != "job_name_up" {
+					return fmt.Errorf("unexpected rule Record field, want 'job_name_up', got: %s", rule.Record)
+				}
+				return nil
+			},
+		},
+		testCase{
+			name: "Probe",
+			source: &monitoringv1.Probe{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-probe",
+				},
+				Spec: monitoringv1.ProbeSpec{
+					ProberSpec: monitoringv1.ProberSpec{
+						URL: "http://example.com/probe",
+					},
+				},
+			},
+			targetTpl: &victoriametricsv1beta1.VMProbe{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "e2e-test-probe",
+				},
+			},
+			targetValidator: func(obj controllerutil.Object) error {
+				vp := obj.(*victoriametricsv1beta1.VMProbe)
+				if vp.Spec.VMProberSpec.URL != "http://example.com/probe" {
+					return fmt.Errorf("unexpected prober url, want 'http://example.com/probe', got: %s", vp.Spec.VMProberSpec.URL)
+				}
+				return nil
+			},
+		},
+	}
+)
+
+func getObject(obj controllerutil.Object) (controllerutil.Object, error) {
+	obj = obj.DeepCopyObject().(controllerutil.Object)
+	err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj)
+	return obj, err
+}
 
 var _ = Describe("test  prometheusConverter Controller", func() {
 	Context("e2e prome converter", func() {
-
-		Context("crud", func() {
-			Context("create", func() {
-				name := "create-servicemonitor"
-				namespace := "default"
+		for _, testCaseIt := range testCases {
+			testCase := testCaseIt
+			Context(fmt.Sprintf("crud %s", testCase.name), func() {
 				AfterEach(func() {
-					Expect(k8sClient.Delete(context.TODO(),
-						&monitoringv1.ServiceMonitor{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: namespace,
-								Name:      name,
-							}})).To(Succeed())
-					Expect(k8sClient.Delete(context.TODO(),
-						&victoriametricsv1beta1.VMServiceScrape{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: namespace,
-								Name:      name,
-							}})).To(Succeed())
-
-				})
-
-				It("should create prometheus ServiceMonitor", func() {
-					Expect(k8sClient.Create(context.TODO(), &monitoringv1.ServiceMonitor{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: namespace,
-							Name:      name,
-						},
-						Spec: monitoringv1.ServiceMonitorSpec{
-							Endpoints: []monitoringv1.Endpoint{
-								{Port: "8081"},
-							},
-							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"managed-by": "vm-operator"}},
-						},
-					})).To(Succeed())
+					k8sClient.Delete(context.TODO(), testCase.source) // nolint:errcheck
 					Eventually(func() error {
-						return k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &victoriametricsv1beta1.VMServiceScrape{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      name,
-								Namespace: namespace,
-							},
-						})
+						_, err := getObject(testCase.source)
+						if err == nil {
+							return fmt.Errorf("Should be deleted")
+						}
+						return nil
 					}, 60, 1).Should(Succeed())
-				})
-				It("should create prometheus ServiceMonitor with relabel filter", func() {
-					Expect(k8sClient.Create(context.TODO(), &monitoringv1.ServiceMonitor{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: namespace,
-							Name:      name,
-						},
-						Spec: monitoringv1.ServiceMonitorSpec{
-							Endpoints: []monitoringv1.Endpoint{
-								{
-									Port: "8081",
-									RelabelConfigs: []*monitoringv1.RelabelConfig{
-										{
-											Action: "keep",
-										},
-										{
-											Action:       "drop",
-											SourceLabels: []string{"__address__"},
-										},
-									},
-								},
-							},
-							Selector: metav1.LabelSelector{MatchLabels: map[string]string{"managed-by": "vm-operator"}},
-						},
-					})).To(Succeed())
+
+					k8sClient.Delete(context.TODO(), testCase.targetTpl) // nolint:errcheck
 					Eventually(func() error {
-						expectedVMServiceScrape := &victoriametricsv1beta1.VMServiceScrape{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      name,
-								Namespace: namespace,
-							}}
-						err := k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, expectedVMServiceScrape)
-						if err != nil {
-							return err
-						}
-						if len(expectedVMServiceScrape.Spec.Endpoints) != 1 {
-							return fmt.Errorf("unexpected number of endpoints, want 1, got: %d", len(expectedVMServiceScrape.Spec.Endpoints))
-						}
-						endpoint := expectedVMServiceScrape.Spec.Endpoints[0]
-						if len(endpoint.RelabelConfigs) != 1 {
-							return fmt.Errorf("unexpected relabelConfig for vmservice scrape, want len 1, got endpoint: %v", endpoint)
+						_, err := getObject(testCase.targetTpl)
+						if err == nil {
+							return fmt.Errorf("Should be deleted")
 						}
 						return nil
 					}, 60, 1).Should(Succeed())
 				})
 
+				It("Should convert the object", func() {
+					source := testCase.source.DeepCopyObject().(controllerutil.Object)
+
+					Expect(k8sClient.Create(context.TODO(), source)).To(Succeed())
+					Eventually(func() error {
+						target, err := getObject(testCase.targetTpl)
+						if err != nil {
+							return err
+						}
+						return testCase.targetValidator(target)
+					}, 60, 1).Should(Succeed())
+				})
+
+				It("Should update the converted object", func() {
+					source := testCase.source.DeepCopyObject().(controllerutil.Object)
+
+					Expect(k8sClient.Create(context.TODO(), source)).To(Succeed())
+					Eventually(func() error {
+						_, err := getObject(testCase.targetTpl)
+						return err
+					}, 60, 1).Should(Succeed())
+
+					labels := source.GetLabels()
+					if labels == nil {
+						labels = make(map[string]string)
+					}
+					labels["testKey"] = "testValue"
+					source.SetLabels(labels)
+
+					Expect(k8sClient.Update(context.TODO(), source)).To(Succeed())
+					Eventually(func() error {
+						target, err := getObject(testCase.targetTpl)
+						if err != nil {
+							return err
+						}
+						if target.GetLabels() == nil || target.GetLabels()["testKey"] != "testValue" {
+							return fmt.Errorf("unexpected labels, want testKey=testValue, got: %v", target.GetLabels())
+						}
+						return nil
+					}, 60, 1).Should(Succeed())
+				})
+
+
 			})
-
-		},
-		)
-
+		}
 	})
 })

--- a/e2e/prometheus_converter_test.go
+++ b/e2e/prometheus_converter_test.go
@@ -264,7 +264,7 @@ var _ = Describe("test  prometheusConverter Controller", func() {
 					Eventually(func() error {
 						_, err := getObject(testCase.targetTpl)
 						if err == nil {
-							return fmt.Errorf("expected %s to disappear", testCase.name)
+							return fmt.Errorf("expected converted %s to disappear", testCase.name)
 						}
 						return nil
 					}, 60, 1).Should(Succeed())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,8 @@ type BaseOperatorConf struct {
 		PrometheusRule bool `default:"true"`
 		Probe          bool `default:"true"`
 	}
+	EnabledPrometheusConverterOwnerReferences bool `default:"false"`
+
 	Host                      string `default:"0.0.0.0"`
 	ListenAddress             string `default:"0.0.0.0"`
 	DefaultLabels             string `default:"managed-by=vm-operator"`

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -164,10 +164,10 @@ func RunManager(ctx context.Context) error {
 		setupLog.Error(err, "cannot build promClient")
 		return err
 	}
-	converterController := controllers.NewConverterController(prom, mgr.GetClient())
+	converterController := controllers.NewConverterController(prom, mgr.GetClient(), config.MustGetBaseConfig())
 
 	errG := &errgroup.Group{}
-	converterController.Run(ctx, errG, config.MustGetBaseConfig())
+	converterController.Run(ctx, errG)
 	setupLog.Info("vmconverter was started")
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
I've noticed that removing a `PrometheusRule` doesn't make the corresponding `VMRule` deleted immediately as I've expected. As it seemed easy to code (just adding some `ownerReferences`) I've decided to have some fun and add it myself. For consistency I've updated other converters as well. Apart from e2e tests I've deployed it on some 'real' cluster and tested PrometheusRule behaviour - worked as expected.

During tests I've encountered that issue (at least I think it's an issue) with typo in prober discovery so I've fixed it as well.

Can such a feature be added? I haven't found any related information in documentation or discussion in issues (although I haven't searched a lot).

I'm not sure if this should be enabled by default. From my point of view it should, but I imagine it might break someone else's deployment (someone might, even unintentionally, rely on the fact that converted objects persist after original ones are removed). I can add some `EnablePrometheusConverterOwnerReferences` (false by default) setting to the configuration and pass it down to converters.