### PR TITLE
adds watching for owned resources

### DIFF
--- a/controllers/factory/psp/psp.go
+++ b/controllers/factory/psp/psp.go
@@ -153,11 +153,10 @@ func buildSA(cr CRDObject) *v1.ServiceAccount {
 func buildClusterRoleForPSP(cr CRDObject) *v12.ClusterRole {
 	return &v12.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       cr.GetNamespace(),
-			Name:            cr.PrefixedName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
-			OwnerReferences: cr.AsOwner(),
+			Namespace:   cr.GetNamespace(),
+			Name:        cr.PrefixedName(),
+			Labels:      cr.Labels(),
+			Annotations: cr.Annotations(),
 		},
 		Rules: []v12.PolicyRule{
 			{
@@ -173,11 +172,10 @@ func buildClusterRoleForPSP(cr CRDObject) *v12.ClusterRole {
 func buildClusterRoleBinding(cr CRDObject) *v12.ClusterRoleBinding {
 	return &v12.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.PrefixedName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
-			OwnerReferences: cr.AsOwner(),
+			Name:        cr.PrefixedName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.Labels(),
+			Annotations: cr.Annotations(),
 		},
 		Subjects: []v12.Subject{
 			{
@@ -197,11 +195,10 @@ func buildClusterRoleBinding(cr CRDObject) *v12.ClusterRoleBinding {
 func BuildPSP(cr CRDObject) *v1beta1.PodSecurityPolicy {
 	return &v1beta1.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.GetPSPName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
-			OwnerReferences: cr.AsOwner(),
+			Name:        cr.GetPSPName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.Labels(),
+			Annotations: cr.Annotations(),
 		},
 		Spec: v1beta1.PodSecurityPolicySpec{
 			ReadOnlyRootFilesystem: false,

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -78,11 +78,10 @@ func ensureVMAgentCRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cl
 func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *v12.ClusterRoleBinding {
 	return &v12.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.GetClusterRoleName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
-			OwnerReferences: cr.AsOwner(),
+			Name:        cr.GetClusterRoleName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.Labels(),
+			Annotations: cr.Annotations(),
 		},
 		Subjects: []v12.Subject{
 			{
@@ -102,11 +101,10 @@ func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *v12.ClusterRoleBindin
 func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *v12.ClusterRole {
 	return &v12.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.GetClusterRoleName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
-			OwnerReferences: cr.AsOwner(),
+			Name:        cr.GetClusterRoleName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.Labels(),
+			Annotations: cr.Annotations(),
 		},
 		Rules: []v12.PolicyRule{
 			{

--- a/controllers/vmagent_controller.go
+++ b/controllers/vmagent_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/go-logr/logr"
@@ -117,5 +118,9 @@ func (r *VMAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&victoriametricsv1beta1.VMAgent{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
+		Owns(&v1.Secret{}).
+		Owns(&v1.Service{}).
+		Owns(&v1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/vmalert_controller.go
+++ b/controllers/vmalert_controller.go
@@ -105,6 +105,7 @@ func (r *VMAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
 		Owns(&v1.ConfigMap{}).
+		Owns(&v1.Secret{}).
 		Owns(&v1.Service{}).
 		Owns(&v1.ServiceAccount{}).
 		Complete(r)

--- a/controllers/vmalert_controller.go
+++ b/controllers/vmalert_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -102,5 +103,9 @@ func (r *VMAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&victoriametricsv1beta1.VMAlert{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
+		Owns(&v1.ConfigMap{}).
+		Owns(&v1.Service{}).
+		Owns(&v1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/vmalertmanager_controller.go
+++ b/controllers/vmalertmanager_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -89,5 +90,9 @@ func (r *VMAlertmanagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&victoriametricsv1beta1.VMAlertmanager{}).
 		Owns(&appsv1.StatefulSet{}).
+		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
+		Owns(&v1.Secret{}).
+		Owns(&v1.Service{}).
+		Owns(&v1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/vmcluster_controller.go
+++ b/controllers/vmcluster_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -79,6 +80,9 @@ func (r *VMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&victoriametricsv1beta1.VMCluster{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
 		Owns(&appsv1.StatefulSet{}).
+		Owns(&v1.Service{}).
+		Owns(&v1.ServiceAccount{}).
 		Complete(r)
 }

--- a/controllers/vmsingle_controller.go
+++ b/controllers/vmsingle_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -104,5 +105,8 @@ func (r *VMSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&victoriametricsv1beta1.VMSingle{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&victoriametricsv1beta1.VMServiceScrape{}).
+		Owns(&v1.Service{}).
+		Owns(&v1.ServiceAccount{}).
 		Complete(r)
 }


### PR DESCRIPTION
it must prevent bug for https://github.com/VictoriaMetrics/operator/issues/159
in case of kubernetes-controller manager removes object, it will be recreated after sync.
NOTE cluster wide objects cannot be owned by namespaced objects, in this case operator creates orphaned objects,
that cannot be deleted with garbage collection. Need to bind it to related CRD in future.