### PR TITLE
Add prefix to clusterrole and clusterrolebinding

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
     name:  proxy-rolebinding
 - path: service_account_patch.yaml
   target:
-    name: manager-rolebinding
+    name: vm-operator-manager-rolebinding
 - path: service_account_patch.yaml
   target:
     name: vm-operator-psp-rolebinding

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: vm-operator-manager-role
 rules:
 - apiGroups:
     - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: vm-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: vm-operator-manager-role
 subjects:
 - kind: ServiceAccount
   name: monitoring-system


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

This PR intends to resolve name conflicts caused by some global resources like `clusterrole` and `clusterrolebinding`.

We are using both jaeger-operator and vm operator which shares some common names. This has incurred some permission issues in our staging cluster.