### PR TITLE
Add `WATCH_NAMESPACE` environment variable support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ all: build
 # Run tests
 test: generate fmt vet manifests fix118 fix_crd_nulls
 	echo 'mode: atomic' > coverage.txt  && \
-	$(TEST_ARGS) $(REPO)/controllers/...
+	$(TEST_ARGS) $(REPO)/controllers/... $(REPO)/api/...
 	$(GOCMD) tool cover -func coverage.txt  | grep total
 
 # Build manager binary

--- a/controllers/vmalertmanagerconfig_controller.go
+++ b/controllers/vmalertmanagerconfig_controller.go
@@ -63,7 +63,7 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// select alertmanagers
 	var vmams operatorv1beta1.VMAlertmanagerList
-	if err := r.Client.List(ctx, &vmams); err != nil {
+	if err := r.Client.List(ctx, &vmams, config.MustGetNamespaceListOptions()); err != nil {
 		l.Error(err, "cannot list vmalertmanagers")
 		return ctrl.Result{}, err
 	}

--- a/controllers/vmnodescrape_controller.go
+++ b/controllers/vmnodescrape_controller.go
@@ -64,7 +64,7 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	defer vmAgentSync.Unlock()
 
 	vmAgentInstances := &operatorv1beta1.VMAgentList{}
-	err = r.List(ctx, vmAgentInstances)
+	err = r.List(ctx, vmAgentInstances, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmagent objects")
 		return ctrl.Result{}, err

--- a/controllers/vmpodscrape_controller.go
+++ b/controllers/vmpodscrape_controller.go
@@ -64,7 +64,7 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	defer vmAgentSync.Unlock()
 
 	vmAgentInstances := &victoriametricsv1beta1.VMAgentList{}
-	err = r.List(ctx, vmAgentInstances)
+	err = r.List(ctx, vmAgentInstances, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmagent objects")
 		return ctrl.Result{}, err

--- a/controllers/vmprobe_controller.go
+++ b/controllers/vmprobe_controller.go
@@ -62,7 +62,7 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	defer vmAgentSync.Unlock()
 
 	vmAgentInstances := &operatorv1beta1.VMAgentList{}
-	err = r.List(ctx, vmAgentInstances)
+	err = r.List(ctx, vmAgentInstances, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmagent objects")
 		return ctrl.Result{}, err

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -71,10 +71,10 @@ func NewConverterController(promCl versioned.Interface, vclient client.Client, b
 	c.ruleInf = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return promCl.MonitoringV1().PrometheusRules("").List(context.TODO(), options)
+				return promCl.MonitoringV1().PrometheusRules(config.MustGetWatchNamespace()).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return promCl.MonitoringV1().PrometheusRules("").Watch(context.TODO(), options)
+				return promCl.MonitoringV1().PrometheusRules(config.MustGetWatchNamespace()).Watch(context.TODO(), options)
 			},
 		},
 		&v1.PrometheusRule{},
@@ -88,10 +88,10 @@ func NewConverterController(promCl versioned.Interface, vclient client.Client, b
 	c.podInf = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return promCl.MonitoringV1().PodMonitors("").List(context.TODO(), options)
+				return promCl.MonitoringV1().PodMonitors(config.MustGetWatchNamespace()).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return promCl.MonitoringV1().PodMonitors("").Watch(context.TODO(), options)
+				return promCl.MonitoringV1().PodMonitors(config.MustGetWatchNamespace()).Watch(context.TODO(), options)
 			},
 		},
 		&v1.PodMonitor{},
@@ -105,10 +105,10 @@ func NewConverterController(promCl versioned.Interface, vclient client.Client, b
 	c.serviceInf = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return promCl.MonitoringV1().ServiceMonitors("").List(context.TODO(), options)
+				return promCl.MonitoringV1().ServiceMonitors(config.MustGetWatchNamespace()).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return promCl.MonitoringV1().ServiceMonitors("").Watch(context.TODO(), options)
+				return promCl.MonitoringV1().ServiceMonitors(config.MustGetWatchNamespace()).Watch(context.TODO(), options)
 			},
 		},
 		&v1.ServiceMonitor{},
@@ -122,10 +122,10 @@ func NewConverterController(promCl versioned.Interface, vclient client.Client, b
 	c.probeInf = cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return promCl.MonitoringV1().Probes("").List(context.TODO(), options)
+				return promCl.MonitoringV1().Probes(config.MustGetWatchNamespace()).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return promCl.MonitoringV1().Probes("").Watch(context.TODO(), options)
+				return promCl.MonitoringV1().Probes(config.MustGetWatchNamespace()).Watch(context.TODO(), options)
 			},
 		},
 		&v1.Probe{},

