### PR TITLE
vmagent support dnsConfig

### DIFF
--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -353,6 +353,11 @@ type VMAgentSpec struct {
 	// TerminationGracePeriodSeconds period for container graceful termination
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+	// Specifies the DNS parameters of a pod.
+	// Parameters specified here will be merged to the generated DNS
+	// configuration based on DNSPolicy.
+	// +optional
+	DNSConfig *v1.PodDNSConfig `json:"dnsConfig,omitempty"`
 }
 
 // VMAgentRemoteWriteSettings - defines global settings for all remoteWrite urls.

--- a/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -282,6 +282,42 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
+              dnsConfig:
+                description: Specifies the DNS parameters of a pod. Parameters specified
+                  here will be merged to the generated DNS configuration based on
+                  DNSPolicy.
+                properties:
+                  nameservers:
+                    description: A list of DNS name server IP addresses. This will
+                      be appended to the base nameservers generated from DNSPolicy.
+                      Duplicated nameservers will be removed.
+                    items:
+                      type: string
+                    type: array
+                  options:
+                    description: A list of DNS resolver options. This will be merged
+                      with the base options generated from DNSPolicy. Duplicated entries
+                      will be removed. Resolution options given in Options will override
+                      those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
+                      properties:
+                        name:
+                          description: Required.
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  searches:
+                    description: A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from
+                      DNSPolicy. Duplicated search paths will be removed.
+                    items:
+                      type: string
+                    type: array
+                type: object
               dnsPolicy:
                 description: DNSPolicy set DNS policy for the pod
                 type: string

--- a/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
@@ -273,6 +273,41 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               type: array
+            dnsConfig:
+              description: Specifies the DNS parameters of a pod. Parameters specified
+                here will be merged to the generated DNS configuration based on DNSPolicy.
+              properties:
+                nameservers:
+                  description: A list of DNS name server IP addresses. This will be
+                    appended to the base nameservers generated from DNSPolicy. Duplicated
+                    nameservers will be removed.
+                  items:
+                    type: string
+                  type: array
+                options:
+                  description: A list of DNS resolver options. This will be merged
+                    with the base options generated from DNSPolicy. Duplicated entries
+                    will be removed. Resolution options given in Options will override
+                    those that appear in the base DNSPolicy.
+                  items:
+                    description: PodDNSConfigOption defines DNS resolver options of
+                      a pod.
+                    properties:
+                      name:
+                        description: Required.
+                        type: string
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                searches:
+                  description: A list of DNS search domains for host-name lookup.
+                    This will be appended to the base search paths generated from
+                    DNSPolicy. Duplicated search paths will be removed.
+                  items:
+                    type: string
+                  type: array
+              type: object
             dnsPolicy:
               description: DNSPolicy set DNS policy for the pod
               type: string

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -408,6 +408,7 @@ func makeSpecForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOperat
 			PriorityClassName:             cr.Spec.PriorityClassName,
 			HostNetwork:                   cr.Spec.HostNetwork,
 			DNSPolicy:                     cr.Spec.DNSPolicy,
+			DNSConfig:                     cr.Spec.DNSConfig,
 			RuntimeClassName:              cr.Spec.RuntimeClassName,
 			HostAliases:                   cr.Spec.HostAliases,
 			TopologySpreadConstraints:     cr.Spec.TopologySpreadConstraints,


### PR DESCRIPTION
In our company, we need to specify dnsConfig by our own, so I added `dnsConfig` field to vmagent spec. Please take this case into consideration and check if the way I implemented is correct. Thanks a lot. 

https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/, this official doc talks about the usage of `dnsConfig`. 

Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>