### PR TITLE
Add deletecollection verb to the editor roles

### DIFF
--- a/config/rbac/vmagent_editor_role.yaml
+++ b/config/rbac/vmagent_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmalert_editor_role.yaml
+++ b/config/rbac/vmalert_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmalertmanager_editor_role.yaml
+++ b/config/rbac/vmalertmanager_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmnodescrape_editor_role.yaml
+++ b/config/rbac/vmnodescrape_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmpodscrape_editor_role.yaml
+++ b/config/rbac/vmpodscrape_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmprobe_editor_role.yaml
+++ b/config/rbac/vmprobe_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmrule_editor_role.yaml
+++ b/config/rbac/vmrule_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmservicescrape_editor_role.yaml
+++ b/config/rbac/vmservicescrape_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:

--- a/config/rbac/vmsingle_editor_role.yaml
+++ b/config/rbac/vmsingle_editor_role.yaml
@@ -16,6 +16,7 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection
 - apiGroups:
   - operator.victoriametrics.com
   resources:


### PR DESCRIPTION
The current editor role manifests don't have verb `deletecollection`.
It seems there's no reason not to grant, so can I do it?