### PR TITLE
fix dedup.minScrapeInterval behavior in case of VMCluster replication

### DIFF
--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -1171,7 +1171,7 @@ func makePodSpecForVMStorage(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) 
 
 	if cr.Spec.ReplicationFactor != nil {
 		var dedupIsSet bool
-		for arg := range cr.Spec.VMSelect.ExtraArgs {
+		for arg := range cr.Spec.VMStorage.ExtraArgs {
 			if strings.Contains(arg, "dedup.minScrapeInterval") {
 				dedupIsSet = true
 			}


### PR DESCRIPTION
If `replicationFactor` is specified in VMCluster, the operator will add `-dedup.minScrapeInterval=1ms` to vmstorage and vmselect.

If vmselect has `-dedup.minScrapeInterval` option in `extraArgs`, the operator will not add `-dedup.minScrapeInterval=1ms` and will honor `extraArgs`.

**problem**: On the other hand, even if vmstorage has `-dedup.minScrapeInterval` option is `extraArgs`, the operator will add `-dedup.minScrapeInterval=1ms`. Instead, if **vmselect** has `-dedup.minScrapeInterval` option is `extraArgs`, the operator will not add `-dedup.minScrapeInterval=1ms` to vmstorage.

It's hard to imagine that only one of the `extraArgs` in vmselect and vmstorage has the dedup option, but I think it's a good idea to fix the process.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>