### PR TITLE
Allow customization of VMServiceScrape in various objects

### DIFF
--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -2,12 +2,13 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/pointer"
-	"strings"
 )
 
 // VMAgentSpec defines the desired state of VMAgent
@@ -297,6 +298,9 @@ type VMAgentSpec struct {
 	// ServiceSpec that will be added to vmagent service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 
 	// ShardCount - numbers of shards of VMAgent
 	// in this case operator will use 1 deployment/sts per shard with

--- a/api/v1beta1/vmalert_types.go
+++ b/api/v1beta1/vmalert_types.go
@@ -214,6 +214,9 @@ type VMAlertSpec struct {
 	// ServiceSpec that will be added to vmalert service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 
 	// UpdateStrategy - overrides default update strategy.
 	// +kubebuilder:validation:Enum=Recreate;RollingUpdate

--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -2,8 +2,9 @@ package v1beta1
 
 import (
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -204,6 +205,9 @@ type VMAlertmanagerSpec struct {
 	// ServiceSpec that will be added to vmalertmanager service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 	// PodDisruptionBudget created by operator
 	// +optional
 	PodDisruptionBudget *EmbeddedPodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`

--- a/api/v1beta1/vmauth_types.go
+++ b/api/v1beta1/vmauth_types.go
@@ -153,6 +153,9 @@ type VMAuthSpec struct {
 	// ServiceSpec that will be added to vmsingle service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 	// PodDisruptionBudget created by operator
 	// +optional
 	PodDisruptionBudget *EmbeddedPodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -247,6 +247,9 @@ type VMSelect struct {
 	// ServiceSpec that will be added to vmselect service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 	// PodDisruptionBudget created by operator
 	// +optional
 	PodDisruptionBudget *EmbeddedPodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
@@ -411,6 +414,9 @@ type VMInsert struct {
 	// ServiceSpec that will be added to vminsert service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 
 	// UpdateStrategy - overrides default update strategy.
 	// +kubebuilder:validation:Enum=Recreate;RollingUpdate
@@ -569,6 +575,9 @@ type VMStorage struct {
 	// ServiceSpec that will be create additional service for vmstorage
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 	// PodDisruptionBudget created by operator
 	// +optional
 	PodDisruptionBudget *EmbeddedPodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`

--- a/api/v1beta1/vmsingle_types.go
+++ b/api/v1beta1/vmsingle_types.go
@@ -166,6 +166,9 @@ type VMSingleSpec struct {
 	// ServiceSpec that will be added to vmsingle service spec
 	// +optional
 	ServiceSpec *ServiceSpec `json:"serviceSpec,omitempty"`
+	// ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec
+	// +optional
+	ServiceScrapeSpec *VMServiceScrapeSpec `json:"serviceScrapeSpec,omitempty"`
 	// LivenessProbe that will be added to VMSingle pod
 	*EmbeddedProbes `json:",inline"`
 	// NodeSelector Define which Nodes the Pods are scheduled on.

--- a/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -1762,6 +1762,832 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+              serviceScrapeSpec:
+                description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                  spec
+                properties:
+                  discoveryRole:
+                    description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                      discovery. by default, its endpoints. can be changed to service
+                      or endpointslices. note, that with service setting, you have
+                      to use port: "name" and cannot use targetPort for endpoints.'
+                    enum:
+                    - endpoints
+                    - service
+                    - endpointslices
+                    type: string
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceScrape.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving
+                        Prometheus metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate
+                            over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: The secret in the service scrape namespace
+                                that contains the password for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            password_file:
+                              description: PasswordFile defines path to password file
+                                at disk
+                              type: string
+                            username:
+                              description: The secret in the service scrape namespace
+                                that contains the username for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        bearerTokenSecret:
+                          description: Secret to mount to read bearer token for scraping
+                            targets. The secret needs to be in the same namespace
+                            as the service scrape and accessible by the victoria-metrics
+                            operator.
+                          nullable: true
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        follow_redirects:
+                          description: FollowRedirects controls redirects for scraping.
+                          type: boolean
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on
+                            collisions with target labels.
+                          type: boolean
+                        honorTimestamps:
+                          description: HonorTimestamps controls whether vmagent respects
+                            the timestamps present in scraped data.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelConfigs:
+                          description: MetricRelabelConfigs to apply to samples before
+                            ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        oauth2:
+                          description: OAuth2 defines auth configuration
+                          properties:
+                            client_id:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            client_secret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            client_secret_file:
+                              description: ClientSecretFile defines path for client
+                                secret file.
+                              type: string
+                            endpoint_params:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            token_url:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - client_id
+                          - token_url
+                          type: object
+                        params:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers
+                            to. Mutually exclusive with targetPort.
+                          type: string
+                        proxyURL:
+                          description: ProxyURL eg http://proxyserver:2195 Directs
+                            scrapes to proxy through this endpoint.
+                          type: string
+                        relabelConfigs:
+                          description: 'RelabelConfigs to apply to samples before
+                            scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        sampleLimit:
+                          description: SampleLimit defines per-endpoint limit on number
+                            of scraped samples that will be accepted.
+                          format: int64
+                          type: integer
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrape_interval:
+                          description: ScrapeInterval is the same as Interval and
+                            has priority over it. one of scrape_interval or interval
+                            can be used
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the pod port this endpoint
+                            refers to. Mutually exclusive with port.
+                          x-kubernetes-int-or-string: true
+                        tlsConfig:
+                          description: TLSConfig configuration to use when scraping
+                            the endpoint
+                          properties:
+                            ca:
+                              description: Stuct containing the CA cert to use for
+                                the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            caFile:
+                              description: Path to the CA cert in the container to
+                                use for the targets.
+                              type: string
+                            cert:
+                              description: Struct containing the client cert file
+                                for the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            certFile:
+                              description: Path to the client cert file in the container
+                                for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: Path to the client key file in the container
+                                for the targets.
+                              type: string
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        vm_scrape_params:
+                          description: VMScrapeParams defines VictoriaMetrics specific
+                            scrape parametrs
+                          properties:
+                            disable_compression:
+                              type: boolean
+                            disable_keep_alive:
+                              type: boolean
+                            metric_relabel_debug:
+                              type: boolean
+                            proxy_client_config:
+                              description: ProxyClientConfig configures proxy auth
+                                settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                              properties:
+                                basic_auth:
+                                  description: 'BasicAuth allow an endpoint to authenticate
+                                    over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                  properties:
+                                    password:
+                                      description: The secret in the service scrape
+                                        namespace that contains the password for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    password_file:
+                                      description: PasswordFile defines path to password
+                                        file at disk
+                                      type: string
+                                    username:
+                                      description: The secret in the service scrape
+                                        namespace that contains the username for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                bearer_token:
+                                  description: SecretKeySelector selects a key of
+                                    a Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                bearer_token_file:
+                                  type: string
+                                tls_config:
+                                  description: TLSConfig specifies TLSConfig configuration
+                                    parameters.
+                                  properties:
+                                    ca:
+                                      description: Stuct containing the CA cert to
+                                        use for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    caFile:
+                                      description: Path to the CA cert in the container
+                                        to use for the targets.
+                                      type: string
+                                    cert:
+                                      description: Struct containing the client cert
+                                        file for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    certFile:
+                                      description: Path to the client cert file in
+                                        the container for the targets.
+                                      type: string
+                                    insecureSkipVerify:
+                                      description: Disable target certificate validation.
+                                      type: boolean
+                                    keyFile:
+                                      description: Path to the client key file in
+                                        the container for the targets.
+                                      type: string
+                                    keySecret:
+                                      description: Secret containing the client key
+                                        file for the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    serverName:
+                                      description: Used to verify the hostname for
+                                        the targets.
+                                      type: string
+                                  type: object
+                              type: object
+                            relabel_debug:
+                              type: boolean
+                            scrape_align_interval:
+                              type: string
+                            scrape_offset:
+                              type: string
+                            stream_parse:
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: Selector to select which namespaces the Endpoints
+                      objects are discovered from.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are
+                          selected in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  podTargetLabels:
+                    description: PodTargetLabels transfers labels on the Kubernetes
+                      Pod onto the target.
+                    items:
+                      type: string
+                    type: array
+                  sampleLimit:
+                    description: SampleLimit defines per-scrape limit on number of
+                      scraped samples that will be accepted.
+                    format: int64
+                    type: integer
+                  selector:
+                    description: Selector to select Endpoints objects by corresponding
+                      Service labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                type: object
               serviceSpec:
                 description: ServiceSpec that will be added to vmagent service spec
                 properties:

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -461,6 +461,832 @@ spec:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use
                 type: string
+              serviceScrapeSpec:
+                description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                  spec
+                properties:
+                  discoveryRole:
+                    description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                      discovery. by default, its endpoints. can be changed to service
+                      or endpointslices. note, that with service setting, you have
+                      to use port: "name" and cannot use targetPort for endpoints.'
+                    enum:
+                    - endpoints
+                    - service
+                    - endpointslices
+                    type: string
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceScrape.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving
+                        Prometheus metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate
+                            over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: The secret in the service scrape namespace
+                                that contains the password for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            password_file:
+                              description: PasswordFile defines path to password file
+                                at disk
+                              type: string
+                            username:
+                              description: The secret in the service scrape namespace
+                                that contains the username for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        bearerTokenSecret:
+                          description: Secret to mount to read bearer token for scraping
+                            targets. The secret needs to be in the same namespace
+                            as the service scrape and accessible by the victoria-metrics
+                            operator.
+                          nullable: true
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        follow_redirects:
+                          description: FollowRedirects controls redirects for scraping.
+                          type: boolean
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on
+                            collisions with target labels.
+                          type: boolean
+                        honorTimestamps:
+                          description: HonorTimestamps controls whether vmagent respects
+                            the timestamps present in scraped data.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelConfigs:
+                          description: MetricRelabelConfigs to apply to samples before
+                            ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        oauth2:
+                          description: OAuth2 defines auth configuration
+                          properties:
+                            client_id:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            client_secret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            client_secret_file:
+                              description: ClientSecretFile defines path for client
+                                secret file.
+                              type: string
+                            endpoint_params:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            token_url:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - client_id
+                          - token_url
+                          type: object
+                        params:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers
+                            to. Mutually exclusive with targetPort.
+                          type: string
+                        proxyURL:
+                          description: ProxyURL eg http://proxyserver:2195 Directs
+                            scrapes to proxy through this endpoint.
+                          type: string
+                        relabelConfigs:
+                          description: 'RelabelConfigs to apply to samples before
+                            scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        sampleLimit:
+                          description: SampleLimit defines per-endpoint limit on number
+                            of scraped samples that will be accepted.
+                          format: int64
+                          type: integer
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrape_interval:
+                          description: ScrapeInterval is the same as Interval and
+                            has priority over it. one of scrape_interval or interval
+                            can be used
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the pod port this endpoint
+                            refers to. Mutually exclusive with port.
+                          x-kubernetes-int-or-string: true
+                        tlsConfig:
+                          description: TLSConfig configuration to use when scraping
+                            the endpoint
+                          properties:
+                            ca:
+                              description: Stuct containing the CA cert to use for
+                                the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            caFile:
+                              description: Path to the CA cert in the container to
+                                use for the targets.
+                              type: string
+                            cert:
+                              description: Struct containing the client cert file
+                                for the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            certFile:
+                              description: Path to the client cert file in the container
+                                for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: Path to the client key file in the container
+                                for the targets.
+                              type: string
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        vm_scrape_params:
+                          description: VMScrapeParams defines VictoriaMetrics specific
+                            scrape parametrs
+                          properties:
+                            disable_compression:
+                              type: boolean
+                            disable_keep_alive:
+                              type: boolean
+                            metric_relabel_debug:
+                              type: boolean
+                            proxy_client_config:
+                              description: ProxyClientConfig configures proxy auth
+                                settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                              properties:
+                                basic_auth:
+                                  description: 'BasicAuth allow an endpoint to authenticate
+                                    over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                  properties:
+                                    password:
+                                      description: The secret in the service scrape
+                                        namespace that contains the password for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    password_file:
+                                      description: PasswordFile defines path to password
+                                        file at disk
+                                      type: string
+                                    username:
+                                      description: The secret in the service scrape
+                                        namespace that contains the username for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                bearer_token:
+                                  description: SecretKeySelector selects a key of
+                                    a Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                bearer_token_file:
+                                  type: string
+                                tls_config:
+                                  description: TLSConfig specifies TLSConfig configuration
+                                    parameters.
+                                  properties:
+                                    ca:
+                                      description: Stuct containing the CA cert to
+                                        use for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    caFile:
+                                      description: Path to the CA cert in the container
+                                        to use for the targets.
+                                      type: string
+                                    cert:
+                                      description: Struct containing the client cert
+                                        file for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    certFile:
+                                      description: Path to the client cert file in
+                                        the container for the targets.
+                                      type: string
+                                    insecureSkipVerify:
+                                      description: Disable target certificate validation.
+                                      type: boolean
+                                    keyFile:
+                                      description: Path to the client key file in
+                                        the container for the targets.
+                                      type: string
+                                    keySecret:
+                                      description: Secret containing the client key
+                                        file for the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    serverName:
+                                      description: Used to verify the hostname for
+                                        the targets.
+                                      type: string
+                                  type: object
+                              type: object
+                            relabel_debug:
+                              type: boolean
+                            scrape_align_interval:
+                              type: string
+                            scrape_offset:
+                              type: string
+                            stream_parse:
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: Selector to select which namespaces the Endpoints
+                      objects are discovered from.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are
+                          selected in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  podTargetLabels:
+                    description: PodTargetLabels transfers labels on the Kubernetes
+                      Pod onto the target.
+                    items:
+                      type: string
+                    type: array
+                  sampleLimit:
+                    description: SampleLimit defines per-scrape limit on number of
+                      scraped samples that will be accepted.
+                    format: int64
+                    type: integer
+                  selector:
+                    description: Selector to select Endpoints objects by corresponding
+                      Service labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                type: object
               serviceSpec:
                 description: ServiceSpec that will be added to vmalertmanager service
                   spec

--- a/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -1550,6 +1550,832 @@ spec:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMAlert Pods.
                 type: string
+              serviceScrapeSpec:
+                description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                  spec
+                properties:
+                  discoveryRole:
+                    description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                      discovery. by default, its endpoints. can be changed to service
+                      or endpointslices. note, that with service setting, you have
+                      to use port: "name" and cannot use targetPort for endpoints.'
+                    enum:
+                    - endpoints
+                    - service
+                    - endpointslices
+                    type: string
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceScrape.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving
+                        Prometheus metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate
+                            over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: The secret in the service scrape namespace
+                                that contains the password for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            password_file:
+                              description: PasswordFile defines path to password file
+                                at disk
+                              type: string
+                            username:
+                              description: The secret in the service scrape namespace
+                                that contains the username for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        bearerTokenSecret:
+                          description: Secret to mount to read bearer token for scraping
+                            targets. The secret needs to be in the same namespace
+                            as the service scrape and accessible by the victoria-metrics
+                            operator.
+                          nullable: true
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        follow_redirects:
+                          description: FollowRedirects controls redirects for scraping.
+                          type: boolean
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on
+                            collisions with target labels.
+                          type: boolean
+                        honorTimestamps:
+                          description: HonorTimestamps controls whether vmagent respects
+                            the timestamps present in scraped data.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelConfigs:
+                          description: MetricRelabelConfigs to apply to samples before
+                            ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        oauth2:
+                          description: OAuth2 defines auth configuration
+                          properties:
+                            client_id:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            client_secret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            client_secret_file:
+                              description: ClientSecretFile defines path for client
+                                secret file.
+                              type: string
+                            endpoint_params:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            token_url:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - client_id
+                          - token_url
+                          type: object
+                        params:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers
+                            to. Mutually exclusive with targetPort.
+                          type: string
+                        proxyURL:
+                          description: ProxyURL eg http://proxyserver:2195 Directs
+                            scrapes to proxy through this endpoint.
+                          type: string
+                        relabelConfigs:
+                          description: 'RelabelConfigs to apply to samples before
+                            scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        sampleLimit:
+                          description: SampleLimit defines per-endpoint limit on number
+                            of scraped samples that will be accepted.
+                          format: int64
+                          type: integer
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrape_interval:
+                          description: ScrapeInterval is the same as Interval and
+                            has priority over it. one of scrape_interval or interval
+                            can be used
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the pod port this endpoint
+                            refers to. Mutually exclusive with port.
+                          x-kubernetes-int-or-string: true
+                        tlsConfig:
+                          description: TLSConfig configuration to use when scraping
+                            the endpoint
+                          properties:
+                            ca:
+                              description: Stuct containing the CA cert to use for
+                                the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            caFile:
+                              description: Path to the CA cert in the container to
+                                use for the targets.
+                              type: string
+                            cert:
+                              description: Struct containing the client cert file
+                                for the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            certFile:
+                              description: Path to the client cert file in the container
+                                for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: Path to the client key file in the container
+                                for the targets.
+                              type: string
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        vm_scrape_params:
+                          description: VMScrapeParams defines VictoriaMetrics specific
+                            scrape parametrs
+                          properties:
+                            disable_compression:
+                              type: boolean
+                            disable_keep_alive:
+                              type: boolean
+                            metric_relabel_debug:
+                              type: boolean
+                            proxy_client_config:
+                              description: ProxyClientConfig configures proxy auth
+                                settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                              properties:
+                                basic_auth:
+                                  description: 'BasicAuth allow an endpoint to authenticate
+                                    over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                  properties:
+                                    password:
+                                      description: The secret in the service scrape
+                                        namespace that contains the password for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    password_file:
+                                      description: PasswordFile defines path to password
+                                        file at disk
+                                      type: string
+                                    username:
+                                      description: The secret in the service scrape
+                                        namespace that contains the username for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                bearer_token:
+                                  description: SecretKeySelector selects a key of
+                                    a Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                bearer_token_file:
+                                  type: string
+                                tls_config:
+                                  description: TLSConfig specifies TLSConfig configuration
+                                    parameters.
+                                  properties:
+                                    ca:
+                                      description: Stuct containing the CA cert to
+                                        use for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    caFile:
+                                      description: Path to the CA cert in the container
+                                        to use for the targets.
+                                      type: string
+                                    cert:
+                                      description: Struct containing the client cert
+                                        file for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    certFile:
+                                      description: Path to the client cert file in
+                                        the container for the targets.
+                                      type: string
+                                    insecureSkipVerify:
+                                      description: Disable target certificate validation.
+                                      type: boolean
+                                    keyFile:
+                                      description: Path to the client key file in
+                                        the container for the targets.
+                                      type: string
+                                    keySecret:
+                                      description: Secret containing the client key
+                                        file for the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    serverName:
+                                      description: Used to verify the hostname for
+                                        the targets.
+                                      type: string
+                                  type: object
+                              type: object
+                            relabel_debug:
+                              type: boolean
+                            scrape_align_interval:
+                              type: string
+                            scrape_offset:
+                              type: string
+                            stream_parse:
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: Selector to select which namespaces the Endpoints
+                      objects are discovered from.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are
+                          selected in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  podTargetLabels:
+                    description: PodTargetLabels transfers labels on the Kubernetes
+                      Pod onto the target.
+                    items:
+                      type: string
+                    type: array
+                  sampleLimit:
+                    description: SampleLimit defines per-scrape limit on number of
+                      scraped samples that will be accepted.
+                    format: int64
+                    type: integer
+                  selector:
+                    description: Selector to select Endpoints objects by corresponding
+                      Service labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                type: object
               serviceSpec:
                 description: ServiceSpec that will be added to vmalert service spec
                 properties:

--- a/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -532,6 +532,832 @@ spec:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMAuth Pods.
                 type: string
+              serviceScrapeSpec:
+                description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                  spec
+                properties:
+                  discoveryRole:
+                    description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                      discovery. by default, its endpoints. can be changed to service
+                      or endpointslices. note, that with service setting, you have
+                      to use port: "name" and cannot use targetPort for endpoints.'
+                    enum:
+                    - endpoints
+                    - service
+                    - endpointslices
+                    type: string
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceScrape.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving
+                        Prometheus metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate
+                            over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: The secret in the service scrape namespace
+                                that contains the password for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            password_file:
+                              description: PasswordFile defines path to password file
+                                at disk
+                              type: string
+                            username:
+                              description: The secret in the service scrape namespace
+                                that contains the username for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        bearerTokenSecret:
+                          description: Secret to mount to read bearer token for scraping
+                            targets. The secret needs to be in the same namespace
+                            as the service scrape and accessible by the victoria-metrics
+                            operator.
+                          nullable: true
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        follow_redirects:
+                          description: FollowRedirects controls redirects for scraping.
+                          type: boolean
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on
+                            collisions with target labels.
+                          type: boolean
+                        honorTimestamps:
+                          description: HonorTimestamps controls whether vmagent respects
+                            the timestamps present in scraped data.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelConfigs:
+                          description: MetricRelabelConfigs to apply to samples before
+                            ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        oauth2:
+                          description: OAuth2 defines auth configuration
+                          properties:
+                            client_id:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            client_secret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            client_secret_file:
+                              description: ClientSecretFile defines path for client
+                                secret file.
+                              type: string
+                            endpoint_params:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            token_url:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - client_id
+                          - token_url
+                          type: object
+                        params:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers
+                            to. Mutually exclusive with targetPort.
+                          type: string
+                        proxyURL:
+                          description: ProxyURL eg http://proxyserver:2195 Directs
+                            scrapes to proxy through this endpoint.
+                          type: string
+                        relabelConfigs:
+                          description: 'RelabelConfigs to apply to samples before
+                            scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        sampleLimit:
+                          description: SampleLimit defines per-endpoint limit on number
+                            of scraped samples that will be accepted.
+                          format: int64
+                          type: integer
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrape_interval:
+                          description: ScrapeInterval is the same as Interval and
+                            has priority over it. one of scrape_interval or interval
+                            can be used
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the pod port this endpoint
+                            refers to. Mutually exclusive with port.
+                          x-kubernetes-int-or-string: true
+                        tlsConfig:
+                          description: TLSConfig configuration to use when scraping
+                            the endpoint
+                          properties:
+                            ca:
+                              description: Stuct containing the CA cert to use for
+                                the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            caFile:
+                              description: Path to the CA cert in the container to
+                                use for the targets.
+                              type: string
+                            cert:
+                              description: Struct containing the client cert file
+                                for the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            certFile:
+                              description: Path to the client cert file in the container
+                                for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: Path to the client key file in the container
+                                for the targets.
+                              type: string
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        vm_scrape_params:
+                          description: VMScrapeParams defines VictoriaMetrics specific
+                            scrape parametrs
+                          properties:
+                            disable_compression:
+                              type: boolean
+                            disable_keep_alive:
+                              type: boolean
+                            metric_relabel_debug:
+                              type: boolean
+                            proxy_client_config:
+                              description: ProxyClientConfig configures proxy auth
+                                settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                              properties:
+                                basic_auth:
+                                  description: 'BasicAuth allow an endpoint to authenticate
+                                    over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                  properties:
+                                    password:
+                                      description: The secret in the service scrape
+                                        namespace that contains the password for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    password_file:
+                                      description: PasswordFile defines path to password
+                                        file at disk
+                                      type: string
+                                    username:
+                                      description: The secret in the service scrape
+                                        namespace that contains the username for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                bearer_token:
+                                  description: SecretKeySelector selects a key of
+                                    a Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                bearer_token_file:
+                                  type: string
+                                tls_config:
+                                  description: TLSConfig specifies TLSConfig configuration
+                                    parameters.
+                                  properties:
+                                    ca:
+                                      description: Stuct containing the CA cert to
+                                        use for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    caFile:
+                                      description: Path to the CA cert in the container
+                                        to use for the targets.
+                                      type: string
+                                    cert:
+                                      description: Struct containing the client cert
+                                        file for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    certFile:
+                                      description: Path to the client cert file in
+                                        the container for the targets.
+                                      type: string
+                                    insecureSkipVerify:
+                                      description: Disable target certificate validation.
+                                      type: boolean
+                                    keyFile:
+                                      description: Path to the client key file in
+                                        the container for the targets.
+                                      type: string
+                                    keySecret:
+                                      description: Secret containing the client key
+                                        file for the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    serverName:
+                                      description: Used to verify the hostname for
+                                        the targets.
+                                      type: string
+                                  type: object
+                              type: object
+                            relabel_debug:
+                              type: boolean
+                            scrape_align_interval:
+                              type: string
+                            scrape_offset:
+                              type: string
+                            stream_parse:
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: Selector to select which namespaces the Endpoints
+                      objects are discovered from.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are
+                          selected in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  podTargetLabels:
+                    description: PodTargetLabels transfers labels on the Kubernetes
+                      Pod onto the target.
+                    items:
+                      type: string
+                    type: array
+                  sampleLimit:
+                    description: SampleLimit defines per-scrape limit on number of
+                      scraped samples that will be accepted.
+                    format: int64
+                    type: integer
+                  selector:
+                    description: Selector to select Endpoints objects by corresponding
+                      Service labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                type: object
               serviceSpec:
                 description: ServiceSpec that will be added to vmsingle service spec
                 properties:

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -391,6 +391,854 @@ spec:
                       PodSecurityContext.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  serviceScrapeSpec:
+                    description: ServiceScrapeSpec that will be added to vmselect
+                      VMServiceScrape spec
+                    properties:
+                      discoveryRole:
+                        description: 'DiscoveryRole - defines kubernetes_sd role for
+                          objects discovery. by default, its endpoints. can be changed
+                          to service or endpointslices. note, that with service setting,
+                          you have to use port: "name" and cannot use targetPort for
+                          endpoints.'
+                        enum:
+                        - endpoints
+                        - service
+                        - endpointslices
+                        type: string
+                      endpoints:
+                        description: A list of endpoints allowed as part of this ServiceScrape.
+                        items:
+                          description: Endpoint defines a scrapeable endpoint serving
+                            Prometheus metrics.
+                          properties:
+                            basicAuth:
+                              description: 'BasicAuth allow an endpoint to authenticate
+                                over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                              properties:
+                                password:
+                                  description: The secret in the service scrape namespace
+                                    that contains the password for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                password_file:
+                                  description: PasswordFile defines path to password
+                                    file at disk
+                                  type: string
+                                username:
+                                  description: The secret in the service scrape namespace
+                                    that contains the username for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            bearerTokenFile:
+                              description: File to read bearer token for scraping
+                                targets.
+                              type: string
+                            bearerTokenSecret:
+                              description: Secret to mount to read bearer token for
+                                scraping targets. The secret needs to be in the same
+                                namespace as the service scrape and accessible by
+                                the victoria-metrics operator.
+                              nullable: true
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            follow_redirects:
+                              description: FollowRedirects controls redirects for
+                                scraping.
+                              type: boolean
+                            honorLabels:
+                              description: HonorLabels chooses the metric's labels
+                                on collisions with target labels.
+                              type: boolean
+                            honorTimestamps:
+                              description: HonorTimestamps controls whether vmagent
+                                respects the timestamps present in scraped data.
+                              type: boolean
+                            interval:
+                              description: Interval at which metrics should be scraped
+                              type: string
+                            metricRelabelConfigs:
+                              description: MetricRelabelConfigs to apply to samples
+                                before ingestion.
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            oauth2:
+                              description: OAuth2 defines auth configuration
+                              properties:
+                                client_id:
+                                  description: The secret or configmap containing
+                                    the OAuth2 client id
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                client_secret:
+                                  description: The secret containing the OAuth2 client
+                                    secret
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                client_secret_file:
+                                  description: ClientSecretFile defines path for client
+                                    secret file.
+                                  type: string
+                                endpoint_params:
+                                  additionalProperties:
+                                    type: string
+                                  description: Parameters to append to the token URL
+                                  type: object
+                                scopes:
+                                  description: OAuth2 scopes used for the token request
+                                  items:
+                                    type: string
+                                  type: array
+                                token_url:
+                                  description: The URL to fetch the token from
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - client_id
+                              - token_url
+                              type: object
+                            params:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Optional HTTP URL parameters
+                              type: object
+                            path:
+                              description: HTTP path to scrape for metrics.
+                              type: string
+                            port:
+                              description: Name of the service port this endpoint
+                                refers to. Mutually exclusive with targetPort.
+                              type: string
+                            proxyURL:
+                              description: ProxyURL eg http://proxyserver:2195 Directs
+                                scrapes to proxy through this endpoint.
+                              type: string
+                            relabelConfigs:
+                              description: 'RelabelConfigs to apply to samples before
+                                scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            sampleLimit:
+                              description: SampleLimit defines per-endpoint limit
+                                on number of scraped samples that will be accepted.
+                              format: int64
+                              type: integer
+                            scheme:
+                              description: HTTP scheme to use for scraping.
+                              type: string
+                            scrape_interval:
+                              description: ScrapeInterval is the same as Interval
+                                and has priority over it. one of scrape_interval or
+                                interval can be used
+                              type: string
+                            scrapeTimeout:
+                              description: Timeout after which the scrape is ended
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the pod port this endpoint
+                                refers to. Mutually exclusive with port.
+                              x-kubernetes-int-or-string: true
+                            tlsConfig:
+                              description: TLSConfig configuration to use when scraping
+                                the endpoint
+                              properties:
+                                ca:
+                                  description: Stuct containing the CA cert to use
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                caFile:
+                                  description: Path to the CA cert in the container
+                                    to use for the targets.
+                                  type: string
+                                cert:
+                                  description: Struct containing the client cert file
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                certFile:
+                                  description: Path to the client cert file in the
+                                    container for the targets.
+                                  type: string
+                                insecureSkipVerify:
+                                  description: Disable target certificate validation.
+                                  type: boolean
+                                keyFile:
+                                  description: Path to the client key file in the
+                                    container for the targets.
+                                  type: string
+                                keySecret:
+                                  description: Secret containing the client key file
+                                    for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                serverName:
+                                  description: Used to verify the hostname for the
+                                    targets.
+                                  type: string
+                              type: object
+                            vm_scrape_params:
+                              description: VMScrapeParams defines VictoriaMetrics
+                                specific scrape parametrs
+                              properties:
+                                disable_compression:
+                                  type: boolean
+                                disable_keep_alive:
+                                  type: boolean
+                                metric_relabel_debug:
+                                  type: boolean
+                                proxy_client_config:
+                                  description: ProxyClientConfig configures proxy
+                                    auth settings for scraping See feature description
+                                    https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                  properties:
+                                    basic_auth:
+                                      description: 'BasicAuth allow an endpoint to
+                                        authenticate over basic authentication More
+                                        info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                      properties:
+                                        password:
+                                          description: The secret in the service scrape
+                                            namespace that contains the password for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        password_file:
+                                          description: PasswordFile defines path to
+                                            password file at disk
+                                          type: string
+                                        username:
+                                          description: The secret in the service scrape
+                                            namespace that contains the username for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    bearer_token:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    bearer_token_file:
+                                      type: string
+                                    tls_config:
+                                      description: TLSConfig specifies TLSConfig configuration
+                                        parameters.
+                                      properties:
+                                        ca:
+                                          description: Stuct containing the CA cert
+                                            to use for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        caFile:
+                                          description: Path to the CA cert in the
+                                            container to use for the targets.
+                                          type: string
+                                        cert:
+                                          description: Struct containing the client
+                                            cert file for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        certFile:
+                                          description: Path to the client cert file
+                                            in the container for the targets.
+                                          type: string
+                                        insecureSkipVerify:
+                                          description: Disable target certificate
+                                            validation.
+                                          type: boolean
+                                        keyFile:
+                                          description: Path to the client key file
+                                            in the container for the targets.
+                                          type: string
+                                        keySecret:
+                                          description: Secret containing the client
+                                            key file for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        serverName:
+                                          description: Used to verify the hostname
+                                            for the targets.
+                                          type: string
+                                      type: object
+                                  type: object
+                                relabel_debug:
+                                  type: boolean
+                                scrape_align_interval:
+                                  type: string
+                                scrape_offset:
+                                  type: string
+                                stream_parse:
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      jobLabel:
+                        description: The label to use to retrieve the job name from.
+                        type: string
+                      namespaceSelector:
+                        description: Selector to select which namespaces the Endpoints
+                          objects are discovered from.
+                        properties:
+                          any:
+                            description: Boolean describing whether all namespaces
+                              are selected in contrast to a list restricting them.
+                            type: boolean
+                          matchNames:
+                            description: List of namespace names.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      podTargetLabels:
+                        description: PodTargetLabels transfers labels on the Kubernetes
+                          Pod onto the target.
+                        items:
+                          type: string
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-scrape limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      selector:
+                        description: Selector to select Endpoints objects by corresponding
+                          Service labels.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      targetLabels:
+                        description: TargetLabels transfers labels on the Kubernetes
+                          Service onto the target.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - endpoints
+                    type: object
                   serviceSpec:
                     description: ServiceSpec that will be added to vminsert service
                       spec
@@ -853,6 +1701,854 @@ spec:
                       PodSecurityContext.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  serviceScrapeSpec:
+                    description: ServiceScrapeSpec that will be added to vmselect
+                      VMServiceScrape spec
+                    properties:
+                      discoveryRole:
+                        description: 'DiscoveryRole - defines kubernetes_sd role for
+                          objects discovery. by default, its endpoints. can be changed
+                          to service or endpointslices. note, that with service setting,
+                          you have to use port: "name" and cannot use targetPort for
+                          endpoints.'
+                        enum:
+                        - endpoints
+                        - service
+                        - endpointslices
+                        type: string
+                      endpoints:
+                        description: A list of endpoints allowed as part of this ServiceScrape.
+                        items:
+                          description: Endpoint defines a scrapeable endpoint serving
+                            Prometheus metrics.
+                          properties:
+                            basicAuth:
+                              description: 'BasicAuth allow an endpoint to authenticate
+                                over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                              properties:
+                                password:
+                                  description: The secret in the service scrape namespace
+                                    that contains the password for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                password_file:
+                                  description: PasswordFile defines path to password
+                                    file at disk
+                                  type: string
+                                username:
+                                  description: The secret in the service scrape namespace
+                                    that contains the username for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            bearerTokenFile:
+                              description: File to read bearer token for scraping
+                                targets.
+                              type: string
+                            bearerTokenSecret:
+                              description: Secret to mount to read bearer token for
+                                scraping targets. The secret needs to be in the same
+                                namespace as the service scrape and accessible by
+                                the victoria-metrics operator.
+                              nullable: true
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            follow_redirects:
+                              description: FollowRedirects controls redirects for
+                                scraping.
+                              type: boolean
+                            honorLabels:
+                              description: HonorLabels chooses the metric's labels
+                                on collisions with target labels.
+                              type: boolean
+                            honorTimestamps:
+                              description: HonorTimestamps controls whether vmagent
+                                respects the timestamps present in scraped data.
+                              type: boolean
+                            interval:
+                              description: Interval at which metrics should be scraped
+                              type: string
+                            metricRelabelConfigs:
+                              description: MetricRelabelConfigs to apply to samples
+                                before ingestion.
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            oauth2:
+                              description: OAuth2 defines auth configuration
+                              properties:
+                                client_id:
+                                  description: The secret or configmap containing
+                                    the OAuth2 client id
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                client_secret:
+                                  description: The secret containing the OAuth2 client
+                                    secret
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                client_secret_file:
+                                  description: ClientSecretFile defines path for client
+                                    secret file.
+                                  type: string
+                                endpoint_params:
+                                  additionalProperties:
+                                    type: string
+                                  description: Parameters to append to the token URL
+                                  type: object
+                                scopes:
+                                  description: OAuth2 scopes used for the token request
+                                  items:
+                                    type: string
+                                  type: array
+                                token_url:
+                                  description: The URL to fetch the token from
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - client_id
+                              - token_url
+                              type: object
+                            params:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Optional HTTP URL parameters
+                              type: object
+                            path:
+                              description: HTTP path to scrape for metrics.
+                              type: string
+                            port:
+                              description: Name of the service port this endpoint
+                                refers to. Mutually exclusive with targetPort.
+                              type: string
+                            proxyURL:
+                              description: ProxyURL eg http://proxyserver:2195 Directs
+                                scrapes to proxy through this endpoint.
+                              type: string
+                            relabelConfigs:
+                              description: 'RelabelConfigs to apply to samples before
+                                scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            sampleLimit:
+                              description: SampleLimit defines per-endpoint limit
+                                on number of scraped samples that will be accepted.
+                              format: int64
+                              type: integer
+                            scheme:
+                              description: HTTP scheme to use for scraping.
+                              type: string
+                            scrape_interval:
+                              description: ScrapeInterval is the same as Interval
+                                and has priority over it. one of scrape_interval or
+                                interval can be used
+                              type: string
+                            scrapeTimeout:
+                              description: Timeout after which the scrape is ended
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the pod port this endpoint
+                                refers to. Mutually exclusive with port.
+                              x-kubernetes-int-or-string: true
+                            tlsConfig:
+                              description: TLSConfig configuration to use when scraping
+                                the endpoint
+                              properties:
+                                ca:
+                                  description: Stuct containing the CA cert to use
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                caFile:
+                                  description: Path to the CA cert in the container
+                                    to use for the targets.
+                                  type: string
+                                cert:
+                                  description: Struct containing the client cert file
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                certFile:
+                                  description: Path to the client cert file in the
+                                    container for the targets.
+                                  type: string
+                                insecureSkipVerify:
+                                  description: Disable target certificate validation.
+                                  type: boolean
+                                keyFile:
+                                  description: Path to the client key file in the
+                                    container for the targets.
+                                  type: string
+                                keySecret:
+                                  description: Secret containing the client key file
+                                    for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                serverName:
+                                  description: Used to verify the hostname for the
+                                    targets.
+                                  type: string
+                              type: object
+                            vm_scrape_params:
+                              description: VMScrapeParams defines VictoriaMetrics
+                                specific scrape parametrs
+                              properties:
+                                disable_compression:
+                                  type: boolean
+                                disable_keep_alive:
+                                  type: boolean
+                                metric_relabel_debug:
+                                  type: boolean
+                                proxy_client_config:
+                                  description: ProxyClientConfig configures proxy
+                                    auth settings for scraping See feature description
+                                    https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                  properties:
+                                    basic_auth:
+                                      description: 'BasicAuth allow an endpoint to
+                                        authenticate over basic authentication More
+                                        info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                      properties:
+                                        password:
+                                          description: The secret in the service scrape
+                                            namespace that contains the password for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        password_file:
+                                          description: PasswordFile defines path to
+                                            password file at disk
+                                          type: string
+                                        username:
+                                          description: The secret in the service scrape
+                                            namespace that contains the username for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    bearer_token:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    bearer_token_file:
+                                      type: string
+                                    tls_config:
+                                      description: TLSConfig specifies TLSConfig configuration
+                                        parameters.
+                                      properties:
+                                        ca:
+                                          description: Stuct containing the CA cert
+                                            to use for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        caFile:
+                                          description: Path to the CA cert in the
+                                            container to use for the targets.
+                                          type: string
+                                        cert:
+                                          description: Struct containing the client
+                                            cert file for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        certFile:
+                                          description: Path to the client cert file
+                                            in the container for the targets.
+                                          type: string
+                                        insecureSkipVerify:
+                                          description: Disable target certificate
+                                            validation.
+                                          type: boolean
+                                        keyFile:
+                                          description: Path to the client key file
+                                            in the container for the targets.
+                                          type: string
+                                        keySecret:
+                                          description: Secret containing the client
+                                            key file for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        serverName:
+                                          description: Used to verify the hostname
+                                            for the targets.
+                                          type: string
+                                      type: object
+                                  type: object
+                                relabel_debug:
+                                  type: boolean
+                                scrape_align_interval:
+                                  type: string
+                                scrape_offset:
+                                  type: string
+                                stream_parse:
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      jobLabel:
+                        description: The label to use to retrieve the job name from.
+                        type: string
+                      namespaceSelector:
+                        description: Selector to select which namespaces the Endpoints
+                          objects are discovered from.
+                        properties:
+                          any:
+                            description: Boolean describing whether all namespaces
+                              are selected in contrast to a list restricting them.
+                            type: boolean
+                          matchNames:
+                            description: List of namespace names.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      podTargetLabels:
+                        description: PodTargetLabels transfers labels on the Kubernetes
+                          Pod onto the target.
+                        items:
+                          type: string
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-scrape limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      selector:
+                        description: Selector to select Endpoints objects by corresponding
+                          Service labels.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      targetLabels:
+                        description: TargetLabels transfers labels on the Kubernetes
+                          Service onto the target.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - endpoints
+                    type: object
                   serviceSpec:
                     description: ServiceSpec that will be added to vmselect service
                       spec
@@ -1634,6 +3330,854 @@ spec:
                       PodSecurityContext.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  serviceScrapeSpec:
+                    description: ServiceScrapeSpec that will be added to vmselect
+                      VMServiceScrape spec
+                    properties:
+                      discoveryRole:
+                        description: 'DiscoveryRole - defines kubernetes_sd role for
+                          objects discovery. by default, its endpoints. can be changed
+                          to service or endpointslices. note, that with service setting,
+                          you have to use port: "name" and cannot use targetPort for
+                          endpoints.'
+                        enum:
+                        - endpoints
+                        - service
+                        - endpointslices
+                        type: string
+                      endpoints:
+                        description: A list of endpoints allowed as part of this ServiceScrape.
+                        items:
+                          description: Endpoint defines a scrapeable endpoint serving
+                            Prometheus metrics.
+                          properties:
+                            basicAuth:
+                              description: 'BasicAuth allow an endpoint to authenticate
+                                over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                              properties:
+                                password:
+                                  description: The secret in the service scrape namespace
+                                    that contains the password for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                password_file:
+                                  description: PasswordFile defines path to password
+                                    file at disk
+                                  type: string
+                                username:
+                                  description: The secret in the service scrape namespace
+                                    that contains the username for authentication.
+                                    It must be at them same namespace as CRD
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            bearerTokenFile:
+                              description: File to read bearer token for scraping
+                                targets.
+                              type: string
+                            bearerTokenSecret:
+                              description: Secret to mount to read bearer token for
+                                scraping targets. The secret needs to be in the same
+                                namespace as the service scrape and accessible by
+                                the victoria-metrics operator.
+                              nullable: true
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            follow_redirects:
+                              description: FollowRedirects controls redirects for
+                                scraping.
+                              type: boolean
+                            honorLabels:
+                              description: HonorLabels chooses the metric's labels
+                                on collisions with target labels.
+                              type: boolean
+                            honorTimestamps:
+                              description: HonorTimestamps controls whether vmagent
+                                respects the timestamps present in scraped data.
+                              type: boolean
+                            interval:
+                              description: Interval at which metrics should be scraped
+                              type: string
+                            metricRelabelConfigs:
+                              description: MetricRelabelConfigs to apply to samples
+                                before ingestion.
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            oauth2:
+                              description: OAuth2 defines auth configuration
+                              properties:
+                                client_id:
+                                  description: The secret or configmap containing
+                                    the OAuth2 client id
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                client_secret:
+                                  description: The secret containing the OAuth2 client
+                                    secret
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                client_secret_file:
+                                  description: ClientSecretFile defines path for client
+                                    secret file.
+                                  type: string
+                                endpoint_params:
+                                  additionalProperties:
+                                    type: string
+                                  description: Parameters to append to the token URL
+                                  type: object
+                                scopes:
+                                  description: OAuth2 scopes used for the token request
+                                  items:
+                                    type: string
+                                  type: array
+                                token_url:
+                                  description: The URL to fetch the token from
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - client_id
+                              - token_url
+                              type: object
+                            params:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Optional HTTP URL parameters
+                              type: object
+                            path:
+                              description: HTTP path to scrape for metrics.
+                              type: string
+                            port:
+                              description: Name of the service port this endpoint
+                                refers to. Mutually exclusive with targetPort.
+                              type: string
+                            proxyURL:
+                              description: ProxyURL eg http://proxyserver:2195 Directs
+                                scrapes to proxy through this endpoint.
+                              type: string
+                            relabelConfigs:
+                              description: 'RelabelConfigs to apply to samples before
+                                scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                              items:
+                                description: 'RelabelConfig allows dynamic rewriting
+                                  of the label set, being applied to samples before
+                                  ingestion. It defines `<metric_relabel_configs>`-section
+                                  of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                                properties:
+                                  action:
+                                    description: Action to perform based on regex
+                                      matching. Default is 'replace'
+                                    type: string
+                                  modulus:
+                                    description: Modulus to take of the hash of the
+                                      source label values.
+                                    format: int64
+                                    type: integer
+                                  regex:
+                                    description: Regular expression against which
+                                      the extracted value is matched. Default is '(.*)'
+                                    type: string
+                                  replacement:
+                                    description: Replacement value against which a
+                                      regex replace is performed if the regular expression
+                                      matches. Regex capture groups are available.
+                                      Default is '$1'
+                                    type: string
+                                  separator:
+                                    description: Separator placed between concatenated
+                                      source label values. default is ';'.
+                                    type: string
+                                  source_labels:
+                                    description: UnderScoreSourceLabels - additional
+                                      form of source labels source_labels for compatibility
+                                      with original relabel config. if set  both sourceLabels
+                                      and source_labels, sourceLabels has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    items:
+                                      type: string
+                                    type: array
+                                  sourceLabels:
+                                    description: The source labels select values from
+                                      existing labels. Their content is concatenated
+                                      using the configured separator and matched against
+                                      the configured regular expression for the replace,
+                                      keep, and drop actions.
+                                    items:
+                                      type: string
+                                    type: array
+                                  target_label:
+                                    description: UnderScoreTargetLabel - additional
+                                      form of target label - target_label for compatibility
+                                      with original relabel config. if set  both targetLabel
+                                      and target_label, targetLabel has priority.
+                                      for details https://github.com/VictoriaMetrics/operator/issues/131
+                                    type: string
+                                  targetLabel:
+                                    description: Label to which the resulting value
+                                      is written in a replace action. It is mandatory
+                                      for replace actions. Regex capture groups are
+                                      available.
+                                    type: string
+                                type: object
+                              type: array
+                            sampleLimit:
+                              description: SampleLimit defines per-endpoint limit
+                                on number of scraped samples that will be accepted.
+                              format: int64
+                              type: integer
+                            scheme:
+                              description: HTTP scheme to use for scraping.
+                              type: string
+                            scrape_interval:
+                              description: ScrapeInterval is the same as Interval
+                                and has priority over it. one of scrape_interval or
+                                interval can be used
+                              type: string
+                            scrapeTimeout:
+                              description: Timeout after which the scrape is ended
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the pod port this endpoint
+                                refers to. Mutually exclusive with port.
+                              x-kubernetes-int-or-string: true
+                            tlsConfig:
+                              description: TLSConfig configuration to use when scraping
+                                the endpoint
+                              properties:
+                                ca:
+                                  description: Stuct containing the CA cert to use
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                caFile:
+                                  description: Path to the CA cert in the container
+                                    to use for the targets.
+                                  type: string
+                                cert:
+                                  description: Struct containing the client cert file
+                                    for the targets.
+                                  properties:
+                                    configMap:
+                                      description: ConfigMap containing data to use
+                                        for the targets.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    secret:
+                                      description: Secret containing data to use for
+                                        the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                certFile:
+                                  description: Path to the client cert file in the
+                                    container for the targets.
+                                  type: string
+                                insecureSkipVerify:
+                                  description: Disable target certificate validation.
+                                  type: boolean
+                                keyFile:
+                                  description: Path to the client key file in the
+                                    container for the targets.
+                                  type: string
+                                keySecret:
+                                  description: Secret containing the client key file
+                                    for the targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                serverName:
+                                  description: Used to verify the hostname for the
+                                    targets.
+                                  type: string
+                              type: object
+                            vm_scrape_params:
+                              description: VMScrapeParams defines VictoriaMetrics
+                                specific scrape parametrs
+                              properties:
+                                disable_compression:
+                                  type: boolean
+                                disable_keep_alive:
+                                  type: boolean
+                                metric_relabel_debug:
+                                  type: boolean
+                                proxy_client_config:
+                                  description: ProxyClientConfig configures proxy
+                                    auth settings for scraping See feature description
+                                    https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                  properties:
+                                    basic_auth:
+                                      description: 'BasicAuth allow an endpoint to
+                                        authenticate over basic authentication More
+                                        info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                      properties:
+                                        password:
+                                          description: The secret in the service scrape
+                                            namespace that contains the password for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        password_file:
+                                          description: PasswordFile defines path to
+                                            password file at disk
+                                          type: string
+                                        username:
+                                          description: The secret in the service scrape
+                                            namespace that contains the username for
+                                            authentication. It must be at them same
+                                            namespace as CRD
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    bearer_token:
+                                      description: SecretKeySelector selects a key
+                                        of a Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    bearer_token_file:
+                                      type: string
+                                    tls_config:
+                                      description: TLSConfig specifies TLSConfig configuration
+                                        parameters.
+                                      properties:
+                                        ca:
+                                          description: Stuct containing the CA cert
+                                            to use for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        caFile:
+                                          description: Path to the CA cert in the
+                                            container to use for the targets.
+                                          type: string
+                                        cert:
+                                          description: Struct containing the client
+                                            cert file for the targets.
+                                          properties:
+                                            configMap:
+                                              description: ConfigMap containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            secret:
+                                              description: Secret containing data
+                                                to use for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        certFile:
+                                          description: Path to the client cert file
+                                            in the container for the targets.
+                                          type: string
+                                        insecureSkipVerify:
+                                          description: Disable target certificate
+                                            validation.
+                                          type: boolean
+                                        keyFile:
+                                          description: Path to the client key file
+                                            in the container for the targets.
+                                          type: string
+                                        keySecret:
+                                          description: Secret containing the client
+                                            key file for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        serverName:
+                                          description: Used to verify the hostname
+                                            for the targets.
+                                          type: string
+                                      type: object
+                                  type: object
+                                relabel_debug:
+                                  type: boolean
+                                scrape_align_interval:
+                                  type: string
+                                scrape_offset:
+                                  type: string
+                                stream_parse:
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      jobLabel:
+                        description: The label to use to retrieve the job name from.
+                        type: string
+                      namespaceSelector:
+                        description: Selector to select which namespaces the Endpoints
+                          objects are discovered from.
+                        properties:
+                          any:
+                            description: Boolean describing whether all namespaces
+                              are selected in contrast to a list restricting them.
+                            type: boolean
+                          matchNames:
+                            description: List of namespace names.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      podTargetLabels:
+                        description: PodTargetLabels transfers labels on the Kubernetes
+                          Pod onto the target.
+                        items:
+                          type: string
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-scrape limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      selector:
+                        description: Selector to select Endpoints objects by corresponding
+                          Service labels.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      targetLabels:
+                        description: TargetLabels transfers labels on the Kubernetes
+                          Service onto the target.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - endpoints
+                    type: object
                   serviceSpec:
                     description: ServiceSpec that will be create additional service
                       for vmstorage

--- a/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -308,6 +308,832 @@ spec:
                 description: ServiceAccountName is the name of the ServiceAccount
                   to use to run the VMSingle Pods.
                 type: string
+              serviceScrapeSpec:
+                description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                  spec
+                properties:
+                  discoveryRole:
+                    description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                      discovery. by default, its endpoints. can be changed to service
+                      or endpointslices. note, that with service setting, you have
+                      to use port: "name" and cannot use targetPort for endpoints.'
+                    enum:
+                    - endpoints
+                    - service
+                    - endpointslices
+                    type: string
+                  endpoints:
+                    description: A list of endpoints allowed as part of this ServiceScrape.
+                    items:
+                      description: Endpoint defines a scrapeable endpoint serving
+                        Prometheus metrics.
+                      properties:
+                        basicAuth:
+                          description: 'BasicAuth allow an endpoint to authenticate
+                            over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                          properties:
+                            password:
+                              description: The secret in the service scrape namespace
+                                that contains the password for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            password_file:
+                              description: PasswordFile defines path to password file
+                                at disk
+                              type: string
+                            username:
+                              description: The secret in the service scrape namespace
+                                that contains the username for authentication. It
+                                must be at them same namespace as CRD
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                        bearerTokenFile:
+                          description: File to read bearer token for scraping targets.
+                          type: string
+                        bearerTokenSecret:
+                          description: Secret to mount to read bearer token for scraping
+                            targets. The secret needs to be in the same namespace
+                            as the service scrape and accessible by the victoria-metrics
+                            operator.
+                          nullable: true
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        follow_redirects:
+                          description: FollowRedirects controls redirects for scraping.
+                          type: boolean
+                        honorLabels:
+                          description: HonorLabels chooses the metric's labels on
+                            collisions with target labels.
+                          type: boolean
+                        honorTimestamps:
+                          description: HonorTimestamps controls whether vmagent respects
+                            the timestamps present in scraped data.
+                          type: boolean
+                        interval:
+                          description: Interval at which metrics should be scraped
+                          type: string
+                        metricRelabelConfigs:
+                          description: MetricRelabelConfigs to apply to samples before
+                            ingestion.
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        oauth2:
+                          description: OAuth2 defines auth configuration
+                          properties:
+                            client_id:
+                              description: The secret or configmap containing the
+                                OAuth2 client id
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            client_secret:
+                              description: The secret containing the OAuth2 client
+                                secret
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            client_secret_file:
+                              description: ClientSecretFile defines path for client
+                                secret file.
+                              type: string
+                            endpoint_params:
+                              additionalProperties:
+                                type: string
+                              description: Parameters to append to the token URL
+                              type: object
+                            scopes:
+                              description: OAuth2 scopes used for the token request
+                              items:
+                                type: string
+                              type: array
+                            token_url:
+                              description: The URL to fetch the token from
+                              minLength: 1
+                              type: string
+                          required:
+                          - client_id
+                          - token_url
+                          type: object
+                        params:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Optional HTTP URL parameters
+                          type: object
+                        path:
+                          description: HTTP path to scrape for metrics.
+                          type: string
+                        port:
+                          description: Name of the service port this endpoint refers
+                            to. Mutually exclusive with targetPort.
+                          type: string
+                        proxyURL:
+                          description: ProxyURL eg http://proxyserver:2195 Directs
+                            scrapes to proxy through this endpoint.
+                          type: string
+                        relabelConfigs:
+                          description: 'RelabelConfigs to apply to samples before
+                            scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                          items:
+                            description: 'RelabelConfig allows dynamic rewriting of
+                              the label set, being applied to samples before ingestion.
+                              It defines `<metric_relabel_configs>`-section of configuration.
+                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                            properties:
+                              action:
+                                description: Action to perform based on regex matching.
+                                  Default is 'replace'
+                                type: string
+                              modulus:
+                                description: Modulus to take of the hash of the source
+                                  label values.
+                                format: int64
+                                type: integer
+                              regex:
+                                description: Regular expression against which the
+                                  extracted value is matched. Default is '(.*)'
+                                type: string
+                              replacement:
+                                description: Replacement value against which a regex
+                                  replace is performed if the regular expression matches.
+                                  Regex capture groups are available. Default is '$1'
+                                type: string
+                              separator:
+                                description: Separator placed between concatenated
+                                  source label values. default is ';'.
+                                type: string
+                              source_labels:
+                                description: UnderScoreSourceLabels - additional form
+                                  of source labels source_labels for compatibility
+                                  with original relabel config. if set  both sourceLabels
+                                  and source_labels, sourceLabels has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                items:
+                                  type: string
+                                type: array
+                              sourceLabels:
+                                description: The source labels select values from
+                                  existing labels. Their content is concatenated using
+                                  the configured separator and matched against the
+                                  configured regular expression for the replace, keep,
+                                  and drop actions.
+                                items:
+                                  type: string
+                                type: array
+                              target_label:
+                                description: UnderScoreTargetLabel - additional form
+                                  of target label - target_label for compatibility
+                                  with original relabel config. if set  both targetLabel
+                                  and target_label, targetLabel has priority. for
+                                  details https://github.com/VictoriaMetrics/operator/issues/131
+                                type: string
+                              targetLabel:
+                                description: Label to which the resulting value is
+                                  written in a replace action. It is mandatory for
+                                  replace actions. Regex capture groups are available.
+                                type: string
+                            type: object
+                          type: array
+                        sampleLimit:
+                          description: SampleLimit defines per-endpoint limit on number
+                            of scraped samples that will be accepted.
+                          format: int64
+                          type: integer
+                        scheme:
+                          description: HTTP scheme to use for scraping.
+                          type: string
+                        scrape_interval:
+                          description: ScrapeInterval is the same as Interval and
+                            has priority over it. one of scrape_interval or interval
+                            can be used
+                          type: string
+                        scrapeTimeout:
+                          description: Timeout after which the scrape is ended
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Name or number of the pod port this endpoint
+                            refers to. Mutually exclusive with port.
+                          x-kubernetes-int-or-string: true
+                        tlsConfig:
+                          description: TLSConfig configuration to use when scraping
+                            the endpoint
+                          properties:
+                            ca:
+                              description: Stuct containing the CA cert to use for
+                                the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            caFile:
+                              description: Path to the CA cert in the container to
+                                use for the targets.
+                              type: string
+                            cert:
+                              description: Struct containing the client cert file
+                                for the targets.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            certFile:
+                              description: Path to the client cert file in the container
+                                for the targets.
+                              type: string
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keyFile:
+                              description: Path to the client key file in the container
+                                for the targets.
+                              type: string
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        vm_scrape_params:
+                          description: VMScrapeParams defines VictoriaMetrics specific
+                            scrape parametrs
+                          properties:
+                            disable_compression:
+                              type: boolean
+                            disable_keep_alive:
+                              type: boolean
+                            metric_relabel_debug:
+                              type: boolean
+                            proxy_client_config:
+                              description: ProxyClientConfig configures proxy auth
+                                settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                              properties:
+                                basic_auth:
+                                  description: 'BasicAuth allow an endpoint to authenticate
+                                    over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                  properties:
+                                    password:
+                                      description: The secret in the service scrape
+                                        namespace that contains the password for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    password_file:
+                                      description: PasswordFile defines path to password
+                                        file at disk
+                                      type: string
+                                    username:
+                                      description: The secret in the service scrape
+                                        namespace that contains the username for authentication.
+                                        It must be at them same namespace as CRD
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                bearer_token:
+                                  description: SecretKeySelector selects a key of
+                                    a Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                bearer_token_file:
+                                  type: string
+                                tls_config:
+                                  description: TLSConfig specifies TLSConfig configuration
+                                    parameters.
+                                  properties:
+                                    ca:
+                                      description: Stuct containing the CA cert to
+                                        use for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    caFile:
+                                      description: Path to the CA cert in the container
+                                        to use for the targets.
+                                      type: string
+                                    cert:
+                                      description: Struct containing the client cert
+                                        file for the targets.
+                                      properties:
+                                        configMap:
+                                          description: ConfigMap containing data to
+                                            use for the targets.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        secret:
+                                          description: Secret containing data to use
+                                            for the targets.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    certFile:
+                                      description: Path to the client cert file in
+                                        the container for the targets.
+                                      type: string
+                                    insecureSkipVerify:
+                                      description: Disable target certificate validation.
+                                      type: boolean
+                                    keyFile:
+                                      description: Path to the client key file in
+                                        the container for the targets.
+                                      type: string
+                                    keySecret:
+                                      description: Secret containing the client key
+                                        file for the targets.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    serverName:
+                                      description: Used to verify the hostname for
+                                        the targets.
+                                      type: string
+                                  type: object
+                              type: object
+                            relabel_debug:
+                              type: boolean
+                            scrape_align_interval:
+                              type: string
+                            scrape_offset:
+                              type: string
+                            stream_parse:
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
+                  jobLabel:
+                    description: The label to use to retrieve the job name from.
+                    type: string
+                  namespaceSelector:
+                    description: Selector to select which namespaces the Endpoints
+                      objects are discovered from.
+                    properties:
+                      any:
+                        description: Boolean describing whether all namespaces are
+                          selected in contrast to a list restricting them.
+                        type: boolean
+                      matchNames:
+                        description: List of namespace names.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  podTargetLabels:
+                    description: PodTargetLabels transfers labels on the Kubernetes
+                      Pod onto the target.
+                    items:
+                      type: string
+                    type: array
+                  sampleLimit:
+                    description: SampleLimit defines per-scrape limit on number of
+                      scraped samples that will be accepted.
+                    format: int64
+                    type: integer
+                  selector:
+                    description: Selector to select Endpoints objects by corresponding
+                      Service labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  targetLabels:
+                    description: TargetLabels transfers labels on the Kubernetes Service
+                      onto the target.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - endpoints
+                type: object
               serviceSpec:
                 description: ServiceSpec that will be added to vmsingle service spec
                 properties:

--- a/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
@@ -1733,6 +1733,829 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            serviceScrapeSpec:
+              description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                spec
+              properties:
+                discoveryRole:
+                  description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                    discovery. by default, its endpoints. can be changed to service
+                    or endpointslices. note, that with service setting, you have to
+                    use port: "name" and cannot use targetPort for endpoints.'
+                  enum:
+                  - endpoints
+                  - service
+                  - endpointslices
+                  type: string
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceScrape.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate
+                          over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service scrape namespace
+                              that contains the password for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          password_file:
+                            description: PasswordFile defines path to password file
+                              at disk
+                            type: string
+                          username:
+                            description: The secret in the service scrape namespace
+                              that contains the username for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as
+                          the service scrape and accessible by the victoria-metrics
+                          operator.
+                        nullable: true
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      follow_redirects:
+                        description: FollowRedirects controls redirects for scraping.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether vmagent respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelConfigs:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 defines auth configuration
+                        properties:
+                          client_id:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          client_secret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          client_secret_file:
+                            description: ClientSecretFile defines path for client
+                              secret file.
+                            type: string
+                          endpoint_params:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          token_url:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                        - client_id
+                        - token_url
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers
+                          to. Mutually exclusive with targetPort.
+                        type: string
+                      proxyURL:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelConfigs:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-endpoint limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrape_interval:
+                        description: ScrapeInterval is the same as Interval and has
+                          priority over it. one of scrape_interval or interval can
+                          be used
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the pod port this endpoint
+                          refers to. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLSConfig configuration to use when scraping
+                          the endpoint
+                        properties:
+                          ca:
+                            description: Stuct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the container to use
+                              for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the container
+                              for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the container
+                              for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for
+                              the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                      vm_scrape_params:
+                        description: VMScrapeParams defines VictoriaMetrics specific
+                          scrape parametrs
+                        properties:
+                          disable_compression:
+                            type: boolean
+                          disable_keep_alive:
+                            type: boolean
+                          metric_relabel_debug:
+                            type: boolean
+                          proxy_client_config:
+                            description: ProxyClientConfig configures proxy auth settings
+                              for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                            properties:
+                              basic_auth:
+                                description: 'BasicAuth allow an endpoint to authenticate
+                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearer_token:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              bearer_token_file:
+                                type: string
+                              tls_config:
+                                description: TLSConfig specifies TLSConfig configuration
+                                  parameters.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          relabel_debug:
+                            type: boolean
+                          scrape_align_interval:
+                            type: string
+                          scrape_offset:
+                            type: string
+                          stream_parse:
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: The label to use to retrieve the job name from.
+                  type: string
+                namespaceSelector:
+                  description: Selector to select which namespaces the Endpoints objects
+                    are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes
+                    Pod onto the target.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects by corresponding
+                    Service labels.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels on the Kubernetes Service
+                    onto the target.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - endpoints
+              type: object
             serviceSpec:
               description: ServiceSpec that will be added to vmagent service spec
               properties:

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -456,6 +456,829 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use
               type: string
+            serviceScrapeSpec:
+              description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                spec
+              properties:
+                discoveryRole:
+                  description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                    discovery. by default, its endpoints. can be changed to service
+                    or endpointslices. note, that with service setting, you have to
+                    use port: "name" and cannot use targetPort for endpoints.'
+                  enum:
+                  - endpoints
+                  - service
+                  - endpointslices
+                  type: string
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceScrape.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate
+                          over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service scrape namespace
+                              that contains the password for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          password_file:
+                            description: PasswordFile defines path to password file
+                              at disk
+                            type: string
+                          username:
+                            description: The secret in the service scrape namespace
+                              that contains the username for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as
+                          the service scrape and accessible by the victoria-metrics
+                          operator.
+                        nullable: true
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      follow_redirects:
+                        description: FollowRedirects controls redirects for scraping.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether vmagent respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelConfigs:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 defines auth configuration
+                        properties:
+                          client_id:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          client_secret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          client_secret_file:
+                            description: ClientSecretFile defines path for client
+                              secret file.
+                            type: string
+                          endpoint_params:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          token_url:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                        - client_id
+                        - token_url
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers
+                          to. Mutually exclusive with targetPort.
+                        type: string
+                      proxyURL:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelConfigs:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-endpoint limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrape_interval:
+                        description: ScrapeInterval is the same as Interval and has
+                          priority over it. one of scrape_interval or interval can
+                          be used
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the pod port this endpoint
+                          refers to. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLSConfig configuration to use when scraping
+                          the endpoint
+                        properties:
+                          ca:
+                            description: Stuct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the container to use
+                              for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the container
+                              for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the container
+                              for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for
+                              the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                      vm_scrape_params:
+                        description: VMScrapeParams defines VictoriaMetrics specific
+                          scrape parametrs
+                        properties:
+                          disable_compression:
+                            type: boolean
+                          disable_keep_alive:
+                            type: boolean
+                          metric_relabel_debug:
+                            type: boolean
+                          proxy_client_config:
+                            description: ProxyClientConfig configures proxy auth settings
+                              for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                            properties:
+                              basic_auth:
+                                description: 'BasicAuth allow an endpoint to authenticate
+                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearer_token:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              bearer_token_file:
+                                type: string
+                              tls_config:
+                                description: TLSConfig specifies TLSConfig configuration
+                                  parameters.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          relabel_debug:
+                            type: boolean
+                          scrape_align_interval:
+                            type: string
+                          scrape_offset:
+                            type: string
+                          stream_parse:
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: The label to use to retrieve the job name from.
+                  type: string
+                namespaceSelector:
+                  description: Selector to select which namespaces the Endpoints objects
+                    are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes
+                    Pod onto the target.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects by corresponding
+                    Service labels.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels on the Kubernetes Service
+                    onto the target.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - endpoints
+              type: object
             serviceSpec:
               description: ServiceSpec that will be added to vmalertmanager service
                 spec

--- a/config/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
@@ -1513,6 +1513,829 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAlert Pods.
               type: string
+            serviceScrapeSpec:
+              description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                spec
+              properties:
+                discoveryRole:
+                  description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                    discovery. by default, its endpoints. can be changed to service
+                    or endpointslices. note, that with service setting, you have to
+                    use port: "name" and cannot use targetPort for endpoints.'
+                  enum:
+                  - endpoints
+                  - service
+                  - endpointslices
+                  type: string
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceScrape.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate
+                          over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service scrape namespace
+                              that contains the password for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          password_file:
+                            description: PasswordFile defines path to password file
+                              at disk
+                            type: string
+                          username:
+                            description: The secret in the service scrape namespace
+                              that contains the username for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as
+                          the service scrape and accessible by the victoria-metrics
+                          operator.
+                        nullable: true
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      follow_redirects:
+                        description: FollowRedirects controls redirects for scraping.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether vmagent respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelConfigs:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 defines auth configuration
+                        properties:
+                          client_id:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          client_secret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          client_secret_file:
+                            description: ClientSecretFile defines path for client
+                              secret file.
+                            type: string
+                          endpoint_params:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          token_url:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                        - client_id
+                        - token_url
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers
+                          to. Mutually exclusive with targetPort.
+                        type: string
+                      proxyURL:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelConfigs:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-endpoint limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrape_interval:
+                        description: ScrapeInterval is the same as Interval and has
+                          priority over it. one of scrape_interval or interval can
+                          be used
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the pod port this endpoint
+                          refers to. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLSConfig configuration to use when scraping
+                          the endpoint
+                        properties:
+                          ca:
+                            description: Stuct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the container to use
+                              for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the container
+                              for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the container
+                              for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for
+                              the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                      vm_scrape_params:
+                        description: VMScrapeParams defines VictoriaMetrics specific
+                          scrape parametrs
+                        properties:
+                          disable_compression:
+                            type: boolean
+                          disable_keep_alive:
+                            type: boolean
+                          metric_relabel_debug:
+                            type: boolean
+                          proxy_client_config:
+                            description: ProxyClientConfig configures proxy auth settings
+                              for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                            properties:
+                              basic_auth:
+                                description: 'BasicAuth allow an endpoint to authenticate
+                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearer_token:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              bearer_token_file:
+                                type: string
+                              tls_config:
+                                description: TLSConfig specifies TLSConfig configuration
+                                  parameters.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          relabel_debug:
+                            type: boolean
+                          scrape_align_interval:
+                            type: string
+                          scrape_offset:
+                            type: string
+                          stream_parse:
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: The label to use to retrieve the job name from.
+                  type: string
+                namespaceSelector:
+                  description: Selector to select which namespaces the Endpoints objects
+                    are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes
+                    Pod onto the target.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects by corresponding
+                    Service labels.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels on the Kubernetes Service
+                    onto the target.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - endpoints
+              type: object
             serviceSpec:
               description: ServiceSpec that will be added to vmalert service spec
               properties:

--- a/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
@@ -527,6 +527,829 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMAuth Pods.
               type: string
+            serviceScrapeSpec:
+              description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                spec
+              properties:
+                discoveryRole:
+                  description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                    discovery. by default, its endpoints. can be changed to service
+                    or endpointslices. note, that with service setting, you have to
+                    use port: "name" and cannot use targetPort for endpoints.'
+                  enum:
+                  - endpoints
+                  - service
+                  - endpointslices
+                  type: string
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceScrape.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate
+                          over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service scrape namespace
+                              that contains the password for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          password_file:
+                            description: PasswordFile defines path to password file
+                              at disk
+                            type: string
+                          username:
+                            description: The secret in the service scrape namespace
+                              that contains the username for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as
+                          the service scrape and accessible by the victoria-metrics
+                          operator.
+                        nullable: true
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      follow_redirects:
+                        description: FollowRedirects controls redirects for scraping.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether vmagent respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelConfigs:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 defines auth configuration
+                        properties:
+                          client_id:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          client_secret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          client_secret_file:
+                            description: ClientSecretFile defines path for client
+                              secret file.
+                            type: string
+                          endpoint_params:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          token_url:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                        - client_id
+                        - token_url
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers
+                          to. Mutually exclusive with targetPort.
+                        type: string
+                      proxyURL:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelConfigs:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-endpoint limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrape_interval:
+                        description: ScrapeInterval is the same as Interval and has
+                          priority over it. one of scrape_interval or interval can
+                          be used
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the pod port this endpoint
+                          refers to. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLSConfig configuration to use when scraping
+                          the endpoint
+                        properties:
+                          ca:
+                            description: Stuct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the container to use
+                              for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the container
+                              for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the container
+                              for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for
+                              the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                      vm_scrape_params:
+                        description: VMScrapeParams defines VictoriaMetrics specific
+                          scrape parametrs
+                        properties:
+                          disable_compression:
+                            type: boolean
+                          disable_keep_alive:
+                            type: boolean
+                          metric_relabel_debug:
+                            type: boolean
+                          proxy_client_config:
+                            description: ProxyClientConfig configures proxy auth settings
+                              for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                            properties:
+                              basic_auth:
+                                description: 'BasicAuth allow an endpoint to authenticate
+                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearer_token:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              bearer_token_file:
+                                type: string
+                              tls_config:
+                                description: TLSConfig specifies TLSConfig configuration
+                                  parameters.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          relabel_debug:
+                            type: boolean
+                          scrape_align_interval:
+                            type: string
+                          scrape_offset:
+                            type: string
+                          stream_parse:
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: The label to use to retrieve the job name from.
+                  type: string
+                namespaceSelector:
+                  description: Selector to select which namespaces the Endpoints objects
+                    are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes
+                    Pod onto the target.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects by corresponding
+                    Service labels.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels on the Kubernetes Service
+                    onto the target.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - endpoints
+              type: object
             serviceSpec:
               description: ServiceSpec that will be added to vmsingle service spec
               properties:

--- a/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
@@ -385,6 +385,847 @@ spec:
                     and common container settings. This defaults to the default PodSecurityContext.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                serviceScrapeSpec:
+                  description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                    spec
+                  properties:
+                    discoveryRole:
+                      description: 'DiscoveryRole - defines kubernetes_sd role for
+                        objects discovery. by default, its endpoints. can be changed
+                        to service or endpointslices. note, that with service setting,
+                        you have to use port: "name" and cannot use targetPort for
+                        endpoints.'
+                      enum:
+                      - endpoints
+                      - service
+                      - endpointslices
+                      type: string
+                    endpoints:
+                      description: A list of endpoints allowed as part of this ServiceScrape.
+                      items:
+                        description: Endpoint defines a scrapeable endpoint serving
+                          Prometheus metrics.
+                        properties:
+                          basicAuth:
+                            description: 'BasicAuth allow an endpoint to authenticate
+                              over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                            properties:
+                              password:
+                                description: The secret in the service scrape namespace
+                                  that contains the password for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              password_file:
+                                description: PasswordFile defines path to password
+                                  file at disk
+                                type: string
+                              username:
+                                description: The secret in the service scrape namespace
+                                  that contains the username for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          bearerTokenFile:
+                            description: File to read bearer token for scraping targets.
+                            type: string
+                          bearerTokenSecret:
+                            description: Secret to mount to read bearer token for
+                              scraping targets. The secret needs to be in the same
+                              namespace as the service scrape and accessible by the
+                              victoria-metrics operator.
+                            nullable: true
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          follow_redirects:
+                            description: FollowRedirects controls redirects for scraping.
+                            type: boolean
+                          honorLabels:
+                            description: HonorLabels chooses the metric's labels on
+                              collisions with target labels.
+                            type: boolean
+                          honorTimestamps:
+                            description: HonorTimestamps controls whether vmagent
+                              respects the timestamps present in scraped data.
+                            type: boolean
+                          interval:
+                            description: Interval at which metrics should be scraped
+                            type: string
+                          metricRelabelConfigs:
+                            description: MetricRelabelConfigs to apply to samples
+                              before ingestion.
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          oauth2:
+                            description: OAuth2 defines auth configuration
+                            properties:
+                              client_id:
+                                description: The secret or configmap containing the
+                                  OAuth2 client id
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              client_secret:
+                                description: The secret containing the OAuth2 client
+                                  secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              client_secret_file:
+                                description: ClientSecretFile defines path for client
+                                  secret file.
+                                type: string
+                              endpoint_params:
+                                additionalProperties:
+                                  type: string
+                                description: Parameters to append to the token URL
+                                type: object
+                              scopes:
+                                description: OAuth2 scopes used for the token request
+                                items:
+                                  type: string
+                                type: array
+                              token_url:
+                                description: The URL to fetch the token from
+                                minLength: 1
+                                type: string
+                            required:
+                            - client_id
+                            - token_url
+                            type: object
+                          params:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Optional HTTP URL parameters
+                            type: object
+                          path:
+                            description: HTTP path to scrape for metrics.
+                            type: string
+                          port:
+                            description: Name of the service port this endpoint refers
+                              to. Mutually exclusive with targetPort.
+                            type: string
+                          proxyURL:
+                            description: ProxyURL eg http://proxyserver:2195 Directs
+                              scrapes to proxy through this endpoint.
+                            type: string
+                          relabelConfigs:
+                            description: 'RelabelConfigs to apply to samples before
+                              scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          sampleLimit:
+                            description: SampleLimit defines per-endpoint limit on
+                              number of scraped samples that will be accepted.
+                            format: int64
+                            type: integer
+                          scheme:
+                            description: HTTP scheme to use for scraping.
+                            type: string
+                          scrape_interval:
+                            description: ScrapeInterval is the same as Interval and
+                              has priority over it. one of scrape_interval or interval
+                              can be used
+                            type: string
+                          scrapeTimeout:
+                            description: Timeout after which the scrape is ended
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the pod port this endpoint
+                              refers to. Mutually exclusive with port.
+                            x-kubernetes-int-or-string: true
+                          tlsConfig:
+                            description: TLSConfig configuration to use when scraping
+                              the endpoint
+                            properties:
+                              ca:
+                                description: Stuct containing the CA cert to use for
+                                  the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              caFile:
+                                description: Path to the CA cert in the container
+                                  to use for the targets.
+                                type: string
+                              cert:
+                                description: Struct containing the client cert file
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              certFile:
+                                description: Path to the client cert file in the container
+                                  for the targets.
+                                type: string
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keyFile:
+                                description: Path to the client key file in the container
+                                  for the targets.
+                                type: string
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                          vm_scrape_params:
+                            description: VMScrapeParams defines VictoriaMetrics specific
+                              scrape parametrs
+                            properties:
+                              disable_compression:
+                                type: boolean
+                              disable_keep_alive:
+                                type: boolean
+                              metric_relabel_debug:
+                                type: boolean
+                              proxy_client_config:
+                                description: ProxyClientConfig configures proxy auth
+                                  settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                properties:
+                                  basic_auth:
+                                    description: 'BasicAuth allow an endpoint to authenticate
+                                      over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                    properties:
+                                      password:
+                                        description: The secret in the service scrape
+                                          namespace that contains the password for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      password_file:
+                                        description: PasswordFile defines path to
+                                          password file at disk
+                                        type: string
+                                      username:
+                                        description: The secret in the service scrape
+                                          namespace that contains the username for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  bearer_token:
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  bearer_token_file:
+                                    type: string
+                                  tls_config:
+                                    description: TLSConfig specifies TLSConfig configuration
+                                      parameters.
+                                    properties:
+                                      ca:
+                                        description: Stuct containing the CA cert
+                                          to use for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      caFile:
+                                        description: Path to the CA cert in the container
+                                          to use for the targets.
+                                        type: string
+                                      cert:
+                                        description: Struct containing the client
+                                          cert file for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      certFile:
+                                        description: Path to the client cert file
+                                          in the container for the targets.
+                                        type: string
+                                      insecureSkipVerify:
+                                        description: Disable target certificate validation.
+                                        type: boolean
+                                      keyFile:
+                                        description: Path to the client key file in
+                                          the container for the targets.
+                                        type: string
+                                      keySecret:
+                                        description: Secret containing the client
+                                          key file for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      serverName:
+                                        description: Used to verify the hostname for
+                                          the targets.
+                                        type: string
+                                    type: object
+                                type: object
+                              relabel_debug:
+                                type: boolean
+                              scrape_align_interval:
+                                type: string
+                              scrape_offset:
+                                type: string
+                              stream_parse:
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    jobLabel:
+                      description: The label to use to retrieve the job name from.
+                      type: string
+                    namespaceSelector:
+                      description: Selector to select which namespaces the Endpoints
+                        objects are discovered from.
+                      properties:
+                        any:
+                          description: Boolean describing whether all namespaces are
+                            selected in contrast to a list restricting them.
+                          type: boolean
+                        matchNames:
+                          description: List of namespace names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    podTargetLabels:
+                      description: PodTargetLabels transfers labels on the Kubernetes
+                        Pod onto the target.
+                      items:
+                        type: string
+                      type: array
+                    sampleLimit:
+                      description: SampleLimit defines per-scrape limit on number
+                        of scraped samples that will be accepted.
+                      format: int64
+                      type: integer
+                    selector:
+                      description: Selector to select Endpoints objects by corresponding
+                        Service labels.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    targetLabels:
+                      description: TargetLabels transfers labels on the Kubernetes
+                        Service onto the target.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - endpoints
+                  type: object
                 serviceSpec:
                   description: ServiceSpec that will be added to vminsert service
                     spec
@@ -840,6 +1681,847 @@ spec:
                     and common container settings. This defaults to the default PodSecurityContext.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                serviceScrapeSpec:
+                  description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                    spec
+                  properties:
+                    discoveryRole:
+                      description: 'DiscoveryRole - defines kubernetes_sd role for
+                        objects discovery. by default, its endpoints. can be changed
+                        to service or endpointslices. note, that with service setting,
+                        you have to use port: "name" and cannot use targetPort for
+                        endpoints.'
+                      enum:
+                      - endpoints
+                      - service
+                      - endpointslices
+                      type: string
+                    endpoints:
+                      description: A list of endpoints allowed as part of this ServiceScrape.
+                      items:
+                        description: Endpoint defines a scrapeable endpoint serving
+                          Prometheus metrics.
+                        properties:
+                          basicAuth:
+                            description: 'BasicAuth allow an endpoint to authenticate
+                              over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                            properties:
+                              password:
+                                description: The secret in the service scrape namespace
+                                  that contains the password for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              password_file:
+                                description: PasswordFile defines path to password
+                                  file at disk
+                                type: string
+                              username:
+                                description: The secret in the service scrape namespace
+                                  that contains the username for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          bearerTokenFile:
+                            description: File to read bearer token for scraping targets.
+                            type: string
+                          bearerTokenSecret:
+                            description: Secret to mount to read bearer token for
+                              scraping targets. The secret needs to be in the same
+                              namespace as the service scrape and accessible by the
+                              victoria-metrics operator.
+                            nullable: true
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          follow_redirects:
+                            description: FollowRedirects controls redirects for scraping.
+                            type: boolean
+                          honorLabels:
+                            description: HonorLabels chooses the metric's labels on
+                              collisions with target labels.
+                            type: boolean
+                          honorTimestamps:
+                            description: HonorTimestamps controls whether vmagent
+                              respects the timestamps present in scraped data.
+                            type: boolean
+                          interval:
+                            description: Interval at which metrics should be scraped
+                            type: string
+                          metricRelabelConfigs:
+                            description: MetricRelabelConfigs to apply to samples
+                              before ingestion.
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          oauth2:
+                            description: OAuth2 defines auth configuration
+                            properties:
+                              client_id:
+                                description: The secret or configmap containing the
+                                  OAuth2 client id
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              client_secret:
+                                description: The secret containing the OAuth2 client
+                                  secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              client_secret_file:
+                                description: ClientSecretFile defines path for client
+                                  secret file.
+                                type: string
+                              endpoint_params:
+                                additionalProperties:
+                                  type: string
+                                description: Parameters to append to the token URL
+                                type: object
+                              scopes:
+                                description: OAuth2 scopes used for the token request
+                                items:
+                                  type: string
+                                type: array
+                              token_url:
+                                description: The URL to fetch the token from
+                                minLength: 1
+                                type: string
+                            required:
+                            - client_id
+                            - token_url
+                            type: object
+                          params:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Optional HTTP URL parameters
+                            type: object
+                          path:
+                            description: HTTP path to scrape for metrics.
+                            type: string
+                          port:
+                            description: Name of the service port this endpoint refers
+                              to. Mutually exclusive with targetPort.
+                            type: string
+                          proxyURL:
+                            description: ProxyURL eg http://proxyserver:2195 Directs
+                              scrapes to proxy through this endpoint.
+                            type: string
+                          relabelConfigs:
+                            description: 'RelabelConfigs to apply to samples before
+                              scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          sampleLimit:
+                            description: SampleLimit defines per-endpoint limit on
+                              number of scraped samples that will be accepted.
+                            format: int64
+                            type: integer
+                          scheme:
+                            description: HTTP scheme to use for scraping.
+                            type: string
+                          scrape_interval:
+                            description: ScrapeInterval is the same as Interval and
+                              has priority over it. one of scrape_interval or interval
+                              can be used
+                            type: string
+                          scrapeTimeout:
+                            description: Timeout after which the scrape is ended
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the pod port this endpoint
+                              refers to. Mutually exclusive with port.
+                            x-kubernetes-int-or-string: true
+                          tlsConfig:
+                            description: TLSConfig configuration to use when scraping
+                              the endpoint
+                            properties:
+                              ca:
+                                description: Stuct containing the CA cert to use for
+                                  the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              caFile:
+                                description: Path to the CA cert in the container
+                                  to use for the targets.
+                                type: string
+                              cert:
+                                description: Struct containing the client cert file
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              certFile:
+                                description: Path to the client cert file in the container
+                                  for the targets.
+                                type: string
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keyFile:
+                                description: Path to the client key file in the container
+                                  for the targets.
+                                type: string
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                          vm_scrape_params:
+                            description: VMScrapeParams defines VictoriaMetrics specific
+                              scrape parametrs
+                            properties:
+                              disable_compression:
+                                type: boolean
+                              disable_keep_alive:
+                                type: boolean
+                              metric_relabel_debug:
+                                type: boolean
+                              proxy_client_config:
+                                description: ProxyClientConfig configures proxy auth
+                                  settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                properties:
+                                  basic_auth:
+                                    description: 'BasicAuth allow an endpoint to authenticate
+                                      over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                    properties:
+                                      password:
+                                        description: The secret in the service scrape
+                                          namespace that contains the password for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      password_file:
+                                        description: PasswordFile defines path to
+                                          password file at disk
+                                        type: string
+                                      username:
+                                        description: The secret in the service scrape
+                                          namespace that contains the username for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  bearer_token:
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  bearer_token_file:
+                                    type: string
+                                  tls_config:
+                                    description: TLSConfig specifies TLSConfig configuration
+                                      parameters.
+                                    properties:
+                                      ca:
+                                        description: Stuct containing the CA cert
+                                          to use for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      caFile:
+                                        description: Path to the CA cert in the container
+                                          to use for the targets.
+                                        type: string
+                                      cert:
+                                        description: Struct containing the client
+                                          cert file for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      certFile:
+                                        description: Path to the client cert file
+                                          in the container for the targets.
+                                        type: string
+                                      insecureSkipVerify:
+                                        description: Disable target certificate validation.
+                                        type: boolean
+                                      keyFile:
+                                        description: Path to the client key file in
+                                          the container for the targets.
+                                        type: string
+                                      keySecret:
+                                        description: Secret containing the client
+                                          key file for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      serverName:
+                                        description: Used to verify the hostname for
+                                          the targets.
+                                        type: string
+                                    type: object
+                                type: object
+                              relabel_debug:
+                                type: boolean
+                              scrape_align_interval:
+                                type: string
+                              scrape_offset:
+                                type: string
+                              stream_parse:
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    jobLabel:
+                      description: The label to use to retrieve the job name from.
+                      type: string
+                    namespaceSelector:
+                      description: Selector to select which namespaces the Endpoints
+                        objects are discovered from.
+                      properties:
+                        any:
+                          description: Boolean describing whether all namespaces are
+                            selected in contrast to a list restricting them.
+                          type: boolean
+                        matchNames:
+                          description: List of namespace names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    podTargetLabels:
+                      description: PodTargetLabels transfers labels on the Kubernetes
+                        Pod onto the target.
+                      items:
+                        type: string
+                      type: array
+                    sampleLimit:
+                      description: SampleLimit defines per-scrape limit on number
+                        of scraped samples that will be accepted.
+                      format: int64
+                      type: integer
+                    selector:
+                      description: Selector to select Endpoints objects by corresponding
+                        Service labels.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    targetLabels:
+                      description: TargetLabels transfers labels on the Kubernetes
+                        Service onto the target.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - endpoints
+                  type: object
                 serviceSpec:
                   description: ServiceSpec that will be added to vmselect service
                     spec
@@ -1608,6 +3290,847 @@ spec:
                     and common container settings. This defaults to the default PodSecurityContext.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                serviceScrapeSpec:
+                  description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                    spec
+                  properties:
+                    discoveryRole:
+                      description: 'DiscoveryRole - defines kubernetes_sd role for
+                        objects discovery. by default, its endpoints. can be changed
+                        to service or endpointslices. note, that with service setting,
+                        you have to use port: "name" and cannot use targetPort for
+                        endpoints.'
+                      enum:
+                      - endpoints
+                      - service
+                      - endpointslices
+                      type: string
+                    endpoints:
+                      description: A list of endpoints allowed as part of this ServiceScrape.
+                      items:
+                        description: Endpoint defines a scrapeable endpoint serving
+                          Prometheus metrics.
+                        properties:
+                          basicAuth:
+                            description: 'BasicAuth allow an endpoint to authenticate
+                              over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                            properties:
+                              password:
+                                description: The secret in the service scrape namespace
+                                  that contains the password for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              password_file:
+                                description: PasswordFile defines path to password
+                                  file at disk
+                                type: string
+                              username:
+                                description: The secret in the service scrape namespace
+                                  that contains the username for authentication. It
+                                  must be at them same namespace as CRD
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          bearerTokenFile:
+                            description: File to read bearer token for scraping targets.
+                            type: string
+                          bearerTokenSecret:
+                            description: Secret to mount to read bearer token for
+                              scraping targets. The secret needs to be in the same
+                              namespace as the service scrape and accessible by the
+                              victoria-metrics operator.
+                            nullable: true
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          follow_redirects:
+                            description: FollowRedirects controls redirects for scraping.
+                            type: boolean
+                          honorLabels:
+                            description: HonorLabels chooses the metric's labels on
+                              collisions with target labels.
+                            type: boolean
+                          honorTimestamps:
+                            description: HonorTimestamps controls whether vmagent
+                              respects the timestamps present in scraped data.
+                            type: boolean
+                          interval:
+                            description: Interval at which metrics should be scraped
+                            type: string
+                          metricRelabelConfigs:
+                            description: MetricRelabelConfigs to apply to samples
+                              before ingestion.
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          oauth2:
+                            description: OAuth2 defines auth configuration
+                            properties:
+                              client_id:
+                                description: The secret or configmap containing the
+                                  OAuth2 client id
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              client_secret:
+                                description: The secret containing the OAuth2 client
+                                  secret
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              client_secret_file:
+                                description: ClientSecretFile defines path for client
+                                  secret file.
+                                type: string
+                              endpoint_params:
+                                additionalProperties:
+                                  type: string
+                                description: Parameters to append to the token URL
+                                type: object
+                              scopes:
+                                description: OAuth2 scopes used for the token request
+                                items:
+                                  type: string
+                                type: array
+                              token_url:
+                                description: The URL to fetch the token from
+                                minLength: 1
+                                type: string
+                            required:
+                            - client_id
+                            - token_url
+                            type: object
+                          params:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Optional HTTP URL parameters
+                            type: object
+                          path:
+                            description: HTTP path to scrape for metrics.
+                            type: string
+                          port:
+                            description: Name of the service port this endpoint refers
+                              to. Mutually exclusive with targetPort.
+                            type: string
+                          proxyURL:
+                            description: ProxyURL eg http://proxyserver:2195 Directs
+                              scrapes to proxy through this endpoint.
+                            type: string
+                          relabelConfigs:
+                            description: 'RelabelConfigs to apply to samples before
+                              scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                            items:
+                              description: 'RelabelConfig allows dynamic rewriting
+                                of the label set, being applied to samples before
+                                ingestion. It defines `<metric_relabel_configs>`-section
+                                of configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                              properties:
+                                action:
+                                  description: Action to perform based on regex matching.
+                                    Default is 'replace'
+                                  type: string
+                                modulus:
+                                  description: Modulus to take of the hash of the
+                                    source label values.
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  description: Regular expression against which the
+                                    extracted value is matched. Default is '(.*)'
+                                  type: string
+                                replacement:
+                                  description: Replacement value against which a regex
+                                    replace is performed if the regular expression
+                                    matches. Regex capture groups are available. Default
+                                    is '$1'
+                                  type: string
+                                separator:
+                                  description: Separator placed between concatenated
+                                    source label values. default is ';'.
+                                  type: string
+                                source_labels:
+                                  description: UnderScoreSourceLabels - additional
+                                    form of source labels source_labels for compatibility
+                                    with original relabel config. if set  both sourceLabels
+                                    and source_labels, sourceLabels has priority.
+                                    for details https://github.com/VictoriaMetrics/operator/issues/131
+                                  items:
+                                    type: string
+                                  type: array
+                                sourceLabels:
+                                  description: The source labels select values from
+                                    existing labels. Their content is concatenated
+                                    using the configured separator and matched against
+                                    the configured regular expression for the replace,
+                                    keep, and drop actions.
+                                  items:
+                                    type: string
+                                  type: array
+                                target_label:
+                                  description: UnderScoreTargetLabel - additional
+                                    form of target label - target_label for compatibility
+                                    with original relabel config. if set  both targetLabel
+                                    and target_label, targetLabel has priority. for
+                                    details https://github.com/VictoriaMetrics/operator/issues/131
+                                  type: string
+                                targetLabel:
+                                  description: Label to which the resulting value
+                                    is written in a replace action. It is mandatory
+                                    for replace actions. Regex capture groups are
+                                    available.
+                                  type: string
+                              type: object
+                            type: array
+                          sampleLimit:
+                            description: SampleLimit defines per-endpoint limit on
+                              number of scraped samples that will be accepted.
+                            format: int64
+                            type: integer
+                          scheme:
+                            description: HTTP scheme to use for scraping.
+                            type: string
+                          scrape_interval:
+                            description: ScrapeInterval is the same as Interval and
+                              has priority over it. one of scrape_interval or interval
+                              can be used
+                            type: string
+                          scrapeTimeout:
+                            description: Timeout after which the scrape is ended
+                            type: string
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the pod port this endpoint
+                              refers to. Mutually exclusive with port.
+                            x-kubernetes-int-or-string: true
+                          tlsConfig:
+                            description: TLSConfig configuration to use when scraping
+                              the endpoint
+                            properties:
+                              ca:
+                                description: Stuct containing the CA cert to use for
+                                  the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              caFile:
+                                description: Path to the CA cert in the container
+                                  to use for the targets.
+                                type: string
+                              cert:
+                                description: Struct containing the client cert file
+                                  for the targets.
+                                properties:
+                                  configMap:
+                                    description: ConfigMap containing data to use
+                                      for the targets.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    description: Secret containing data to use for
+                                      the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              certFile:
+                                description: Path to the client cert file in the container
+                                  for the targets.
+                                type: string
+                              insecureSkipVerify:
+                                description: Disable target certificate validation.
+                                type: boolean
+                              keyFile:
+                                description: Path to the client key file in the container
+                                  for the targets.
+                                type: string
+                              keySecret:
+                                description: Secret containing the client key file
+                                  for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                description: Used to verify the hostname for the targets.
+                                type: string
+                            type: object
+                          vm_scrape_params:
+                            description: VMScrapeParams defines VictoriaMetrics specific
+                              scrape parametrs
+                            properties:
+                              disable_compression:
+                                type: boolean
+                              disable_keep_alive:
+                                type: boolean
+                              metric_relabel_debug:
+                                type: boolean
+                              proxy_client_config:
+                                description: ProxyClientConfig configures proxy auth
+                                  settings for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                                properties:
+                                  basic_auth:
+                                    description: 'BasicAuth allow an endpoint to authenticate
+                                      over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                    properties:
+                                      password:
+                                        description: The secret in the service scrape
+                                          namespace that contains the password for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      password_file:
+                                        description: PasswordFile defines path to
+                                          password file at disk
+                                        type: string
+                                      username:
+                                        description: The secret in the service scrape
+                                          namespace that contains the username for
+                                          authentication. It must be at them same
+                                          namespace as CRD
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  bearer_token:
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  bearer_token_file:
+                                    type: string
+                                  tls_config:
+                                    description: TLSConfig specifies TLSConfig configuration
+                                      parameters.
+                                    properties:
+                                      ca:
+                                        description: Stuct containing the CA cert
+                                          to use for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      caFile:
+                                        description: Path to the CA cert in the container
+                                          to use for the targets.
+                                        type: string
+                                      cert:
+                                        description: Struct containing the client
+                                          cert file for the targets.
+                                        properties:
+                                          configMap:
+                                            description: ConfigMap containing data
+                                              to use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          secret:
+                                            description: Secret containing data to
+                                              use for the targets.
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      certFile:
+                                        description: Path to the client cert file
+                                          in the container for the targets.
+                                        type: string
+                                      insecureSkipVerify:
+                                        description: Disable target certificate validation.
+                                        type: boolean
+                                      keyFile:
+                                        description: Path to the client key file in
+                                          the container for the targets.
+                                        type: string
+                                      keySecret:
+                                        description: Secret containing the client
+                                          key file for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      serverName:
+                                        description: Used to verify the hostname for
+                                          the targets.
+                                        type: string
+                                    type: object
+                                type: object
+                              relabel_debug:
+                                type: boolean
+                              scrape_align_interval:
+                                type: string
+                              scrape_offset:
+                                type: string
+                              stream_parse:
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    jobLabel:
+                      description: The label to use to retrieve the job name from.
+                      type: string
+                    namespaceSelector:
+                      description: Selector to select which namespaces the Endpoints
+                        objects are discovered from.
+                      properties:
+                        any:
+                          description: Boolean describing whether all namespaces are
+                            selected in contrast to a list restricting them.
+                          type: boolean
+                        matchNames:
+                          description: List of namespace names.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    podTargetLabels:
+                      description: PodTargetLabels transfers labels on the Kubernetes
+                        Pod onto the target.
+                      items:
+                        type: string
+                      type: array
+                    sampleLimit:
+                      description: SampleLimit defines per-scrape limit on number
+                        of scraped samples that will be accepted.
+                      format: int64
+                      type: integer
+                    selector:
+                      description: Selector to select Endpoints objects by corresponding
+                        Service labels.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    targetLabels:
+                      description: TargetLabels transfers labels on the Kubernetes
+                        Service onto the target.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - endpoints
+                  type: object
                 serviceSpec:
                   description: ServiceSpec that will be create additional service
                     for vmstorage

--- a/config/crd/legacy/operator.victoriametrics.com_vmsingles.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmsingles.yaml
@@ -305,6 +305,829 @@ spec:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the VMSingle Pods.
               type: string
+            serviceScrapeSpec:
+              description: ServiceScrapeSpec that will be added to vmselect VMServiceScrape
+                spec
+              properties:
+                discoveryRole:
+                  description: 'DiscoveryRole - defines kubernetes_sd role for objects
+                    discovery. by default, its endpoints. can be changed to service
+                    or endpointslices. note, that with service setting, you have to
+                    use port: "name" and cannot use targetPort for endpoints.'
+                  enum:
+                  - endpoints
+                  - service
+                  - endpointslices
+                  type: string
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceScrape.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate
+                          over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service scrape namespace
+                              that contains the password for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          password_file:
+                            description: PasswordFile defines path to password file
+                              at disk
+                            type: string
+                          username:
+                            description: The secret in the service scrape namespace
+                              that contains the username for authentication. It must
+                              be at them same namespace as CRD
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as
+                          the service scrape and accessible by the victoria-metrics
+                          operator.
+                        nullable: true
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      follow_redirects:
+                        description: FollowRedirects controls redirects for scraping.
+                        type: boolean
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether vmagent respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelConfigs:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 defines auth configuration
+                        properties:
+                          client_id:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          client_secret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          client_secret_file:
+                            description: ClientSecretFile defines path for client
+                              secret file.
+                            type: string
+                          endpoint_params:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          token_url:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                        - client_id
+                        - token_url
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers
+                          to. Mutually exclusive with targetPort.
+                        type: string
+                      proxyURL:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelConfigs:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of
+                            the label set, being applied to samples before ingestion.
+                            It defines `<metric_relabel_configs>`-section of configuration.
+                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex
+                                replace is performed if the regular expression matches.
+                                Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            source_labels:
+                              description: UnderScoreSourceLabels - additional form
+                                of source labels source_labels for compatibility with
+                                original relabel config. if set  both sourceLabels
+                                and source_labels, sourceLabels has priority. for
+                                details https://github.com/VictoriaMetrics/operator/issues/131
+                              items:
+                                type: string
+                              type: array
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            target_label:
+                              description: UnderScoreTargetLabel - additional form
+                                of target label - target_label for compatibility with
+                                original relabel config. if set  both targetLabel
+                                and target_label, targetLabel has priority. for details
+                                https://github.com/VictoriaMetrics/operator/issues/131
+                              type: string
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      sampleLimit:
+                        description: SampleLimit defines per-endpoint limit on number
+                          of scraped samples that will be accepted.
+                        format: int64
+                        type: integer
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrape_interval:
+                        description: ScrapeInterval is the same as Interval and has
+                          priority over it. one of scrape_interval or interval can
+                          be used
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the pod port this endpoint
+                          refers to. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLSConfig configuration to use when scraping
+                          the endpoint
+                        properties:
+                          ca:
+                            description: Stuct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the container to use
+                              for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for
+                                  the targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the container
+                              for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the container
+                              for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for
+                              the targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                      vm_scrape_params:
+                        description: VMScrapeParams defines VictoriaMetrics specific
+                          scrape parametrs
+                        properties:
+                          disable_compression:
+                            type: boolean
+                          disable_keep_alive:
+                            type: boolean
+                          metric_relabel_debug:
+                            type: boolean
+                          proxy_client_config:
+                            description: ProxyClientConfig configures proxy auth settings
+                              for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy
+                            properties:
+                              basic_auth:
+                                description: 'BasicAuth allow an endpoint to authenticate
+                                  over basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                                properties:
+                                  password:
+                                    description: The secret in the service scrape
+                                      namespace that contains the password for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  password_file:
+                                    description: PasswordFile defines path to password
+                                      file at disk
+                                    type: string
+                                  username:
+                                    description: The secret in the service scrape
+                                      namespace that contains the username for authentication.
+                                      It must be at them same namespace as CRD
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              bearer_token:
+                                description: SecretKeySelector selects a key of a
+                                  Secret.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              bearer_token_file:
+                                type: string
+                              tls_config:
+                                description: TLSConfig specifies TLSConfig configuration
+                                  parameters.
+                                properties:
+                                  ca:
+                                    description: Stuct containing the CA cert to use
+                                      for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  caFile:
+                                    description: Path to the CA cert in the container
+                                      to use for the targets.
+                                    type: string
+                                  cert:
+                                    description: Struct containing the client cert
+                                      file for the targets.
+                                    properties:
+                                      configMap:
+                                        description: ConfigMap containing data to
+                                          use for the targets.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      secret:
+                                        description: Secret containing data to use
+                                          for the targets.
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  certFile:
+                                    description: Path to the client cert file in the
+                                      container for the targets.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: Disable target certificate validation.
+                                    type: boolean
+                                  keyFile:
+                                    description: Path to the client key file in the
+                                      container for the targets.
+                                    type: string
+                                  keySecret:
+                                    description: Secret containing the client key
+                                      file for the targets.
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  serverName:
+                                    description: Used to verify the hostname for the
+                                      targets.
+                                    type: string
+                                type: object
+                            type: object
+                          relabel_debug:
+                            type: boolean
+                          scrape_align_interval:
+                            type: string
+                          scrape_offset:
+                            type: string
+                          stream_parse:
+                            type: boolean
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: The label to use to retrieve the job name from.
+                  type: string
+                namespaceSelector:
+                  description: Selector to select which namespaces the Endpoints objects
+                    are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes
+                    Pod onto the target.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects by corresponding
+                    Service labels.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels on the Kubernetes Service
+                    onto the target.
+                  items:
+                    type: string
+                  type: array
+              required:
+              - endpoints
+              type: object
             serviceSpec:
               description: ServiceSpec that will be added to vmsingle service spec
               properties:

--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -806,7 +806,7 @@ func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client
 		Spec: *serviceScrapeSpec,
 	}
 	scrapeSvc.Spec.Selector = metav1.LabelSelector{MatchLabels: service.Spec.Selector}
-	scrapeSvc.Spec.Endpoints = endPoints
+	scrapeSvc.Spec.Endpoints = append(endPoints, scrapeSvc.Spec.Endpoints...)
 
 	err := rclient.Get(ctx, types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, &existVSS)
 	if err != nil {

--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -770,7 +770,7 @@ func gzipConfig(buf *bytes.Buffer, conf []byte) error {
 	return nil
 }
 
-func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client, service *v1.Service, serviceScrapeSpecTemplate *victoriametricsv1beta1.VMServiceScrapeSpec, metricPath string, filterPortNames ...string) error {
+func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client, service *v1.Service, serviceScrapeSpec *victoriametricsv1beta1.VMServiceScrapeSpec, metricPath string, filterPortNames ...string) error {
 	endPoints := []victoriametricsv1beta1.Endpoint{}
 	for _, servicePort := range service.Spec.Ports {
 		var nameMatched bool
@@ -789,8 +789,12 @@ func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client
 			Path: metricPath,
 		})
 	}
+
 	var existVSS victoriametricsv1beta1.VMServiceScrape
 
+	if serviceScrapeSpec == nil {
+		serviceScrapeSpec = &victoriametricsv1beta1.VMServiceScrapeSpec{}
+	}
 	scrapeSvc := victoriametricsv1beta1.VMServiceScrape{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            service.Name,
@@ -799,7 +803,7 @@ func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client
 			Labels:          service.Labels,
 			Annotations:     service.Annotations,
 		},
-		Spec: *serviceScrapeSpecTemplate.DeepCopy(),
+		Spec: *serviceScrapeSpec,
 	}
 	scrapeSvc.Spec.Selector = metav1.LabelSelector{MatchLabels: service.Spec.Selector}
 	scrapeSvc.Spec.Endpoints = endPoints

--- a/controllers/factory/scrapes_test.go
+++ b/controllers/factory/scrapes_test.go
@@ -904,7 +904,6 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 						},
 					},
 				},
