### PR TITLE
Create alertmanager service scrape by default (#385)

### DIFF
--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -358,6 +358,10 @@ func (cr *VMAlertmanager) AsPodFQDN(idx int) string {
 	return fmt.Sprintf("http://%s-%d.%s.%s.svc:9093", cr.PrefixedName(), idx, cr.PrefixedName(), cr.Namespace)
 }
 
+func (cr *VMAlertmanager) MetricPath() string {
+	return buildPathWithPrefixFlag(cr.Spec.ExtraArgs, metricPath)
+}
+
 // AsCRDOwner implements interface
 func (cr *VMAlertmanager) AsCRDOwner() []metav1.OwnerReference {
 	return crd.GetCRDAsOwner(crd.VMAlertManager)

--- a/controllers/vmalertmanager_controller.go
+++ b/controllers/vmalertmanager_controller.go
@@ -91,10 +91,17 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		reqLogger.Error(err, "cannot create or update vmalertmanager sts")
 		return ctrl.Result{}, err
 	}
-	_, err = factory.CreateOrUpdateAlertManagerService(ctx, instance, r)
+	service, err := factory.CreateOrUpdateAlertManagerService(ctx, instance, r)
 	if err != nil {
 		reqLogger.Error(err, "cannot create or update vmalertmanager service")
 		return ctrl.Result{}, err
+	}
+
+	if !r.BaseConf.DisableSelfServiceScrapeCreation {
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, service, instance.MetricPath(), "http")
+		if err != nil {
+			reqLogger.Error(err, "cannot create serviceScrape for vmalertmanager")
+		}
 	}
 
 	reqLogger.Info("vmalertmanager reconciled")


### PR DESCRIPTION
I'm trying to get vmagent to scrape alertmanager by default. Since I'm quite new to Golang and Kubernetes operators, please let me know if my change makes any sense :)

Fixes https://github.com/VictoriaMetrics/operator/issues/385