### PR TITLE
Help controller-gen with recursive Route type

### DIFF
--- a/api/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/v1beta1/vmalertmanagerconfig_types.go
@@ -142,6 +142,8 @@ type Route struct {
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Routes []*Route `json:"routes,omitempty"`
 	// MuteTimeIntervals for alerts
 	// +optional

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
@@ -2519,8 +2519,7 @@ spec:
                     type: string
                   routes:
                     description: Child routes.
-                    items: {}
-                    type: array
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - receiver
                 type: object

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
@@ -2476,8 +2476,7 @@ spec:
                   type: string
                 routes:
                   description: Child routes.
-                  items: {}
-                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
               required:
               - receiver
               type: object


### PR DESCRIPTION
Ended up not being able to apply the CRDs and that seems to be related to the recursive Route in VMAlertmanagerConfigs. I get the error `The CustomResourceDefinition "vmalertmanagerconfigs.operator.victoriametrics.com" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[route].properties[routes].items.type: Required value: must not be empty for specified array items`. 

Before the CRD were re-generated in a recent commit there was a `x-kubernetes-preserve-unknown-fields: true` inside the `items` object, but I couldn't figure out how to annotate things to imitate that. 

Without `kubebuilder:validation:Schemaless` the empty `items: {}` still gave the same error. I have not tested to see if that ends up parsing things differently when creating configurations, only that the CRD itself gets created without error.