--- a/controllers/vmrule_controller.go
+++ b/controllers/vmrule_controller.go
@@ -70,7 +70,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	vmAlertSync.Lock()
 	defer vmAlertSync.Unlock()
 
-	err = r.List(ctx, alertMngs, &client.ListOptions{})
+	err = r.List(ctx, alertMngs, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmalerts")
 		return ctrl.Result{}, err

--- a/controllers/vmservicescrape_controller.go
+++ b/controllers/vmservicescrape_controller.go
@@ -63,7 +63,7 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	defer vmAgentSync.Unlock()
 
 	vmAgentInstances := &victoriametricsv1beta1.VMAgentList{}
-	err = r.List(ctx, vmAgentInstances)
+	err = r.List(ctx, vmAgentInstances, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmagent objects")
 		return ctrl.Result{}, err

--- a/controllers/vmstaticscrape_controller.go
+++ b/controllers/vmstaticscrape_controller.go
@@ -49,7 +49,7 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer vmAgentSync.Unlock()
 
 	vmAgentInstances := &victoriametricsv1beta1.VMAgentList{}
-	err = r.List(ctx, vmAgentInstances)
+	err = r.List(ctx, vmAgentInstances, config.MustGetNamespaceListOptions())
 	if err != nil {
 		reqLogger.Error(err, "cannot list vmagent objects")
 		return ctrl.Result{}, err

--- a/controllers/vmuser_controller.go
+++ b/controllers/vmuser_controller.go
@@ -212,7 +212,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	globalSecretRefCache.addRefByUser(&instance)
 
 	var vmauthes operatorv1beta1.VMAuthList
-	if err := r.List(ctx, &vmauthes); err != nil {
+	if err := r.List(ctx, &vmauthes, config.MustGetNamespaceListOptions()); err != nil {
 		l.Error(err, "cannot list VMAuth at cluster wide.")
 		return ctrl.Result{}, err
 	}

--- a/e2e/manager_test.go
+++ b/e2e/manager_test.go
@@ -1,37 +1,18 @@
 package e2e
 
 import (
-	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
-	"github.com/VictoriaMetrics/operator/internal/manager"
+	"github.com/VictoriaMetrics/operator/e2e/suite"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var cancelManager context.CancelFunc
-var stopped bool
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -41,63 +22,13 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
-
-	l := zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.DebugLevel))
-	logf.SetLogger(l)
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "config", "crd", "bases"),
-			filepath.Join("..", "hack", "prom_crd"),
-		},
-		UseExistingCluster:       pointer.BoolPtr(true),
-		AttachControlPlaneOutput: true,
-		ErrorIfCRDPathMissing:    true,
-	}
-
-	var err error
-	cfg, err = testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
-
-	err = victoriametricsv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	//prometheus operator scheme for client
-	err = monitoringv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// +kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(k8sClient).ToNot(BeNil())
-
-	// operator settings
-	os.Setenv("VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES", "true")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	go func(ctx context.Context) {
-		defer GinkgoRecover()
-		err := manager.RunManager(ctx)
-		stopped = true
-		Expect(err).To(BeNil())
-	}(ctx)
-	cancelManager = cancel
-
-	close(done)
-}, 60)
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	cancelManager()
-	Eventually(func() bool {
-		return stopped
-	}, 60, 2).Should(BeTrue())
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+var k8sClient client.Client
+var _ = BeforeSuite(func() {
+	suite.Before()
+	k8sClient = suite.K8sClient
 })
