### PR TITLE
fixes alertmanager pagerduty_configs generation

### DIFF
--- a/controllers/factory/alertmanager/config.go
+++ b/controllers/factory/alertmanager/config.go
@@ -561,6 +561,19 @@ func (cb *configBuilder) buildPagerDuty(pd operatorv1beta1.PagerDutyConfig) erro
 	toYaml("client", pd.Client)
 	toYaml("class", pd.Class)
 	toYaml("component", pd.Component)
+	toYaml("group", pd.Group)
+	toYaml("severity", pd.Severity)
+	details := make(map[string]string)
+	if pd.Details != nil {
+		for k, v := range pd.Details {
+			if len(v) > 0 {
+				details[k] = v
+			}
+		}
+		if len(details) > 0 {
+			temp = append(temp, yaml.MapItem{Key: "details", Value: details})
+		}
+	}
 	if pd.SendResolved != nil {
 		temp = append(temp, yaml.MapItem{Key: "send_resolved", Value: *pd.SendResolved})
 	}


### PR DESCRIPTION
Fix CRD VMAlertmanagerConfig's pagerduty_configs. The reason is similar to the issue [#339 ](https://github.com/VictoriaMetrics/operator/issues/339)，pagerduty_config wasn't rendered correctly.
Thanks.