### PR TITLE
allows to changes rolling update strategy for statefulset applications

### DIFF
--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -239,6 +240,12 @@ type VMAlertmanagerSpec struct {
 	// It may be useful if alert doesn't have namespace label for some reason
 	// +optional
 	DisableNamespaceMatcher bool `json:"disableNamespaceMatcher,omitempty"`
+
+	// RollingUpdateStrategy defines strategy for application updates
+	// Default is OnDelete, in this case operator handles update process
+	// Can be changed for RollingUpdate
+	// +optional
+	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 }
 
 // VMAlertmanagerList is a list of Alertmanagers.
@@ -391,6 +398,13 @@ func (cr *VMAlertmanager) AsNotifiers() []VMAlertNotifierSpec {
 		r = append(r, ns)
 	}
 	return r
+}
+
+func (cr VMAlertmanager) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
+	if cr.Spec.RollingUpdateStrategy == "" {
+		return appsv1.OnDeleteStatefulSetStrategyType
+	}
+	return cr.Spec.RollingUpdateStrategy
 }
 
 func (cr *VMAlertmanager) GetVolumeName() string {

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -252,6 +252,12 @@ type VMSelect struct {
 	// NodeSelector Define which Nodes the Pods are scheduled on.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// RollingUpdateStrategy defines strategy for application updates
+	// Default is OnDelete, in this case operator handles update process
+	// Can be changed for RollingUpdate
+	// +optional
+	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 }
 
 func (s VMSelect) GetNameWithPrefix(clusterName string) string {
@@ -574,6 +580,12 @@ type VMStorage struct {
 	// NodeSelector Define which Nodes the Pods are scheduled on.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// RollingUpdateStrategy defines strategy for application updates
+	// Default is OnDelete, in this case operator handles update process
+	// Can be changed for RollingUpdate
+	// +optional
+	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 }
 
 type VMBackup struct {
@@ -648,7 +660,7 @@ type VMBackup struct {
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 }
 
-func (s VMStorage) BuildPodName(baseName string, podIndex int32, namespace, portName, domain string) string {
+func (s VMStorage) BuildPodName(baseName string, podIndex int32, namespace string, portName string, domain string) string {
 	// The default DNS search path is .svc.<cluster domain>
 	if domain == "" {
 		return fmt.Sprintf("%s-%d.%s.%s:%s,", baseName, podIndex, baseName, namespace, portName)
@@ -679,6 +691,20 @@ func (s VMSelect) GetCacheMountVolumeName() string {
 		return storageSpec.VolumeClaimTemplate.Name
 	}
 	return PrefixedName("cachedir", "vmselect")
+}
+
+func (s VMStorage) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
+	if s.RollingUpdateStrategy == "" {
+		return appsv1.OnDeleteStatefulSetStrategyType
+	}
+	return s.RollingUpdateStrategy
+}
+
+func (s VMSelect) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
+	if s.RollingUpdateStrategy == "" {
+		return appsv1.OnDeleteStatefulSetStrategyType
+	}
+	return s.RollingUpdateStrategy
 }
 
 // Image defines docker image settings

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -419,6 +419,11 @@ spec:
                   (milliseconds seconds minutes hours).
                 pattern: '[0-9]+(ms|s|m|h)'
                 type: string
+              rollingUpdateStrategy:
+                description: RollingUpdateStrategy defines strategy for application
+                  updates Default is OnDelete, in this case operator handles update
+                  process Can be changed for RollingUpdate
+                type: string
               routePrefix:
                 description: RoutePrefix VMAlertmanager registers HTTP handlers for.
                   This is useful, if using ExternalURL and a proxy is rewriting HTTP

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -825,6 +825,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  rollingUpdateStrategy:
+                    description: RollingUpdateStrategy defines strategy for application
+                      updates Default is OnDelete, in this case operator handles update
+                      process Can be changed for RollingUpdate
+                    type: string
                   runtimeClassName:
                     description: RuntimeClassName - defines runtime class for kubernetes
                       pod. https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -1601,6 +1606,11 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  rollingUpdateStrategy:
+                    description: RollingUpdateStrategy defines strategy for application
+                      updates Default is OnDelete, in this case operator handles update
+                      process Can be changed for RollingUpdate
+                    type: string
                   runtimeClassName:
                     description: RuntimeClassName - defines runtime class for kubernetes
                       pod. https://kubernetes.io/docs/concepts/containers/runtime-class/

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -414,6 +414,11 @@ spec:
                 (milliseconds seconds minutes hours).
               pattern: '[0-9]+(ms|s|m|h)'
               type: string
+            rollingUpdateStrategy:
+              description: RollingUpdateStrategy defines strategy for application
+                updates Default is OnDelete, in this case operator handles update
+                process Can be changed for RollingUpdate
+              type: string
             routePrefix:
               description: RoutePrefix VMAlertmanager registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP

--- a/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
@@ -814,6 +814,11 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                   type: object
+                rollingUpdateStrategy:
+                  description: RollingUpdateStrategy defines strategy for application
+                    updates Default is OnDelete, in this case operator handles update
+                    process Can be changed for RollingUpdate
+                  type: string
                 runtimeClassName:
                   description: RuntimeClassName - defines runtime class for kubernetes
                     pod. https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -1577,6 +1582,11 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                   type: object
+                rollingUpdateStrategy:
+                  description: RollingUpdateStrategy defines strategy for application
+                    updates Default is OnDelete, in this case operator handles update
+                    process Can be changed for RollingUpdate
+                  type: string
                 runtimeClassName:
                   description: RuntimeClassName - defines runtime class for kubernetes
                     pod. https://kubernetes.io/docs/concepts/containers/runtime-class/

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -110,6 +110,7 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *victoriametricsv1beta1.
 	stsOpts := k8stools.STSOptions{
 		VolumeName:     cr.GetVolumeName,
 		SelectorLabels: cr.SelectorLabels,
+		UpdateStrategy: cr.UpdateStrategy,
 	}
 	return k8stools.HandleSTSUpdate(ctx, rclient, stsOpts, newSts, currentSts, c)
 }
@@ -499,7 +500,7 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 		Replicas:            cr.Spec.ReplicaCount,
 		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-			Type: appsv1.OnDeleteStatefulSetStrategyType,
+			Type: cr.UpdateStrategy(),
 		},
 		Selector: &metav1.LabelSelector{
 			MatchLabels: cr.SelectorLabels(),

--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
 
 	"k8s.io/api/autoscaling/v2beta2"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -230,7 +231,7 @@ func reconcileDeploy(ctx context.Context, rclient client.Client, newDeploy *apps
 		}
 		return fmt.Errorf("cannot get deploy: %s,err: %w", newDeploy.Name, err)
 	}
-	newDeploy.Annotations = labels.Merge(currentDeploy.Annotations, newDeploy.Annotations)
+	newDeploy.Spec.Template.Annotations = k8stools.MergeAnnotations(currentDeploy.Spec.Template.Annotations, newDeploy.Spec.Template.Annotations)
 	newDeploy.Finalizers = victoriametricsv1beta1.MergeFinalizers(newDeploy, victoriametricsv1beta1.FinalizerName)
 	return rclient.Update(ctx, newDeploy)
 }

