### PR TITLE
config/examples/vmalert-full.yaml: fix yaml

### DIFF
--- a/config/examples/vmalert-full.yaml
+++ b/config/examples/vmalert-full.yaml
@@ -50,7 +50,7 @@ spec:
         key: password
   notifiers:
     - url: "http://vmalertmanager-example-0.vmalertmanager.example.default.svc:9093"
-    - selector:
+      selector:
         namespaceSelector:
           any: false
           matchNames:


### PR DESCRIPTION
Applying the example will fail:

```
Error from server (notifier.url at idx: 1 cannot be empty): error when creating "vmalert-full.yaml": admission webhook "vmalert.victoriametrics.com" denied the request: notifier.url at idx: 1 cannot be empty
```

This probably shouldn't create two notifiers, one without an url, but
one notifier with all the attributes.