### PR TITLE
Remove obsolete operator-sdk environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: manager
-	WATCH_NAMESPACE="" OPERATOR_NAME=vms ./bin/manager
+	WATCH_NAMESPACE="" ./bin/manager
 
 # Install CRDs into a cluster
 install: manifests fix118 fix_crd_nulls kustomize

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,12 +27,6 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ""
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: "vm-operator"
         resources:
           limits:
             cpu: 120m


### PR DESCRIPTION
As stated in operator-sdk [migration.md](https://github.com/operator-framework/operator-sdk/blob/master/website/content/en/docs/building-operators/golang/migration.md#migrate-maingo), the environment variables `OPERATOR_NAME` and `POD_NAME` are no longer used. Let's clean them up from kustomization and makefile.