### PR TITLE
adds discoveryRole setting to VMServiceScrape

### DIFF
--- a/api/v1beta1/vmservicescrape_types.go
+++ b/api/v1beta1/vmservicescrape_types.go
@@ -10,6 +10,14 @@ import (
 
 // VMServiceScrapeSpec defines the desired state of VMServiceScrape
 type VMServiceScrapeSpec struct {
+	// DiscoveryRole - defines kubernetes_sd role for objects discovery.
+	// by default, its endpoints.
+	// can be changed to service or endpointslices.
+	// note, that with service setting, you have to use port: "name"
+	// and cannot use targetPort for endpoints.
+	// +optional
+	// +kubebuilder:validation:Enum=endpoints;service;endpointslices
+	DiscoveryRole string `json:"discoveryRole,omitempty"`
 	// The label to use to retrieve the job name from.
 	// +optional
 	JobLabel string `json:"jobLabel,omitempty"`
@@ -21,7 +29,7 @@ type VMServiceScrapeSpec struct {
 	PodTargetLabels []string `json:"podTargetLabels,omitempty"`
 	// A list of endpoints allowed as part of this ServiceScrape.
 	Endpoints []Endpoint `json:"endpoints"`
-	// Selector to select Endpoints objects.
+	// Selector to select Endpoints objects by corresponding Service labels.
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Service selector"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:selector:"

--- a/config/crd/bases/operator.victoriametrics.com_vmservicescrapes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmservicescrapes.yaml
@@ -38,6 +38,16 @@ spec:
         spec:
           description: VMServiceScrapeSpec defines the desired state of VMServiceScrape
           properties:
+            discoveryRole:
+              description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                discovery. by default, its endpoints. can be changed to service or
+                endpointslices. note, that with service setting, you have to use port:
+                "name" and cannot use targetPort for endpoints.'
+              enum:
+              - endpoints
+              - service
+              - endpointslices
+              type: string
             endpoints:
               description: A list of endpoints allowed as part of this ServiceScrape.
               items:
@@ -429,7 +439,8 @@ spec:
               format: int64
               type: integer
             selector:
-              description: Selector to select Endpoints objects.
+              description: Selector to select Endpoints objects by corresponding Service
+                labels.
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.

--- a/config/examples/vmservicescrape-full.yaml
+++ b/config/examples/vmservicescrape-full.yaml
@@ -3,6 +3,7 @@ kind: VMServiceScrape
 metadata:
   name: example-scrape
 spec:
+  discoveryRole: "endpoints"
   jobLabel: job
   targetLabels: []
   podTargetLabels: []

--- a/config/examples/vmservicescrape_service_sd.yaml
+++ b/config/examples/vmservicescrape_service_sd.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: example-service-target
+spec:
+  discoveryRole: service
+  endpoints:
+    - port: http
+      relabelConfigs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: example-application
+      monitored-by: vm-operator

--- a/docs/design.MD
+++ b/docs/design.MD
@@ -100,7 +100,10 @@ and scraping configurations can be matched via label selections. This allows an 
 for how metrics should be exposed. Following these conventions new services will be discovered automatically without 
 need to reconfigure.
 
-Monitoring configuration based on `Endpoints` objects. `Endpoints` objects are essentially lists of IP addresses. 
+Monitoring configuration based on  `discoveryRole` setting. By default, `endpoints` is used to get objects from kubernetes api. 
+Its also possible to use `discoveryRole: service` or `discoveryRole: endpointslices`
+
+ `Endpoints` objects are essentially lists of IP addresses. 
 Typically, `Endpoints` objects are populated by `Service` object. `Service` object discovers `Pod`s by a label 
 selector and adds those to the `Endpoints` object.
 
@@ -116,7 +119,7 @@ Therefore, when specifying an endpoint in the `endpoints` section, they are stri
 > Note: `endpoints` (lowercase) is the field in the `VMServiceScrape` CRD, while `Endpoints` (capitalized) is the Kubernetes object kind.
 
 Both `VMServiceScrape` and discovered targets may belong to any namespace. It is important for cross-namespace monitoring 
-use cases, e.g. for meta-monitoring. Using the `VMServiceScrape` of the `VMAgentSpec` 
+use cases, e.g. for meta-monitoring. Using the `serviceScrapeSelector` of the `VMAgentSpec` 
 one can restrict the namespaces from which `VMServiceScrape`s are selected from by the respective VMAgent server. 
 Using the `namespaceSelector` of the `VMServiceScrape` one can restrict the namespaces from which `Endpoints` can be 
 discovered from. To discover targets in all namespaces the `namespaceSelector` has to be empty:


### PR DESCRIPTION
it allows to choose kubernetes_sd role for filtering objects,
its possible to set role: service, role: endpoints or role: endpointslices
https://github.com/VictoriaMetrics/operator/issues/127