### PR TITLE
Process remote write secret even if BasicAuth is not set

### DIFF
--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -535,14 +535,13 @@ func loadScrapeSecrets(
 
 	// load basic auth for remote write configuration
 	for _, rws := range remoteWriteSpecs {
-		if rws.BasicAuth == nil {
-			continue
+		if rws.BasicAuth != nil {
+			credentials, err := loadBasicAuthSecret(ctx, rclient, namespace, rws.BasicAuth)
+			if err != nil {
+				return nil, fmt.Errorf("could not generate basicAuth for remote write spec %s config. %w", rws.URL, err)
+			}
+			baSecrets[fmt.Sprintf("remoteWriteSpec/%s", rws.URL)] = &credentials
 		}
-		credentials, err := loadBasicAuthSecret(ctx, rclient, namespace, rws.BasicAuth)
-		if err != nil {
-			return nil, fmt.Errorf("could not generate basicAuth for remote write spec %s config. %w", rws.URL, err)
-		}
-		baSecrets[fmt.Sprintf("remoteWriteSpec/%s", rws.URL)] = &credentials
 		if rws.OAuth2 != nil {
 			oauth2, err := loadOAuthSecrets(ctx, rclient, rws.OAuth2, namespace, nsSecretCache, nsCMCache)
 

--- a/controllers/factory/vmagent_test.go
+++ b/controllers/factory/vmagent_test.go
@@ -764,6 +764,33 @@ func TestBuildRemoteWrites(t *testing.T) {
 			},
 			want: []string{"-remoteWrite.oauth2.clientID=,some-id", "-remoteWrite.oauth2.clientSecret=,some-secret", "-remoteWrite.oauth2.scopes=,scope-1", "-remoteWrite.oauth2.tokenUrl=,http://some-url", "-remoteWrite.url=localhost:8429,localhost:8431", "-remoteWrite.sendTimeout=10s,15s"},
 		},
+		{
+			name: "test bearer token",
+			args: args{
+				ssCache: &scrapesSecretsCache{
+					bearerTokens: map[string]string{
+						"remoteWriteSpec/localhost:8431": "token",
+					},
+				},
+				cr: &victoriametricsv1beta1.VMAgent{
+					Spec: victoriametricsv1beta1.VMAgentSpec{RemoteWrite: []victoriametricsv1beta1.VMAgentRemoteWriteSpec{
+						{
+							URL:         "localhost:8429",
+							SendTimeout: pointer.String("10s"),
+						},
+						{
+							URL:         "localhost:8431",
+							SendTimeout: pointer.String("15s"),
+							BearerTokenSecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "some-secret"},
+								Key:                  "some-key",
+							},
+						},
+					}},
+				},
+			},
+			want: []string{"-remoteWrite.bearerToken=\"\",\"token\"", "-remoteWrite.url=localhost:8429,localhost:8431", "-remoteWrite.sendTimeout=10s,15s"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/factory/vmagent_test.go
+++ b/controllers/factory/vmagent_test.go
@@ -114,6 +114,28 @@ func TestCreateOrUpdateVMAgent(t *testing.T) {
 			},
 		},
 		{
+			name: "fail if bearer token secret is missing, without basic auth",
+			args: args{
+				c: config.MustGetBaseConfig(),
+				cr: &victoriametricsv1beta1.VMAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "example-agent-bearer-missing",
+						Namespace: "default",
+					},
+					Spec: victoriametricsv1beta1.VMAgentSpec{
+						RemoteWrite: []victoriametricsv1beta1.VMAgentRemoteWriteSpec{
+							{
+								URL:               "http://remote-write",
+								BearerTokenSecret: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "bearer-secret"}, Key: "token"},
+							},
+						},
+						ServiceScrapeSelector: &metav1.LabelSelector{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "generate vmagent with tls-secret",
 			args: args{
 				c: config.MustGetBaseConfig(),
@@ -713,7 +735,7 @@ func TestBuildRemoteWrites(t *testing.T) {
 			name: "test oauth2",
 			args: args{
 				ssCache: &scrapesSecretsCache{
-					oauth2Secrets: map[string]*oauthCreds{"remoteWriteSpec/localhost:8431": &oauthCreds{
+					oauth2Secrets: map[string]*oauthCreds{"remoteWriteSpec/localhost:8431": {
 						clientID:     "some-id",
 						clientSecret: "some-secret",
 					}},


### PR DESCRIPTION
Remote write secret is ignored when basic auth is not set. There is possibility of using other auth method without using basic auth method, e.g. bearer token.

This PR ensures that remote write secret is processed even if basic auth is not set.