### PR TITLE
Add prefix to `job_name` to prevent name collision

### DIFF
--- a/controllers/factory/probe_build.go
+++ b/controllers/factory/probe_build.go
@@ -23,7 +23,7 @@ func generateProbeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("%s/%s/%d", cr.Namespace, cr.Name, i),
+			Value: fmt.Sprintf("probe/%s/%s/%d", cr.Namespace, cr.Name, i),
 		},
 	}
 	var relabelings []yaml.MapSlice

--- a/controllers/factory/probe_build_test.go
+++ b/controllers/factory/probe_build_test.go
@@ -46,7 +46,7 @@ func Test_generateProbeConfig(t *testing.T) {
 				},
 				i: 0,
 			},
-			want: `job_name: default/static-probe/0
+			want: `job_name: probe/default/static-probe/0
 params:
   module:
   - http
@@ -95,7 +95,7 @@ relabel_configs:
 					},
 				},
 			},
-			want: `job_name: monitor/probe-ingress/0
+			want: `job_name: probe/monitor/probe-ingress/0
 params:
   module:
   - http200
@@ -189,7 +189,7 @@ relabel_configs:
 				},
 				i: 0,
 			},
-			want: `job_name: default/static-probe/0
+			want: `job_name: probe/default/static-probe/0
 scrape_interval: 10s
 scrape_timeout: 15s
 params:

--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -283,7 +283,7 @@ func generatePodScrapeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("%s/%s/%d", m.Namespace, m.Name, i),
+			Value: fmt.Sprintf("podScrape/%s/%s/%d", m.Namespace, m.Name, i),
 		},
 		{
 			Key:   "honor_labels",
@@ -533,7 +533,7 @@ func generateServiceScrapeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("%s/%s/%d", m.Namespace, m.Name, i),
+			Value: fmt.Sprintf("serviceScrape/%s/%s/%d", m.Namespace, m.Name, i),
 		},
 		{
 			Key:   "honor_labels",
@@ -862,7 +862,7 @@ func generateNodeScrapeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("%s/%s/%d", cr.Namespace, cr.Name, i),
+			Value: fmt.Sprintf("nodeScrape/%s/%s/%d", cr.Namespace, cr.Name, i),
 		},
 		{
 			Key:   "honor_labels",

--- a/controllers/factory/scrapes_build_test.go
+++ b/controllers/factory/scrapes_build_test.go
@@ -168,7 +168,7 @@ func Test_generateServiceScrapeConfig(t *testing.T) {
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints
@@ -266,7 +266,7 @@ relabel_configs:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpointslices
@@ -364,7 +364,7 @@ relabel_configs:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: service
@@ -428,7 +428,7 @@ relabel_configs:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: service
@@ -483,7 +483,7 @@ relabel_configs:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: service
@@ -606,7 +606,7 @@ relabel_configs:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: true
 honor_timestamps: true
 kubernetes_sd_configs:
@@ -722,7 +722,7 @@ oauth2:
 				ignoreNamespaceSelectors: false,
 				enforcedNamespaceLabel:   "",
 			},
-			want: `job_name: default/test-scrape/0
+			want: `job_name: serviceScrape/default/test-scrape/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints
@@ -822,7 +822,7 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 					},
 				},
 			},
-			want: `job_name: default/nodes-basic/1
+			want: `job_name: nodeScrape/default/nodes-basic/1
 honor_labels: false
 kubernetes_sd_configs:
 - role: node
@@ -904,7 +904,7 @@ relabel_configs:
 					},
 				},
 			},
-			want: `job_name: default/nodes-basic/1
+			want: `job_name: nodeScrape/default/nodes-basic/1
 honor_labels: true
 honor_timestamps: true
 kubernetes_sd_configs:
@@ -1064,7 +1064,7 @@ func Test_generatePodScrapeConfig(t *testing.T) {
 				},
 				ssCache: &scrapesSecretsCache{},
 			},
-			want: `job_name: default/test-1/0
+			want: `job_name: podScrape/default/test-1/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: pod
@@ -1125,7 +1125,7 @@ relabel_configs:
 				},
 				ssCache: &scrapesSecretsCache{},
 			},