+
+var _ = AfterSuite(suite.After)
 
 //func mustDeleteObject(client client.Client, obj client.Object) error {
 //	if !Expect(func() error {

--- a/e2e/suite/suite.go
+++ b/e2e/suite/suite.go
@@ -1,0 +1,108 @@
+package suite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/manager"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var cfg *rest.Config
+var K8sClient client.Client
+var testEnv *envtest.Environment
+var cancelManager context.CancelFunc
+var stopped = make(chan struct{})
+
+func Before() {
+	l := zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.DebugLevel))
+	logf.SetLogger(l)
+
+	By("bootstrapping test environment")
+
+	wd, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred())
+
+	root := wd
+	for {
+		_, err := os.Stat(filepath.Join(root, "PROJECT"))
+		Expect(err == nil || os.IsNotExist(err)).To(BeTrue())
+		if err == nil {
+			break
+		}
+
+		root = filepath.Dir(root)
+	}
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join(root, "config", "crd", "bases"),
+			filepath.Join(root, "hack", "prom_crd"),
+		},
+		UseExistingCluster:       pointer.BoolPtr(true),
+		AttachControlPlaneOutput: true,
+		ErrorIfCRDPathMissing:    true,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer GinkgoRecover()
+		defer close(done)
+
+		var err error
+		cfg, err = testEnv.Start()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg).ToNot(BeNil())
+
+		err = victoriametricsv1beta1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+		//prometheus operator scheme for client
+		err = monitoringv1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		// +kubebuilder:scaffold:scheme
+
+		K8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(K8sClient).ToNot(BeNil())
+
+		// operator settings
+		err = os.Setenv("VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES", "true")
+		Expect(err).ToNot(HaveOccurred())
+
+		// disable metrics server because it fails to listen when running several test packages one after another
+		// also metrics server isn't very useful in tests
+		os.Args = append(os.Args, "--metrics-addr", "0")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func(ctx context.Context) {
+			defer GinkgoRecover()
+			err := manager.RunManager(ctx)
+			close(stopped)
+			Expect(err).NotTo(HaveOccurred())
+		}(ctx)
+		cancelManager = cancel
+	}()
+
+	Eventually(done, 60, 1).Should(BeClosed())
+}
+
+func After() {
+	By("tearing down the test environment")
+	cancelManager()
+	Eventually(stopped, 60, 2).Should(BeClosed())
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/e2e/watchnamespace/controllers_test.go
+++ b/e2e/watchnamespace/controllers_test.go
@@ -1,0 +1,131 @@
+package watchnamespace
+
+import (
+	"reflect"
+
+	v1beta1vm "github.com/VictoriaMetrics/operator/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// formattableType wraps reflect.Type to provide a friendly diagnostic when assertions on it fail
+type formattableType struct {
+	reflect.Type
+}
+
+func (ft formattableType) GomegaString() string {
+	return ft.String()
+}
+
+var _ = Describe("Controllers", func() {
+	var namespace string
+	objectListProtos := []client.ObjectList{
+		&v1beta1vm.VMClusterList{},
+		&v1beta1vm.VMAgentList{},
+		&v1beta1vm.VMAlertList{},
+		&v1beta1vm.VMAlertmanagerList{},
+		&v1beta1vm.VMSingleList{},
+		&v1beta1vm.VMUserList{},
+	}
+
+	JustBeforeEach(func() {
+		objects := []client.Object{
+			&v1beta1vm.VMCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmcluster",
+				},
+				Spec: v1beta1vm.VMClusterSpec{RetentionPeriod: "1"},
+			},
+			&v1beta1vm.VMAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmagent",
+				},
+			},
+			&v1beta1vm.VMAlert{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmalert",
+				},
+			},
+			&v1beta1vm.VMAlertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmalertmanager",
+				},
+			},
+			&v1beta1vm.VMSingle{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmsingle",
+				},
+				Spec: v1beta1vm.VMSingleSpec{
+					RetentionPeriod: "1",
+				},
+			},
+			&v1beta1vm.VMUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-vmuser",
+				},
+				Spec: v1beta1vm.VMUserSpec{
+					TargetRefs: []v1beta1vm.TargetRef{
+						{
+							Static: &v1beta1vm.StaticRef{
+								URL: "http://vmselect",
+							},
+							Paths: []string{
+								"/select/0/prometheus",
+								"/select/0/graphite",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var objectTypes []formattableType
+		for _, object := range objects {
+			objectTypes = append(objectTypes, formattableType{reflect.TypeOf(object).Elem()})
+		}
+
+		var listObjectTypes []formattableType
+		for _, listProto := range objectListProtos {
+			listObjectTypes = append(listObjectTypes, formattableType{GetListObjectType(listProto)})
+		}
+
+		// self check that we test all objects that we create
+		Expect(objectTypes).To(Equal(listObjectTypes))
+
+		CreateObjects(objects...)
+	})
+
+	AfterEach(func() {
+		DeleteAllObjectsOf(namespace, objectListProtos...)
+	})
+
+	Context("when resources are inside WATCH_NAMESPACE", func() {
+		BeforeEach(func() {
+			namespace = includedNamespace
+		})
+
+		It("should add finalizers", func() {
+			for _, listProto := range objectListProtos {
+				EventuallyShouldHaveFinalizer(namespace, listProto)
+			}
+		})
+	})
+
+	Context("when resources are outside WATCH_NAMESPACE", func() {
+		BeforeEach(func() {
+			namespace = excludedNamespace
+		})
+
+		It("should NOT add finalizer", func() {
+			ConsistentlyShouldNotHaveFinalizer(namespace, objectListProtos...)
+		})
+	})
+})

