### PR TITLE
Fix VMStorage statefulSet pvc create failed

### DIFF
--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -141,7 +141,7 @@ func (ss *StorageSpec) IntoSTSVolume(name string, sts *appsv1.StatefulSetSpec) {
 				Kind:       claimTemplate.Kind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        claimTemplate.Name,
+				Name:        name,
 				Labels:      claimTemplate.Labels,
 				Annotations: claimTemplate.Annotations,
 			},


### PR DESCRIPTION
VMStorage statefulset pvc' name should be `IntoSTSVolume` caller parameters `name`.

> This PR is to fix #482 