--- a/controllers/factory/k8stools/annotations.go
+++ b/controllers/factory/k8stools/annotations.go
@@ -1,0 +1,13 @@
+package k8stools
+
+// MergeAnnotations adds well known annotations to the current map from prev
+// It's needed for kubectl restart at least.
+func MergeAnnotations(prev, current map[string]string) map[string]string {
+	if value, ok := prev["kubectl.kubernetes.io/restartedAt"]; ok {
+		if current == nil {
+			current = make(map[string]string)
+		}
+		current["kubectl.kubernetes.io/restartedAt"] = value
+	}
+	return current
+}

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -263,6 +263,7 @@ func createOrUpdateVMSelect(ctx context.Context, cr *v1beta1.VMCluster, rclient 
 	stsOpts := k8stools.STSOptions{
 		VolumeName:     cr.Spec.VMSelect.GetCacheMountVolumeName,
 		SelectorLabels: cr.VMSelectSelectorLabels,
+		UpdateStrategy: cr.Spec.VMSelect.UpdateStrategy,
 	}
 	return k8stools.HandleSTSUpdate(ctx, rclient, stsOpts, newSts, &currentSts, c)
 }
@@ -390,6 +391,7 @@ func createOrUpdateVMStorage(ctx context.Context, cr *v1beta1.VMCluster, rclient
 	stsOpts := k8stools.STSOptions{
 		VolumeName:     cr.Spec.VMStorage.GetStorageVolumeName,
 		SelectorLabels: cr.VMStorageSelectorLabels,
+		UpdateStrategy: cr.Spec.VMStorage.UpdateStrategy,
 	}
 	return k8stools.HandleSTSUpdate(ctx, rclient, stsOpts, newSts, currentSts, c)
 }