--- a/e2e/watchnamespace/prometheus_converter_test.go
+++ b/e2e/watchnamespace/prometheus_converter_test.go
@@ -1,0 +1,97 @@
+package watchnamespace
+
+import (
+	v1beta1vm "github.com/VictoriaMetrics/operator/api/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("VM Operator", func() {
+	var namespace string
+
+	JustBeforeEach(func() {
+		CreateObjects(
+			&monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service-monitor",
+					Namespace: namespace,
+				},
+				Spec: monitoringv1.ServiceMonitorSpec{
+					Endpoints: []monitoringv1.Endpoint{{
+						Port: "9999",
+					}},
+				},
+			},
+			&monitoringv1.PodMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-monitor",
+					Namespace: namespace,
+				},
+				Spec: monitoringv1.PodMonitorSpec{
+					PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
+						Port: "9999",
+					}},
+				},
+			},
+			&monitoringv1.Probe{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-probe",
+					Namespace: namespace,
+				},
+			},
+			&monitoringv1.PrometheusRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-prometheus-rule",
+					Namespace: namespace,
+				},
+			},
+		)
+	})
+
+	AfterEach(func() {
+		DeleteAllObjectsOf(namespace,
+			&monitoringv1.ServiceMonitorList{},
+			&v1beta1vm.VMServiceScrapeList{},
+			&monitoringv1.PodMonitorList{},
+			&v1beta1vm.VMPodScrapeList{},
+			&monitoringv1.ProbeList{},
+			&v1beta1vm.VMProbeList{},
+			&monitoringv1.PrometheusRuleList{},
+			&v1beta1vm.VMRuleList{},
+		)
+	})
+
+	vmObjectListProtos := []client.ObjectList{
+		&v1beta1vm.VMServiceScrapeList{},
+		&v1beta1vm.VMPodScrapeList{},
+		&v1beta1vm.VMProbeList{},
+		&v1beta1vm.VMRuleList{},
+	}
+
+	Context("when Prometheus operator objects are inside WATCH_NAMESPACE", func() {
+		BeforeEach(func() {
+			namespace = includedNamespace
+		})
+
+		It("should convert Prometheus operator objects to VictoriaMetrics operator objects", func() {
+			for _, listProto := range vmObjectListProtos {
+				Eventually(func() []client.Object {
+					return ListObjectsInNamespace(namespace, listProto)
+				}, 60, 1).ShouldNot(BeEmpty())
+			}
+		})
+	})
+
+	Context("when Prometheus operator objects are outside WATCH_NAMESPACE", func() {
+		BeforeEach(func() {
+			namespace = excludedNamespace
+		})
+
+		It("should NOT convert Prometheus operator objects to to VictoriaMetrics operator objects", func() {
+			Consistently(ListObjectsInNamespace(namespace, vmObjectListProtos...), 10, 1).Should(BeEmpty())
+		})
+	})
+})