-			want: `job_name: default/test-1/0
+			want: `job_name: podScrape/default/test-1/0
 honor_labels: false
 kubernetes_sd_configs:
 - role: pod

--- a/controllers/factory/scrapes_test.go
+++ b/controllers/factory/scrapes_test.go
@@ -617,7 +617,7 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
   external_labels:
     prometheus: default/test
 scrape_configs:
-- job_name: default/test-vms/0
+- job_name: serviceScrape/default/test-vms/0
   honor_labels: false
   kubernetes_sd_configs:
   - role: endpoints
@@ -665,7 +665,7 @@ scrape_configs:
     replacement: ${1}
   - target_label: endpoint
     replacement: "8085"
-- job_name: default/test-vms/1
+- job_name: serviceScrape/default/test-vms/1
   honor_labels: false
   kubernetes_sd_configs:
   - role: endpoints
@@ -712,7 +712,7 @@ scrape_configs:
     replacement: ${1}
   - target_label: endpoint
     replacement: "8083"
-- job_name: default/test-vps/0
+- job_name: podScrape/default/test-vps/0
   honor_labels: false
   kubernetes_sd_configs:
   - role: pod
@@ -754,7 +754,7 @@ scrape_configs:
     ca_file: /etc/vmagent-tls/certs/default_access-creds_ca
     cert_file: /etc/vmagent-tls/certs/default_access-creds_cert
     key_file: /etc/vmagent-tls/certs/default_access-creds_key
-- job_name: default/test-vps/1
+- job_name: podScrape/default/test-vps/1
   honor_labels: false
   kubernetes_sd_configs:
   - role: pod
@@ -795,7 +795,7 @@ scrape_configs:
   - target_label: endpoint
     replacement: "801"
   sample_limit: 10
-- job_name: kube-system/test-vmp/0
+- job_name: probe/kube-system/test-vmp/0
   params:
     module:
     - ""
@@ -809,7 +809,7 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: ""
-- job_name: default/test-vms/0
+- job_name: nodeScrape/default/test-vms/0
   honor_labels: false
   kubernetes_sd_configs:
   - role: node
@@ -822,7 +822,7 @@ scrape_configs:
     target_label: node
   - target_label: job
     replacement: default/test-vms
-- job_name: default/test-vmstatic/0
+- job_name: staticScrape/default/test-vmstatic/0
   honor_labels: false
   static_configs:
   - targets: []

--- a/controllers/factory/static_targets_build.go
+++ b/controllers/factory/static_targets_build.go
@@ -21,7 +21,7 @@ func generateStaticScrapeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("%s/%s/%d", m.Namespace, m.Name, i),
+			Value: fmt.Sprintf("staticScrape/%s/%s/%d", m.Namespace, m.Name, i),
 		},
 		{
 			Key:   "honor_labels",

--- a/controllers/factory/static_targets_build_test.go
+++ b/controllers/factory/static_targets_build_test.go
@@ -44,7 +44,7 @@ func Test_generateStaticScrapeConfig(t *testing.T) {
 					Labels:  map[string]string{"env": "dev", "group": "prod"},
 				},
 			},
-			want: `job_name: default/static-1/0
+			want: `job_name: staticScrape/default/static-1/0
 honor_labels: false
 static_configs:
 - targets:
@@ -86,7 +86,7 @@ relabel_configs:
 				overrideHonorLabels:     true,
 				enforceNamespaceLabel:   "namespace",
 			},
-			want: `job_name: default/static-1/0
+			want: `job_name: staticScrape/default/static-1/0
 honor_labels: false
 honor_timestamps: true
 static_configs:
@@ -228,7 +228,7 @@ metric_relabel_configs: []
 				overrideHonorLabels:     true,
 				enforceNamespaceLabel:   "namespace",
 			},
-			want: `job_name: default/static-1/0
+			want: `job_name: staticScrape/default/static-1/0
 honor_labels: false
 honor_timestamps: true
 static_configs:


### PR DESCRIPTION
Add `serviceScrape`, `podScrape`, `nodeScrape`, `staticScrape` and `probe` prefixes to `job_name` to prevent name collision. This pull request is similar to https://github.com/prometheus-operator/prometheus-operator/pull/3913 .