### PR TITLE
Fix typo in args creation for VMAgent, VMAlert and VMSingle

### DIFF
--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -268,7 +268,7 @@ func makeSpecForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOperat
 	args = append(args, BuildRemoteWriteSettings(cr)...)
 
 	for arg, value := range cr.Spec.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", arg, value))
+		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
 	}
 
 	args = append(args, fmt.Sprintf("-httpListenAddr=:%s", cr.Spec.Port))

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -357,7 +357,7 @@ func vmAlertSpecGen(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOperatorCo
 		confReloadArgs = append(confReloadArgs, fmt.Sprintf("-volume-dir=%s", path.Join(vmAlertConfigDir, cm)))
 	}
 	for arg, value := range cr.Spec.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", arg, value))
+		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
 	}
 
 	args = append(args, fmt.Sprintf("-httpListenAddr=:%s", cr.Spec.Port))

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -217,7 +217,7 @@ func makeSpecForVMSingle(cr *victoriametricsv1beta1.VMSingle, c *config.BaseOper
 	}
 
 	for arg, value := range cr.Spec.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", arg, value))
+		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
 	}
 
 	args = append(args, fmt.Sprintf("-httpListenAddr=:%s", cr.Spec.Port))
@@ -516,7 +516,7 @@ func makeSpecForVMBackuper(
 		args = append(args, fmt.Sprintf("-loggerFormat=%s", *cr.LogFormat))
 	}
 	for arg, value := range cr.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", arg, value))
+		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
 	}
 
 	var ports []corev1.ContainerPort


### PR DESCRIPTION
VMAlert expects args prefixed with single  `-`.