### PR TITLE
Fix size diff result

### DIFF
--- a/controllers/factory/expansion.go
+++ b/controllers/factory/expansion.go
@@ -68,7 +68,10 @@ func wasCreatedSTS(ctx context.Context, rclient client.Client, pvcName string, n
 		}
 
 		if i := newPVC.Spec.Resources.Requests.Storage().Cmp(*actualPVC.Spec.Resources.Requests.Storage()); i != 0 {
-			log.Info("must re-recreate sts, its pvc claim was changed", "size-diff", i)
+			sizeDiff := resource.NewQuantity(0, resource.BinarySI)
+			sizeDiff.Add(*newPVC.Spec.Resources.Requests.Storage())
+			sizeDiff.Sub(*actualPVC.Spec.Resources.Requests.Storage())
+			log.Info("must re-recreate sts, its pvc claim was changed", "size-diff", sizeDiff.String())
 			return true
 		}
 


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

As mentioned in the #211 , the result of `Quantity.Cmp(Quantity) -> int` is not the actual diff size.

I am not sure if this modification is the most elegant way. Pls have a check.