### PR TITLE
Fix alertmanager metrics endpoint when routePrefix is configured

### DIFF
--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -16,13 +16,12 @@ import (
 )
 
 const (
-	vmPathPrefixFlagName             = "http.pathPrefix"
-	vmAlertmanagerPathPrefixFlagName = "web.route-prefix"
-	healthPath                       = "/health"
-	metricPath                       = "/metrics"
-	reloadPath                       = "/-/reload"
-	snapshotCreate                   = "/snapshot/create"
-	snapshotDelete                   = "/snapshot/delete"
+	vmPathPrefixFlagName = "http.pathPrefix"
+	healthPath           = "/health"
+	metricPath           = "/metrics"
+	reloadPath           = "/-/reload"
+	snapshotCreate       = "/snapshot/create"
+	snapshotDelete       = "/snapshot/delete"
 	// FinalizerName name of our finalizer.
 	FinalizerName            = "apps.victoriametrics.com/finalizer"
 	SkipValidationAnnotation = "operator.victoriametrics.com/skip-validation"
@@ -220,13 +219,6 @@ func (ss *ServiceSpec) NameOrDefault(defaultName string) string {
 
 func buildPathWithPrefixFlag(flags map[string]string, defaultPath string) string {
 	if prefix, ok := flags[vmPathPrefixFlagName]; ok {
-		return path.Join(prefix, defaultPath)
-	}
-	return defaultPath
-}
-
-func buildAlertmanagerPathWithPrefixFlag(flags map[string]string, defaultPath string) string {
-	if prefix, ok := flags[vmAlertmanagerPathPrefixFlagName]; ok {
 		return path.Join(prefix, defaultPath)
 	}
 	return defaultPath

--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -2,8 +2,9 @@ package v1beta1
 
 import (
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"path"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	"k8s.io/api/autoscaling/v2beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,12 +16,13 @@ import (
 )
 
 const (
-	vmPathPrefixFlagName = "http.pathPrefix"
-	healthPath           = "/health"
-	metricPath           = "/metrics"
-	reloadPath           = "/-/reload"
-	snapshotCreate       = "/snapshot/create"
-	snapshotDelete       = "/snapshot/delete"
+	vmPathPrefixFlagName             = "http.pathPrefix"
+	vmAlertmanagerPathPrefixFlagName = "web.route-prefix"
+	healthPath                       = "/health"
+	metricPath                       = "/metrics"
+	reloadPath                       = "/-/reload"
+	snapshotCreate                   = "/snapshot/create"
+	snapshotDelete                   = "/snapshot/delete"
 	// FinalizerName name of our finalizer.
 	FinalizerName            = "apps.victoriametrics.com/finalizer"
 	SkipValidationAnnotation = "operator.victoriametrics.com/skip-validation"
@@ -218,6 +220,13 @@ func (ss *ServiceSpec) NameOrDefault(defaultName string) string {
 
 func buildPathWithPrefixFlag(flags map[string]string, defaultPath string) string {
 	if prefix, ok := flags[vmPathPrefixFlagName]; ok {
+		return path.Join(prefix, defaultPath)
+	}
+	return defaultPath
+}
+
+func buildAlertmanagerPathWithPrefixFlag(flags map[string]string, defaultPath string) string {
+	if prefix, ok := flags[vmAlertmanagerPathPrefixFlagName]; ok {
 		return path.Join(prefix, defaultPath)
 	}
 	return defaultPath

--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -388,7 +389,10 @@ func (cr *VMAlertmanager) AsPodFQDN(idx int) string {
 }
 
 func (cr *VMAlertmanager) MetricPath() string {
-	return buildAlertmanagerPathWithPrefixFlag(cr.Spec.ExtraArgs, metricPath)
+	if prefix := cr.Spec.RoutePrefix; prefix != "" {
+		return path.Join(prefix, metricPath)
+	}
+	return metricPath
 }
 
 // AsCRDOwner implements interface

--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -388,7 +388,7 @@ func (cr *VMAlertmanager) AsPodFQDN(idx int) string {
 }
 
 func (cr *VMAlertmanager) MetricPath() string {
-	return buildPathWithPrefixFlag(cr.Spec.ExtraArgs, metricPath)
+	return buildAlertmanagerPathWithPrefixFlag(cr.Spec.ExtraArgs, metricPath)
 }
 
 // AsCRDOwner implements interface


### PR DESCRIPTION
VMAlertmanager CR allows us to configure routePrefix field. If this is used, metrics is not accessible at `/metrics` (it is only accessible at `<routePrefix>/metrics`. Currently, the metrics endpoint that comes up in the generated VMServiceScrape of alertmanager is `/metrics` (even if routePrefix is configured). This PR fixes this by adding the route prefix from routePrefix field of vmalertmanager CR, so that the metrics endpoint points to the right path.

