### PR TITLE
add `nodes/metrics` resource to fix scrape issue

### DIFF
--- a/config/examples/vmagent_rbac.yaml
+++ b/config/examples/vmagent_rbac.yaml
@@ -12,6 +12,7 @@ rules:
   - apiGroups: ["","networking.k8s.io","extensions"]
     resources:
       - nodes
+      - nodes/metrics
       - services
       - endpoints
       - endpointslices

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -123,6 +123,7 @@ func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *v12.ClusterRole {
 				},
 				Resources: []string{
 					"nodes",
+					"nodes/metrics",
 					"nodes/proxy",
 					"services",
 					"endpoints",

--- a/hack/bundle_csv_vmagent.yaml
+++ b/hack/bundle_csv_vmagent.yaml
@@ -6,6 +6,7 @@ spec:
             - apiGroups: [ "","networking.k8s.io","extensions" ]
               resources:
                 - nodes
+                - nodes/metrics
                 - services
                 - endpoints
                 - endpointslices


### PR DESCRIPTION
Failed to scrape kubelet metrics using `release/examples/vmagent_rbac.yaml`. The error logs are as follow:

> 2021-04-06T11:47:59.850Z error VictoriaMetrics/lib/promscrape/scrapework.go:255 error when scraping "https://192.168.1.1:10250/metrics" from job "kubelet" with labels {endpoint="https-metrics",instance="192.168.1.1:10250",job="kubelet",metrics_path="/metrics",namespace="kube-system",node="example.node",prometheus="default/example-vmagent",service="kubelet"}: unexpected status code returned when scraping "https://192.168.1.1:10250/metrics": 403; expecting 200; response body: "Forbidden (user=system:serviceaccount:default:vmagent-example-vmagent, verb=get, resource=nodes, subresource=metrics)"
> 2021-04-06T11:48:01.076Z error VictoriaMetrics/lib/promscrape/scrapework.go:255 error when scraping "https://192.168.1.1:10250/metrics/probes" from job "kubelet" with labels {endpoint="https-metrics",instance="192.168.1.1:10250",job="kubelet",metrics_path="/metrics/probes",namespace="kube-system",node="example.node",prometheus="default/example-vmagent",service="kubelet"}: unexpected status code returned when scraping "https://192.168.1.1:10250/metrics/probes": 403; expecting 200; response body: "Forbidden (user=system:serviceaccount:default:vmagent-example-vmagent, verb=get, resource=nodes, subresource=metrics)"
> 2021-04-06T11:48:06.064Z error VictoriaMetrics/lib/promscrape/scrapework.go:255 error when scraping "https://192.168.1.1:10250/metrics/cadvisor" from job "kubelet" with labels {endpoint="https-metrics",instance="192.168.1.1:10250",job="kubelet",metrics_path="/metrics/cadvisor",namespace="kube-system",node="example.node",prometheus="default/example-vmagent",service="kubelet"}: unexpected status code returned when scraping "https://192.168.1.1:10250/metrics/cadvisor": 403; expecting 200; response body: "Forbidden (user=system:serviceaccount:default:vmagent-example-vmagent, verb=get, resource=nodes, subresource=metrics)"

So I added `nodes/metrics` resource to the cluster role. It works now.