### PR TITLE
Fix inconsistent sort order in scrape label selectors

### DIFF
--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -1154,10 +1154,14 @@ func getNamespacesFromNamespaceSelector(nsSelector *victoriametricsv1beta1.Names
 }
 
 func combineSelectorStr(kvs map[string]string) string {
-	kvsSlice := make([]string, 0)
+	kvsSlice := make([]string, 0, len(kvs))
 	for k, v := range kvs {
 		kvsSlice = append(kvsSlice, fmt.Sprintf("%v=%v", k, v))
 	}
+
+	// Ensure we generate the same selector string for the same kvs,
+	// regardless of Go map iteration order.
+	sort.Strings(kvsSlice)
 
 	return strings.Join(kvsSlice, ",")
 }


### PR DESCRIPTION
Fixes #325. Using multiple `matchLabels` in (e.g.) a `VMPodScrape` causes infinite regenerations of the `VMAgent` configuration `Secret` due to inconsistent iteration order of the Go map holding the label key–value pairs.

Apologies for not updating `scrapes_build_test.go`; couldn’t find any existing test cases that use `matchLabels` to adapt.