### PR TITLE
Default to DNS search paths if ClusterDomainName isn't set explicitly

### DIFF
--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -259,7 +259,11 @@ func (s VMSelect) GetNameWithPrefix(clusterName string) string {
 	}
 	return PrefixedName(s.Name, "vmselect")
 }
-func (s VMSelect) BuildPodFQDNName(baseName string, podIndex int32, namespace, portName, domain string) string {
+func (s VMSelect) BuildPodName(baseName string, podIndex int32, namespace, portName, domain string) string {
+	// The default DNS search path is .svc.<cluster domain>
+	if domain == "" {
+		return fmt.Sprintf("%s-%d.%s.%s:%s,", baseName, podIndex, baseName, namespace, portName)
+	}
 	return fmt.Sprintf("%s-%d.%s.%s.svc.%s:%s,", baseName, podIndex, baseName, namespace, domain, portName)
 }
 
@@ -639,7 +643,11 @@ type VMBackup struct {
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 }
 
-func (s VMStorage) BuildPodFQDNName(baseName string, podIndex int32, namespace, portName, domain string) string {
+func (s VMStorage) BuildPodName(baseName string, podIndex int32, namespace, portName, domain string) string {
+	// The default DNS search path is .svc.<cluster domain>
+	if domain == "" {
+		return fmt.Sprintf("%s-%d.%s.%s:%s,", baseName, podIndex, baseName, namespace, portName)
+	}
 	return fmt.Sprintf("%s-%d.%s.%s.svc.%s:%s,", baseName, podIndex, baseName, namespace, domain, portName)
 }
 

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -589,7 +589,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		}
 		storageArg := "-storageNode="
 		for _, i := range cr.AvailableStorageNodeIDs("select") {
-			storageArg += cr.Spec.VMStorage.BuildPodFQDNName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMSelectPort, c.ClusterDomainName)
+			storageArg += cr.Spec.VMStorage.BuildPodName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMSelectPort, c.ClusterDomainName)
 		}
 		storageArg = strings.TrimSuffix(storageArg, ",")
 
@@ -600,7 +600,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 	selectArg := "-selectNode="
 	vmselectCount := *cr.Spec.VMSelect.ReplicaCount
 	for i := int32(0); i < vmselectCount; i++ {
-		selectArg += cr.Spec.VMSelect.BuildPodFQDNName(cr.Spec.VMSelect.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMSelect.Port, c.ClusterDomainName)
+		selectArg += cr.Spec.VMSelect.BuildPodName(cr.Spec.VMSelect.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMSelect.Port, c.ClusterDomainName)
 	}
 	selectArg = strings.TrimSuffix(selectArg, ",")
 
@@ -868,7 +868,7 @@ func makePodSpecForVMInsert(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		}
 		storageArg := "-storageNode="
 		for _, i := range cr.AvailableStorageNodeIDs("insert") {
-			storageArg += cr.Spec.VMStorage.BuildPodFQDNName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMInsertPort, c.ClusterDomainName)
+			storageArg += cr.Spec.VMStorage.BuildPodName(cr.Spec.VMStorage.GetNameWithPrefix(cr.Name), i, cr.Namespace, cr.Spec.VMStorage.VMInsertPort, c.ClusterDomainName)
 		}
 		storageArg = strings.TrimSuffix(storageArg, ",")
 		log.Info("args for vminsert ", "storage arg", storageArg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,7 +229,7 @@ type BaseOperatorConf struct {
 	Labels                    Labels `ignored:"true"`
 	LogLevel                  string
 	LogFormat                 string
-	ClusterDomainName         string        `default:"cluster.local"`
+	ClusterDomainName         string        `default:""`
 	PodWaitReadyTimeout       time.Duration `default:"80s"`
 	PodWaitReadyIntervalCheck time.Duration `default:"5s"`
 	PodWaitReadyInitDelay     time.Duration `default:"10s"`

--- a/vars.MD
+++ b/vars.MD
@@ -104,7 +104,7 @@
 | VM_LISTENADDRESS | 0.0.0.0 | false | - |
 | VM_DEFAULTLABELS | managed-by=vm-operator | false | - |
 | VM_LABELS | - | false | - |
-| VM_CLUSTERDOMAINNAME | cluster.local | false | - |
+| VM_CLUSTERDOMAINNAME | "" | false | Will use DNS search paths if unset |
 | VM_PODWAITREADYTIMEOUT | 80s | false | - |
 | VM_PODWAITREADYINTERVALCHECK | 5s | false | - |
 | VM_PODWAITREADYINITDELAY | 10s | false | - |


### PR DESCRIPTION
`.svc.<cluster domain>` usually is in the DNS search path of Pods
already, so make use of that in the default case, instead of hardcoding
cluster.local everywhere.

Users with broken DNS search paths can still explicitly configure the
cluster domain via VM_CLUSTERDOMAINNAME, in that case, VM will use the
FQDN.