-				serviceScrapeSpecTemplate: &victoriametricsv1beta1.VMServiceScrapeSpec{},
 			},
 			wantServiceScrapeSpec: victoriametricsv1beta1.VMServiceScrapeSpec{
 				Endpoints: []victoriametricsv1beta1.Endpoint{

--- a/controllers/factory/scrapes_test.go
+++ b/controllers/factory/scrapes_test.go
@@ -948,6 +948,50 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 				TargetLabels: []string{"key"},
 			},
 		},
+		{
+			name: "with extra endpoints",
+			args: args{
+				metricPath:      "/metrics",
+				filterPortNames: []string{"http"},
+				service: &v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vmagent-svc",
+						Labels: map[string]string{
+							"key": "value",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Ports: []v1.ServicePort{
+							{
+								Name: "http",
+							},
+						},
+					},
+				},
+				serviceScrapeSpecTemplate: &victoriametricsv1beta1.VMServiceScrapeSpec{
+					TargetLabels: []string{"key"},
+					Endpoints: []victoriametricsv1beta1.Endpoint{
+						{
+							Path: "/metrics",
+							Port: "sidecar",
+						},
+					},
+				},
+			},
+			wantServiceScrapeSpec: victoriametricsv1beta1.VMServiceScrapeSpec{
+				Endpoints: []victoriametricsv1beta1.Endpoint{
+					{
+						Path: "/metrics",
+						Port: "http",
+					},
+					{
+						Path: "/metrics",
+						Port: "sidecar",
+					},
+				},
+				TargetLabels: []string{"key"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -102,7 +102,7 @@ func CreateOrUpdateVMCluster(ctx context.Context, cr *v1beta1.VMCluster, rclient
 			return status, err
 		}
 		if !c.DisableSelfServiceScrapeCreation {
-			err := CreateVMServiceScrapeFromService(ctx, rclient, storageSvc, cr.MetricPathStorage(), "http")
+			err := CreateVMServiceScrapeFromService(ctx, rclient, storageSvc, cr.Spec.VMStorage.ServiceScrapeSpec, cr.MetricPathStorage(), "http")
 			if err != nil {
 				log.Error(err, "cannot create VMServiceScrape for vmStorage")
 			}
@@ -145,7 +145,7 @@ func CreateOrUpdateVMCluster(ctx context.Context, cr *v1beta1.VMCluster, rclient
 			return status, err
 		}
 		if !c.DisableSelfServiceScrapeCreation {
-			err := CreateVMServiceScrapeFromService(ctx, rclient, selectSvc, cr.MetricPathSelect(), "http")
+			err := CreateVMServiceScrapeFromService(ctx, rclient, selectSvc, cr.Spec.VMSelect.ServiceScrapeSpec, cr.MetricPathSelect(), "http")
 			if err != nil {
 				log.Error(err, "cannot create VMServiceScrape for vmSelect")
 			}
@@ -188,7 +188,7 @@ func CreateOrUpdateVMCluster(ctx context.Context, cr *v1beta1.VMCluster, rclient
 			return status, err
 		}
 		if !c.DisableSelfServiceScrapeCreation {
-			err := CreateVMServiceScrapeFromService(ctx, rclient, insertSvc, cr.MetricPathInsert(), "http")
+			err := CreateVMServiceScrapeFromService(ctx, rclient, insertSvc, cr.Spec.VMInsert.ServiceScrapeSpec, cr.MetricPathInsert(), "http")
 			if err != nil {
 				log.Error(err, "cannot create VMServiceScrape for vmInsert")
 			}

--- a/controllers/vmagent_controller.go
+++ b/controllers/vmagent_controller.go
@@ -106,7 +106,7 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !r.BaseConf.DisableSelfServiceScrapeCreation {
-		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.MetricPath(), "http")
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.Spec.ServiceScrapeSpec, instance.MetricPath(), "http")
 		if err != nil {
 			reqLogger.Error(err, "cannot create serviceScrape for vmagent")
 		}

--- a/controllers/vmalert_controller.go
+++ b/controllers/vmalert_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"sync"
+
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -30,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sync"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 )
@@ -107,7 +108,7 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !r.BaseConf.DisableSelfServiceScrapeCreation {
-		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.MetricPath())
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.Spec.ServiceScrapeSpec, instance.MetricPath())
 		if err != nil {
 			// made on best effort.
 			reqLogger.Error(err, "cannot create serviceScrape for vmalert")

--- a/controllers/vmalertmanager_controller.go
+++ b/controllers/vmalertmanager_controller.go
@@ -18,9 +18,10 @@ package controllers
 
 import (
 	"context"
+	"sync"
+
 	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sync"
 
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -96,7 +97,7 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if !r.BaseConf.DisableSelfServiceScrapeCreation {
-		err := factory.CreateVMServiceScrapeFromService(ctx, r, service, instance.MetricPath(), "http")
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, service, instance.Spec.ServiceScrapeSpec, instance.MetricPath(), "http")
 		if err != nil {
 			reqLogger.Error(err, "cannot create serviceScrape for vmalertmanager")
 		}

--- a/controllers/vmauth_controller.go
+++ b/controllers/vmauth_controller.go
@@ -94,7 +94,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if !r.BaseConf.DisableSelfServiceScrapeCreation {
-		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.MetricPath())
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.Spec.ServiceScrapeSpec, instance.MetricPath())
 		if err != nil {
 			l.Error(err, "cannot create serviceScrape for vmauth")
 		}

--- a/controllers/vmsingle_controller.go
+++ b/controllers/vmsingle_controller.go
@@ -99,7 +99,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if !r.BaseConf.DisableSelfServiceScrapeCreation {
-		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.MetricPath())
+		err := factory.CreateVMServiceScrapeFromService(ctx, r, svc, instance.Spec.ServiceScrapeSpec, instance.MetricPath())
 		if err != nil {
 			reqLogger.Error(err, "cannot create serviceScrape for vmsingle")
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/VictoriaMetrics/VictoriaMetrics v1.73.0
+	github.com/VictoriaMetrics/metricsql v0.40.0
 	github.com/VictoriaMetrics/operator/api v0.0.0-20220220173620-6f1e087b0e5c
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
@@ -33,7 +34,6 @@ require (
 require (
 	cloud.google.com/go/compute v1.2.0 // indirect
 	github.com/VictoriaMetrics/metrics v1.18.1 // indirect
-	github.com/VictoriaMetrics/metricsql v0.40.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Hi @f41gh7,
This is my 2nd pull request: kinda big and includes API changes, so I hope that it can be reviewed well before having any next actions.

This pull request solves #454 by adding `serviceScrapeSpec` on various places, so we can have more flexibility with the generated `VMServiceScrape` objects.

Thank you.