--- a/e2e/watchnamespace/suite_test.go
+++ b/e2e/watchnamespace/suite_test.go
@@ -1,0 +1,48 @@
+package watchnamespace
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/VictoriaMetrics/operator/e2e/suite"
+	"github.com/VictoriaMetrics/operator/internal/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const excludedNamespace = "test-excluded"
+const includedNamespace = "default"
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "e2e Controller WATCH_NAMESPACE Suite")
+}
+
+var k8sClient client.Client
+var _ = BeforeSuite(func() {
+	var err error
+	err = os.Setenv(config.WatchNamespaceEnvVar, "default")
+	Expect(err).NotTo(HaveOccurred())
+
+	suite.Before()
+	k8sClient = suite.K8sClient
+
+	testNamespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: excludedNamespace,
+		},
+	}
+	err = k8sClient.Create(context.Background(), &testNamespace)
+	Expect(err == nil || errors.IsAlreadyExists(err)).To(BeTrue(), "got unexpected namespace creation error: %v", err)
+}, 60)
+
+var _ = AfterSuite(suite.After)

--- a/e2e/watchnamespace/utils_test.go
+++ b/e2e/watchnamespace/utils_test.go
@@ -1,0 +1,114 @@
+package watchnamespace
+
+import (
+	"context"
+	"reflect"
+
+	v1beta1vm "github.com/VictoriaMetrics/operator/api/v1beta1"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateObjects(objects ...client.Object) {
+	for _, obj := range objects {
+		ExpectWithOffset(1, k8sClient.Create(context.Background(), obj)).To(Succeed())
+	}
+}
+
+func DeleteAllObjectsOf(namespace string, listProtos ...client.ObjectList) {
+	nsOption := client.InNamespace(namespace)
+	for _, listProto := range listProtos {
+		objType := GetListObjectType(listProto)
+		proto := reflect.New(objType).Interface()
+		ExpectWithOffset(1, k8sClient.DeleteAllOf(context.Background(), proto.(client.Object), nsOption)).To(Succeed())
+	}
+
+	EventuallyWithOffset(1, func() bool {
+		for _, listProto := range listProtos {
+			if objects := listObjectsByListProto(namespace, listProto); len(objects) > 0 {
+				return false
+			}
+		}
+
+		return true
+	}, 60, 1).Should(BeTrue())
+}
+
+func ListObjectsInNamespace(namespace string, listProtos ...client.ObjectList) []client.Object {
+	var result []client.Object
+	for _, listProto := range listProtos {
+		objects := listObjectsByListProto(namespace, listProto)
+		result = append(result, objects...)
+	}
+
+	return result
+}
+
+func EventuallyShouldHaveFinalizer(namespace string, listProto client.ObjectList) {
+	// EventuallyShouldHaveFinalizer and ConsistentlyShouldNotHaveFinalizer functions are being
+	// used to detect operator activity or the lack of it. They rely on a fact that first thing
+	// the operator does is to add a finalizer to controlled objects. If the operator changes
+	// its behaviour these functions will be unusable for the purpose of checking WATCH_NAMESPACE
+	// restriction.
+
+	EventuallyWithOffset(1, func() []client.Object {
+		objects := listObjectsByListProto(namespace, listProto)
+		Expect(objects).NotTo(BeEmpty())
+
+		var objectsWithoutFinalizers []client.Object
+		for _, object := range objects {
+			finalizers := object.GetFinalizers()
+			if len(finalizers) != 1 || finalizers[0] != v1beta1vm.FinalizerName {
+				objectsWithoutFinalizers = append(objectsWithoutFinalizers, object)
+			}
+		}
+
+		return objectsWithoutFinalizers
+	}, 10, 1).Should(BeEmpty())
+}
+
+func ConsistentlyShouldNotHaveFinalizer(namespace string, listProtos ...client.ObjectList) {
+	// sorry, this has to be slow because we're checking for something not to be done
+	ConsistentlyWithOffset(1, func() []client.Object {
+		var objectsWithFinalizers []client.Object
+		for _, listProto := range listProtos {
+			objects := listObjectsByListProto(namespace, listProto)
+			Expect(objects).NotTo(BeEmpty())
+
+			for _, object := range objects {
+				if len(object.GetFinalizers()) > 0 {
+					objectsWithFinalizers = append(objectsWithFinalizers, object)
+				}
+			}
+		}
+
+		return objectsWithFinalizers
+	}, 10, 1).Should(BeEmpty())
+}
+
+func GetListObjectType(list client.ObjectList) reflect.Type {
+	objType := reflect.ValueOf(list).Elem().FieldByName("Items").Type().Elem()
+	if objType.Kind() == reflect.Ptr {
+		objType = objType.Elem()
+	}
+
+	return objType
+}
+
+func listObjectsByListProto(namespace string, listProto client.ObjectList) []client.Object {
+	var objects []client.Object
+
+	list := listProto.DeepCopyObject().(client.ObjectList)
+	Expect(k8sClient.List(context.Background(), list, client.InNamespace(namespace))).To(Succeed())
+	itemsValue := reflect.ValueOf(list).Elem().FieldByName("Items")
+	for i := 0; i < itemsValue.Len(); i++ {
+		itemValue := itemsValue.Index(i)
+		if itemValue.Kind() != reflect.Ptr {
+			itemValue = itemValue.Addr()
+		}
+
+		objects = append(objects, itemValue.Interface().(client.Object))
+	}
+
+	return objects
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"os"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
@@ -51,6 +52,17 @@ func init() {
 
 }
 
+// getWatchNamespace returns the Namespace the operator should be watching for changes
+func getWatchNamespace() string {
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
+
+	ns, _ := os.LookupEnv(watchNamespaceEnvVar)
+	return ns
+}
+
 func RunManager(ctx context.Context) error {
 
 	// Add flags registered by imported packages (e.g. glog and
@@ -87,6 +99,7 @@ func RunManager(ctx context.Context) error {
 		Port:                  9443,
 		LeaderElection:        *enableLeaderElection,
 		LeaderElectionID:      "57410f0d.victoriametrics.com",
+		Namespace:             getWatchNamespace(),
 		ClientDisableCacheFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}},
 	})
 	if err != nil {


### PR DESCRIPTION
The operator-sdk [documentation](https://github.com/operator-framework/operator-sdk/blob/master/website/content/en/docs/building-operators/golang/operator-scope.md#configuring-watch-namespaces-dynamically) proposes a way to restrict operator scope to a particular namespace. This feature can sometimes be very useful.