### PR TITLE
Add image and link config into alertmanager pagerduty_configs

### DIFF
--- a/api/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/v1beta1/vmalertmanagerconfig_types.go
@@ -615,6 +615,12 @@ type PagerDutyConfig struct {
 	// Backlink to the sender of notification.
 	// +optional
 	ClientURL string `json:"client_url,omitempty"`
+	// Images to attach to the incident.
+	// +optional
+	Images []ImageConfig `json:"images,omitempty"`
+	// Links to attach to the incident.
+	// +optional
+	Links []LinkConfig `json:"links,omitempty"`
 	// Description of the incident.
 	// +optional
 	Description string `json:"description,omitempty"`
@@ -636,6 +642,23 @@ type PagerDutyConfig struct {
 	// HTTP client configuration.
 	// +optional
 	HTTPConfig *HTTPConfig `json:"http_config,omitempty"`
+}
+
+// ImageConfig is used to attach images to the incident.
+// See https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#the-images-property
+// for more information.
+type ImageConfig struct {
+	Href   string `json:"href,omitempty"`
+	Source string `json:"source"`
+	Alt    string `json:"alt,omitempty"`
+}
+
+// LinkConfig is used to attach text links to the incident.
+// See https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#the-links-property
+// for more information.
+type LinkConfig struct {
+	Href string `json:"href"`
+	Text string `json:"text,omitempty"`
 }
 
 // HTTPConfig defines a client HTTP configuration.

--- a/controllers/factory/alertmanager/config.go
+++ b/controllers/factory/alertmanager/config.go
@@ -676,6 +676,37 @@ func (cb *configBuilder) buildPagerDuty(pd operatorv1beta1.PagerDutyConfig) erro
 	toYaml("component", pd.Component)
 	toYaml("group", pd.Group)
 	toYaml("severity", pd.Severity)
+	var images []yaml.MapSlice
+	for _, image := range pd.Images {
+		var imageYAML yaml.MapSlice
+		if len(image.Href) > 0 {
+			imageYAML = append(imageYAML, yaml.MapItem{Key: "href", Value: image.Href})
+		}
+		if len(image.Source) > 0 {
+			imageYAML = append(imageYAML, yaml.MapItem{Key: "source", Value: image.Source})
+		}
+		if len(image.Alt) > 0 {
+			imageYAML = append(imageYAML, yaml.MapItem{Key: "alt", Value: image.Alt})
+		}
+		images = append(images, imageYAML)
+	}
+	if len(images) > 0 {
+		temp = append(temp, yaml.MapItem{Key: "images", Value: images})
+	}
+	var links []yaml.MapSlice
+	for _, link := range pd.Links {
+		var linkYAML yaml.MapSlice
+		if len(link.Href) > 0 {
+			linkYAML = append(linkYAML, yaml.MapItem{Key: "href", Value: link.Href})
+		}
+		if len(link.Text) > 0 {
+			linkYAML = append(linkYAML, yaml.MapItem{Key: "text", Value: link.Text})
+		}
+		links = append(links, linkYAML)
+	}
+	if len(links) > 0 {
+		temp = append(temp, yaml.MapItem{Key: "links", Value: links})
+	}
 	detailKeys := make([]string, 0, len(pd.Details))
 	for detailKey, value := range pd.Details {
 		if len(value) == 0 {

--- a/controllers/factory/alertmanager/config_test.go
+++ b/controllers/factory/alertmanager/config_test.go
@@ -350,6 +350,19 @@ templates: []
 											Class:    "some-class",
 											Group:    "some-group",
 											Severity: "warning",
+											Images: []operatorv1beta1.ImageConfig{
+												{
+													Href:   "http://some-href",
+													Source: "http://some-source",
+													Alt:    "some-alt-text",
+												},
+											},
+											Links: []operatorv1beta1.LinkConfig{
+												{
+													Href: "http://some-href",
+													Text: "some-text",
+												},
+											},
 											Details: map[string]string{
 												"alertname":    "alert-name",
 												"firing":       "alert-title",
@@ -395,6 +408,13 @@ receivers:
     class: some-class
     group: some-group
     severity: warning
+    images:
+    - href: http://some-href
+      source: http://some-source
+      alt: some-alt-text
+    links:
+    - href: http://some-href
+      text: some-text
     details:
       alertname: alert-name
       firing: alert-title


### PR DESCRIPTION
Alertmanager pagerduty_configs is missing image_config and link_config Compared with the official configuration. 