### PR TITLE
adds kubernetes version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ GOCMD=GO111MODULE=on go
 TAG  ?= 0.1.0
 VERSION=$(TAG)
 VERSION_TRIM=$(VERSION:v%=%)
-GOOS ?= linux
-GOARCH ?= amd64
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 BUILD=`date +%FT%T%z`
 LDFLAGS=-ldflags "-w -s  -X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${VERSION}"
 GOBUILD= $(GOCMD) build -trimpath ${LDFLAGS}
@@ -314,7 +314,7 @@ packagemanifests: manifests fix118 fix_crd_nulls
 	mv packagemanifests/$(VERSION_TRIM)/victoriametrics-operator.clusterserviceversion.yaml packagemanifests/$(VERSION_TRIM)/victoriametrics-operator.$(VERSION_TRIM).clusterserviceversion.yaml
 	sed -i "s|$(DOCKER_REPO):.*|$(DOCKER_REPO):$(VERSION)|" packagemanifests/$(VERSION_TRIM)/*
     # remove service account from bundle, OLM creates it automatically.
-	rm packagemanifests/$VERSION_TRIM/packagemanifests/0.22.0/vm-operator-vm-operator_v1_serviceaccount.yaml
+	rm packagemanifests/$(VERSION_TRIM)/vm-operator-vm-operator_v1_serviceaccount.yaml
 	docker run --rm -v "${PWD}":/workdir mikefarah/yq:2.2.0 \
 	 yq m -i -a packagemanifests/$(VERSION_TRIM)/victoriametrics-operator.$(VERSION_TRIM).clusterserviceversion.yaml hack/bundle_csv_vmagent.yaml
 

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -70,9 +70,8 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *victoriametricsv1beta1.
 	}
 
 	if cr.Spec.PodDisruptionBudget != nil {
-		err := CreateOrUpdatePodDisruptionBudgetForAlertManager(ctx, cr, rclient)
-		if err != nil {
-			return fmt.Errorf("cannot update pod disruption budget for vmagent: %w", err)
+		if err := CreateOrUpdatePodDisruptionBudget(ctx, rclient, cr, cr.Kind, cr.Spec.PodDisruptionBudget); err != nil {
+			return fmt.Errorf("cannot update pod disruption budget for alertmanager: %w", err)
 		}
 	}
 	// special hack, we need version for alertmanager a bit earlier.

--- a/controllers/factory/finalize/vmagent.go
+++ b/controllers/factory/finalize/vmagent.go
@@ -10,7 +10,6 @@ import (
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,10 +47,9 @@ func OnVMAgentDelete(ctx context.Context, rclient client.Client, crd *victoriame
 	}
 
 	// check PDB
-	if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := finalizePBD(ctx, rclient, crd); err != nil {
 		return err
 	}
-
 	// remove vmagents service discovery rbac.
 	if err := removeFinalizeObjByName(ctx, rclient, &v12.ClusterRoleBinding{}, crd.GetClusterRoleName(), crd.GetNSName()); err != nil {
 		return err

--- a/controllers/factory/finalize/vmalert.go
+++ b/controllers/factory/finalize/vmalert.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,7 +37,7 @@ func OnVMAlertDelete(ctx context.Context, rclient client.Client, crd *victoriame
 	}
 
 	// check PDB
-	if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := finalizePBD(ctx, rclient, crd); err != nil {
 		return err
 	}
 

--- a/controllers/factory/finalize/vmalertmanager.go
+++ b/controllers/factory/finalize/vmalertmanager.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,7 +37,7 @@ func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, crd *vic
 	}
 
 	// check PDB
-	if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := finalizePBD(ctx, rclient, crd); err != nil {
 		return err
 	}
 

--- a/controllers/factory/finalize/vmauth.go
+++ b/controllers/factory/finalize/vmauth.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/api/networking/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,9 +50,10 @@ func OnVMAuthDelete(ctx context.Context, rclient client.Client, crd *victoriamet
 	}
 
 	// check PDB
-	if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := finalizePBD(ctx, rclient, crd); err != nil {
 		return err
 	}
+
 	// check ingress
 	if err := removeFinalizeObjByName(ctx, rclient, &v12.Ingress{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err

--- a/controllers/factory/finalize/vmcluster.go
+++ b/controllers/factory/finalize/vmcluster.go
@@ -9,7 +9,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,7 +50,7 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *victoria
 		}
 
 		// check PDB
-		if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
 			return err
 		}
 	}
@@ -76,7 +75,7 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *victoria
 		}
 
 		// check PDB
-		if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
 			return err
 		}
 	}
@@ -96,7 +95,7 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *victoria
 		}
 
 		// check PDB
-		if err := removeFinalizeObjByName(ctx, rclient, &policyv1beta1.PodDisruptionBudget{}, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
 			return err
 		}
 	}

--- a/controllers/factory/k8stools/version.go
+++ b/controllers/factory/k8stools/version.go
@@ -1,0 +1,46 @@
+package k8stools
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/version"
+	"strconv"
+)
+
+var (
+	ServerMajorVersion uint64
+	ServerMinorVersion uint64
+)
+
+// TrySetKubernetesServerVersion parses kubernetes
+func TrySetKubernetesServerVersion(vi *version.Info) error {
+	v, err := strconv.ParseUint(vi.Minor, 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse kubernetes server minor version: %q as uint: %w", vi.Minor, err)
+	}
+	ServerMinorVersion = v
+	v, err = strconv.ParseUint(vi.Major, 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse kubernetes server major version: %q as uint: %w", vi.Major, err)
+	}
+	ServerMajorVersion = v
+	return nil
+}
+
+// IsPSPSupported check if PodSecurityPolicy is supported by kubernetes API server
+// https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125
+func IsPSPSupported() bool {
+	if ServerMajorVersion == 1 && ServerMinorVersion < 23 {
+		return false
+	}
+	return true
+}
+
+// IsPDBV1APISupported check if new v1 API is supported by kubernetes API server
+// deprecated since 1.21
+// https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
+func IsPDBV1APISupported() bool {
+	if ServerMajorVersion == 1 && ServerMinorVersion <= 21 {
+		return false
+	}
+	return true
+}

--- a/controllers/factory/psp/psp.go
+++ b/controllers/factory/psp/psp.go
@@ -3,8 +3,8 @@ package psp
 import (
 	"context"
 	"fmt"
-
 	v1beta12 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	v12 "k8s.io/api/rbac/v1"
@@ -34,6 +34,9 @@ type CRDObject interface {
 // ClusterRoleBinding exists.
 func CreateOrUpdateServiceAccountWithPSP(ctx context.Context, cr CRDObject, rclient client.Client) error {
 
+	if !k8stools.IsPSPSupported() {
+		return nil
+	}
 	if err := ensurePSPExists(ctx, cr, rclient); err != nil {
 		return fmt.Errorf("failed check policy: %w", err)
 	}

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -117,8 +117,7 @@ func CreateOrUpdateVMAlert(ctx context.Context, cr *victoriametricsv1beta1.VMAle
 	}
 
 	if cr.Spec.PodDisruptionBudget != nil {
-		err = CreateOrUpdatePodDisruptionBudgetForVMAlert(ctx, cr, rclient)
-		if err != nil {
+		if err := CreateOrUpdatePodDisruptionBudget(ctx, rclient, cr, cr.Kind, cr.Spec.PodDisruptionBudget); err != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot update pod disruption budget for vmalert: %w", err)
 		}
 	}

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -142,7 +142,7 @@ func NewConverterController(promCl versioned.Interface, vclient client.Client, b
 func waitForAPIResource(ctx context.Context, client discovery.DiscoveryInterface, apiGroupVersion string, kind string) error {
 	l := log.WithValues("group", apiGroupVersion, "kind", kind)
 	l.Info("waiting for api resource")
-	tick := time.NewTicker(time.Second * 10)
+	tick := time.NewTicker(time.Minute)
 	for {
 		select {
 		case <-tick.C:


### PR DESCRIPTION
it allows to mitigate issue with deprecation policy for kubernetes and support wide range of cluster version

makes PodSecurityPolicy noop since kubernetes version 1.23
starts using PodDisruptionBudget with api v1 since kubernetes 1.22 version
https://github.com/VictoriaMetrics/operator/issues/412