### PR TITLE
api/vmauth: adds host param for ingress

### DIFF
--- a/api/v1beta1/vmauth_types.go
+++ b/api/v1beta1/vmauth_types.go
@@ -197,6 +197,10 @@ type EmbeddedIngress struct {
 	// must be checked for correctness by user.
 	// +optional
 	ExtraTLS []v12.IngressTLS `json:"extraTls,omitempty"`
+	// Host defines ingress host parameter for default rule
+	// It will be used, only if TlsHosts is empty
+	// +optional
+	Host string `json:"host,omitempty"`
 }
 
 // VMAuthStatus defines the observed state of VMAuth

--- a/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -375,6 +375,10 @@ spec:
                           type: string
                       type: object
                     type: array
+                  host:
+                    description: Host defines ingress host parameter for default rule
+                      It will be used, only if TlsHosts is empty
+                    type: string
                   labels:
                     additionalProperties:
                       type: string

--- a/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
@@ -371,6 +371,10 @@ spec:
                         type: string
                     type: object
                   type: array
+                host:
+                  description: Host defines ingress host parameter for default rule
+                    It will be used, only if TlsHosts is empty
+                  type: string
                 labels:
                   additionalProperties:
                     type: string

--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -375,6 +375,7 @@ var defaultPt = v12.PathTypePrefix
 
 func buildIngressConfig(cr *victoriametricsv1beta1.VMAuth) *v12.Ingress {
 	defaultRule := v12.IngressRule{
+		Host: cr.Spec.Ingress.Host,
 		IngressRuleValue: v12.IngressRuleValue{
 			HTTP: &v12.HTTPIngressRuleValue{
 				Paths: []v12.HTTPIngressPath{


### PR DESCRIPTION
It should allow to configure host param for non-tls ingress deployments

https://github.com/VictoriaMetrics/operator/issues/485