### PR TITLE
Don't use FQDN for pod names

### DIFF
--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -259,8 +259,8 @@ func (s VMSelect) GetNameWithPrefix(clusterName string) string {
 	}
 	return PrefixedName(s.Name, "vmselect")
 }
-func (s VMSelect) BuildPodFQDNName(baseName string, podIndex int32, namespace, portName, domain string) string {
-	return fmt.Sprintf("%s-%d.%s.%s.svc.%s:%s,", baseName, podIndex, baseName, namespace, domain, portName)
+func (s VMSelect) BuildPodName(baseName string, podIndex int32, namespace, portName string) string {
+	return fmt.Sprintf("%s-%d.%s.%s:%s,", baseName, podIndex, baseName, namespace, portName)
 }
 
 func PrefixedName(name, prefix string) string {
@@ -639,8 +639,8 @@ type VMBackup struct {
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 }
 
-func (s VMStorage) BuildPodFQDNName(baseName string, podIndex int32, namespace, portName, domain string) string {
-	return fmt.Sprintf("%s-%d.%s.%s.svc.%s:%s,", baseName, podIndex, baseName, namespace, domain, portName)
+func (s VMStorage) BuildPodName(baseName string, podIndex int32, namespace, portName string) string {
+	return fmt.Sprintf("%s-%d.%s.%s:%s,", baseName, podIndex, baseName, namespace, portName)
 }
 
 func (s VMStorage) GetNameWithPrefix(clusterName string) string {

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -314,13 +314,9 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 		Path:   path.Clean(webRoutePrefix + "/-/reload"),
 	}
 
-	var clusterPeerDomain string
-	if c.ClusterDomainName != "" {
-		clusterPeerDomain = fmt.Sprintf("%s.%s.svc.%s.", cr.PrefixedName(), cr.Namespace, c.ClusterDomainName)
-	} else {
-		// The default DNS search path is .svc.<cluster domain>
-		clusterPeerDomain = cr.PrefixedName()
-	}
+	// The default DNS search path is .svc.<cluster domain>
+	var clusterPeerDomain = cr.PrefixedName()
+
 	for i := int32(0); i < *cr.Spec.ReplicaCount; i++ {
 		amArgs = append(amArgs, fmt.Sprintf("--cluster.peer=%s-%d.%s:9094", cr.PrefixedName(), i, clusterPeerDomain))
 	}

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -589,7 +589,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		}
 		storageArg := "-storageNode="
 		for _, i := range cr.AvailableStorageNodeIDs("select") {
-			storageArg += cr.Spec.VMStorage.BuildPodFQDNName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMSelectPort, c.ClusterDomainName)
+			storageArg += cr.Spec.VMStorage.BuildPodName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMSelectPort)
 		}
 		storageArg = strings.TrimSuffix(storageArg, ",")
 
@@ -600,7 +600,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 	selectArg := "-selectNode="
 	vmselectCount := *cr.Spec.VMSelect.ReplicaCount
 	for i := int32(0); i < vmselectCount; i++ {
-		selectArg += cr.Spec.VMSelect.BuildPodFQDNName(cr.Spec.VMSelect.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMSelect.Port, c.ClusterDomainName)
+		selectArg += cr.Spec.VMSelect.BuildPodName(cr.Spec.VMSelect.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMSelect.Port)
 	}
 	selectArg = strings.TrimSuffix(selectArg, ",")
 
@@ -868,7 +868,7 @@ func makePodSpecForVMInsert(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		}
 		storageArg := "-storageNode="
 		for _, i := range cr.AvailableStorageNodeIDs("insert") {
-			storageArg += cr.Spec.VMStorage.BuildPodFQDNName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMInsertPort, c.ClusterDomainName)
+			storageArg += cr.Spec.VMStorage.BuildPodName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMInsertPort)
 		}
 		storageArg = strings.TrimSuffix(storageArg, ",")
 		log.Info("args for vminsert ", "storage arg", storageArg)

--- a/docs/kustomize-example/manager.patch.yaml
+++ b/docs/kustomize-example/manager.patch.yaml
@@ -10,5 +10,5 @@ spec:
       containers:
       - name: manager
         env:
-        - name: VM_CLUSTERDOMAINNAME
-          value: "private-cluster.prod"
+        - name: VM_PODWAITREADYTIMEOUT
+          value: "120s"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,7 +229,6 @@ type BaseOperatorConf struct {
 	Labels                    Labels `ignored:"true"`
 	LogLevel                  string
 	LogFormat                 string
-	ClusterDomainName         string        `default:"cluster.local"`
 	PodWaitReadyTimeout       time.Duration `default:"80s"`
 	PodWaitReadyIntervalCheck time.Duration `default:"5s"`
 	PodWaitReadyInitDelay     time.Duration `default:"10s"`

--- a/vars.MD
+++ b/vars.MD
@@ -104,7 +104,6 @@
 | VM_LISTENADDRESS | 0.0.0.0 | false | - |
 | VM_DEFAULTLABELS | managed-by=vm-operator | false | - |
 | VM_LABELS | - | false | - |
-| VM_CLUSTERDOMAINNAME | cluster.local | false | - |
 | VM_PODWAITREADYTIMEOUT | 80s | false | - |
 | VM_PODWAITREADYINTERVALCHECK | 5s | false | - |
 | VM_PODWAITREADYINITDELAY | 10s | false | - |


### PR DESCRIPTION
Avoids problems with non-default cluster domain, which isn't really
possible to configure from a CRD anyways.

controllers/factory/alertmanager.go already relies on .svc.<cluster
domain> being in the search path, so this should just work.

Remove the now unused ClusterDomainName config option and update the
kustomize example to patch another setting.

Fixes #354.