@@ -466,7 +468,7 @@ func genVMSelectSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv1
 			},
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.OnDeleteStatefulSetStrategyType,
+				Type: cr.Spec.VMSelect.UpdateStrategy(),
 			},
 			Template:             *podSpec,
 			ServiceName:          cr.Spec.VMSelect.GetNameWithPrefix(cr.Name),
@@ -1055,7 +1057,7 @@ func GenVMStorageSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv
 			},
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.OnDeleteStatefulSetStrategyType,
+				Type: cr.Spec.VMStorage.UpdateStrategy(),
 			},
 			Template:             *podSpec,
 			ServiceName:          cr.Spec.VMStorage.GetNameWithPrefix(cr.Name),

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -110,9 +110,7 @@ func CreateOrUpdateVMSingle(ctx context.Context, cr *victoriametricsv1beta1.VMSi
 		}
 		return nil, fmt.Errorf("cannot get vmsingle deploy: %w", err)
 	}
-	l.Info("vm vmsingle was found, updating it")
-
-	newDeploy.Annotations = labels.Merge(currentDeploy.Annotations, newDeploy.Annotations)
+	newDeploy.Spec.Template.Annotations = k8stools.MergeAnnotations(currentDeploy.Spec.Template.Annotations, newDeploy.Spec.Template.Annotations)
 	newDeploy.Finalizers = victoriametricsv1beta1.MergeFinalizers(currentDeploy, victoriametricsv1beta1.FinalizerName)
 
 	if err := rclient.Update(ctx, newDeploy); err != nil {

--- a/docs/api.MD
+++ b/docs/api.MD
@@ -191,6 +191,7 @@ VMAlertmanagerSpec is a specification of the desired behavior of the VMAlertmana
 | extraArgs | ExtraArgs that will be passed to  VMAuth pod for example remoteWrite.tmpDataPath: /tmp | map[string]string | false |
 | extraEnvs | ExtraEnvs that will be added to VMAuth pod | [][v1.EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvar-v1-core) | false |
 | disableNamespaceMatcher | DisableNamespaceMatcher disables namespace label matcher for VMAlertmanagerConfig It may be useful if alert doesn&#39;t have namespace label for some reason | bool | false |
+| rollingUpdateStrategy | RollingUpdateStrategy defines strategy for application updates Default is OnDelete, in this case operator handles update process Can be changed for RollingUpdate | appsv1.StatefulSetUpdateStrategyType | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -1581,6 +1582,7 @@ VMClusterStatus defines the observed state of VMCluster
 | podDisruptionBudget | PodDisruptionBudget created by operator | *[EmbeddedPodDisruptionBudgetSpec](#embeddedpoddisruptionbudgetspec) | false |
 | hpa |  | *[EmbeddedHPA](#embeddedhpa) | false |
 | nodeSelector | NodeSelector Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| rollingUpdateStrategy | RollingUpdateStrategy defines strategy for application updates Default is OnDelete, in this case operator handles update process Can be changed for RollingUpdate | appsv1.StatefulSetUpdateStrategyType | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -1626,6 +1628,7 @@ VMClusterStatus defines the observed state of VMCluster
 | maintenanceInsertNodeIDs | MaintenanceInsertNodeIDs - excludes given node ids from insert requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc. lets say, you have pod-0, pod-1, pod-2, pod-3. to exclude pod-0 and pod-3 from insert routing, define nodeIDs: [0,3]. Useful at storage expanding, when you want to rebalance some data at cluster. | []int32 | false |
 | maintenanceSelectNodeIDs | MaintenanceInsertNodeIDs - excludes given node ids from select requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc. | []int32 | false |
 | nodeSelector | NodeSelector Define which Nodes the Pods are scheduled on. | map[string]string | false |
+| rollingUpdateStrategy | RollingUpdateStrategy defines strategy for application updates Default is OnDelete, in this case operator handles update process Can be changed for RollingUpdate | appsv1.StatefulSetUpdateStrategyType | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
with rollingUpdateStrategy: RollingUpdate, operator doens't perform statefulset update
it delegates it to the kubernetes statefulset controller.

Default strategy is OnDelete, which controlls rolling update process by operator

RollingUpdate strategy may be useful, when user wants to perform kubectl restart command
or for some reason don't trust rolling update process for operator

 Fixes annotations merge for pod templates, which make possible kubectl restart command for other services

related kubernetes issue with statefulset broken state and why manual rolling update may be needed.
 https://github.com/kubernetes/kubernetes/issues/67250

https://github.com/VictoriaMetrics/operator/issues/389