### PR TITLE
api/vmcluster: reworks expanding for cluster

### DIFF
--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -498,7 +498,7 @@ func (cr VMAgent) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAgent) Annotations() map[string]string {
+func (cr VMAgent) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -526,7 +526,7 @@ func (cr VMAgent) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAgent) Labels() map[string]string {
+func (cr VMAgent) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/v1beta1/vmalert_types.go
+++ b/api/v1beta1/vmalert_types.go
@@ -384,7 +384,7 @@ func (cr VMAlert) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAlert) Annotations() map[string]string {
+func (cr VMAlert) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -412,7 +412,7 @@ func (cr VMAlert) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAlert) Labels() map[string]string {
+func (cr VMAlert) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -317,7 +317,7 @@ func (cr VMAlertmanager) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAlertmanager) Annotations() map[string]string {
+func (cr VMAlertmanager) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -345,7 +345,7 @@ func (cr VMAlertmanager) PodLabels() map[string]string {
 
 }
 
-func (cr VMAlertmanager) Labels() map[string]string {
+func (cr VMAlertmanager) AllLabels() map[string]string {
 
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {

--- a/api/v1beta1/vmauth_types.go
+++ b/api/v1beta1/vmauth_types.go
@@ -252,7 +252,7 @@ func (cr VMAuth) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAuth) Annotations() map[string]string {
+func (cr VMAuth) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -279,7 +279,7 @@ func (cr VMAuth) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAuth) Labels() map[string]string {
+func (cr VMAuth) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -1,8 +1,11 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
 	"path"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -854,15 +857,39 @@ func (cr VMCluster) VMStoragePodAnnotations() map[string]string {
 	return cr.Spec.VMStorage.PodMetadata.Annotations
 }
 
-func (cr VMCluster) Annotations() map[string]string {
+func (cr VMCluster) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string, len(cr.ObjectMeta.Annotations))
 	for annotation, value := range cr.ObjectMeta.Annotations {
-		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
+		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") && !strings.HasPrefix(annotation, "operator.victoriametrics.com/") {
 			annotations[annotation] = value
 		}
 	}
 	return annotations
 }
+
+// LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
+func (cr *VMCluster) LastAppliedSpecAsPatch() (client.Patch, error) {
+	data, err := json.Marshal(cr.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("possible bug, cannot serialize cluster specification as json :%w", err)
+	}
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"operator.victoriametrics/last-applied-spec": %q}}}`, data)
+	return client.RawPatch(types.MergePatchType, []byte(patch)), nil
+}
+
+// GetLastAppliedSpec returns last applied cluster spec
+func (cr *VMCluster) GetLastAppliedSpec() (*VMClusterSpec, error) {
+	var prevClusterSpec VMClusterSpec
+	prevClusterJSON := cr.Annotations["operator.victoriametrics/last-applied-spec"]
+	if prevClusterJSON == "" {
+		return &prevClusterSpec, nil
+	}
+	if err := json.Unmarshal([]byte(prevClusterJSON), &prevClusterSpec); err != nil {
+		return nil, fmt.Errorf("cannot parse last applied cluster spec value: %s : %w", prevClusterJSON, err)
+	}
+	return &prevClusterSpec, nil
+}
+
 func (cr VMCluster) HealthPathSelect() string {
 	if cr.Spec.VMSelect == nil {
 		return healthPath
@@ -952,7 +979,7 @@ func (cr VMCluster) SelectorLabels() map[string]string {
 	}
 }
 
-func (cr VMCluster) Labels() map[string]string {
+func (cr VMCluster) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/v1beta1/vmsingle_types.go
+++ b/api/v1beta1/vmsingle_types.go
@@ -249,7 +249,7 @@ func (cr VMSingle) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMSingle) Annotations() map[string]string {
+func (cr VMSingle) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -276,7 +276,7 @@ func (cr VMSingle) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMSingle) Labels() map[string]string {
+func (cr VMSingle) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/v1beta1/vmuser_types.go
+++ b/api/v1beta1/vmuser_types.go
@@ -152,7 +152,7 @@ func (cr *VMUser) AsOwner() []metav1.OwnerReference {
 	}
 }
 
-func (cr VMUser) Annotations() map[string]string {
+func (cr VMUser) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -171,7 +171,7 @@ func (cr VMUser) SelectorLabels() map[string]string {
 	}
 }
 
-func (cr VMUser) Labels() map[string]string {
+func (cr VMUser) AllLabels() map[string]string {
 	labels := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels != nil {
 		for label, value := range cr.ObjectMeta.Labels {

--- a/api/victoriametrics/v1beta1/vmagent_types.go
+++ b/api/victoriametrics/v1beta1/vmagent_types.go
@@ -498,7 +498,7 @@ func (cr VMAgent) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAgent) Annotations() map[string]string {
+func (cr VMAgent) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -526,7 +526,7 @@ func (cr VMAgent) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAgent) Labels() map[string]string {
+func (cr VMAgent) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/victoriametrics/v1beta1/vmalert_types.go
+++ b/api/victoriametrics/v1beta1/vmalert_types.go
@@ -384,7 +384,7 @@ func (cr VMAlert) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAlert) Annotations() map[string]string {
+func (cr VMAlert) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -412,7 +412,7 @@ func (cr VMAlert) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAlert) Labels() map[string]string {
+func (cr VMAlert) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/victoriametrics/v1beta1/vmalertmanager_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanager_types.go
@@ -317,7 +317,7 @@ func (cr VMAlertmanager) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAlertmanager) Annotations() map[string]string {
+func (cr VMAlertmanager) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -345,7 +345,7 @@ func (cr VMAlertmanager) PodLabels() map[string]string {
 
 }
 
-func (cr VMAlertmanager) Labels() map[string]string {
+func (cr VMAlertmanager) AllLabels() map[string]string {
 
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {

--- a/api/victoriametrics/v1beta1/vmauth_types.go
+++ b/api/victoriametrics/v1beta1/vmauth_types.go
@@ -252,7 +252,7 @@ func (cr VMAuth) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMAuth) Annotations() map[string]string {
+func (cr VMAuth) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -279,7 +279,7 @@ func (cr VMAuth) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMAuth) Labels() map[string]string {
+func (cr VMAuth) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/victoriametrics/v1beta1/vmcluster_types.go
+++ b/api/victoriametrics/v1beta1/vmcluster_types.go
@@ -854,7 +854,7 @@ func (cr VMCluster) VMStoragePodAnnotations() map[string]string {
 	return cr.Spec.VMStorage.PodMetadata.Annotations
 }
 
-func (cr VMCluster) Annotations() map[string]string {
+func (cr VMCluster) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string, len(cr.ObjectMeta.Annotations))
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -952,7 +952,7 @@ func (cr VMCluster) SelectorLabels() map[string]string {
 	}
 }
 
-func (cr VMCluster) Labels() map[string]string {
+func (cr VMCluster) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/victoriametrics/v1beta1/vmsingle_types.go
+++ b/api/victoriametrics/v1beta1/vmsingle_types.go
@@ -249,7 +249,7 @@ func (cr VMSingle) PodAnnotations() map[string]string {
 	return annotations
 }
 
-func (cr VMSingle) Annotations() map[string]string {
+func (cr VMSingle) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -276,7 +276,7 @@ func (cr VMSingle) PodLabels() map[string]string {
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
 }
 
-func (cr VMSingle) Labels() map[string]string {
+func (cr VMSingle) AllLabels() map[string]string {
 	lbls := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels == nil {
 		return lbls

--- a/api/victoriametrics/v1beta1/vmuser_types.go
+++ b/api/victoriametrics/v1beta1/vmuser_types.go
@@ -152,7 +152,7 @@ func (cr *VMUser) AsOwner() []metav1.OwnerReference {
 	}
 }
 
-func (cr VMUser) Annotations() map[string]string {
+func (cr VMUser) AnnotationsFiltered() map[string]string {
 	annotations := make(map[string]string)
 	for annotation, value := range cr.ObjectMeta.Annotations {
 		if !strings.HasPrefix(annotation, "kubectl.kubernetes.io/") {
@@ -171,7 +171,7 @@ func (cr VMUser) SelectorLabels() map[string]string {
 	}
 }
 
-func (cr VMUser) Labels() map[string]string {
+func (cr VMUser) AllLabels() map[string]string {
 	labels := cr.SelectorLabels()
 	if cr.ObjectMeta.Labels != nil {
 		for label, value := range cr.ObjectMeta.Labels {

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -134,8 +134,8 @@ func newStsForAlertManager(cr *victoriametricsv1beta1.VMAlertmanager, c *config.
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
-			Labels:          c.Labels.Merge(cr.Labels()),
-			Annotations:     cr.Annotations(),
+			Labels:          c.Labels.Merge(cr.AllLabels()),
+			Annotations:     cr.AnnotationsFiltered(),
 			Namespace:       cr.Namespace,
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
@@ -532,8 +532,8 @@ func createDefaultAMConfig(ctx context.Context, cr *victoriametricsv1beta1.VMAle
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.ConfigSecretName(),
 			Namespace:       cr.Namespace,
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 		},

--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -68,8 +68,8 @@ func buildResources(crdResources v1.ResourceRequirements, defaultResources confi
 type svcBuilderArgs interface {
 	client.Object
 	PrefixedName() string
-	Annotations() map[string]string
-	Labels() map[string]string
+	AnnotationsFiltered() map[string]string
+	AllLabels() map[string]string
 	SelectorLabels() map[string]string
 	AsOwner() []metav1.OwnerReference
 	GetNSName() string
@@ -106,8 +106,8 @@ func buildDefaultService(cr svcBuilderArgs, defaultPort string, setOptions func(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.GetNSName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 		},
@@ -226,7 +226,7 @@ func buildDefaultPDBV1(cr svcBuilderArgs, spec *victoriametricsv1beta1.EmbeddedP
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
-			Labels:          cr.Labels(),
+			Labels:          cr.AllLabels(),
 			OwnerReferences: cr.AsOwner(),
 			Namespace:       cr.GetNSName(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
@@ -245,7 +245,7 @@ func buildDefaultPDB(cr svcBuilderArgs, spec *victoriametricsv1beta1.EmbeddedPod
 	return &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
-			Labels:          cr.Labels(),
+			Labels:          cr.AllLabels(),
 			OwnerReferences: cr.AsOwner(),
 			Namespace:       cr.GetNSName(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},

--- a/controllers/factory/finalize/common.go
+++ b/controllers/factory/finalize/common.go
@@ -17,8 +17,8 @@ import (
 )
 
 type CRDObject interface {
-	Annotations() map[string]string
-	Labels() map[string]string
+	AnnotationsFiltered() map[string]string
+	GetLabels() map[string]string
 	PrefixedName() string
 	GetServiceAccountName() string
 	GetPSPName() string

--- a/controllers/factory/k8stools/version_test.go
+++ b/controllers/factory/k8stools/version_test.go
@@ -1,0 +1,27 @@
+package k8stools
+
+import "testing"
+
+func TestIsPSPSupported(t *testing.T) {
+	tests := []struct {
+		name  string
+		want  bool
+		major uint64
+		minor uint64
+	}{
+		{
+			name:  "not",
+			major: 1,
+			minor: 22,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ServerMinorVersion = tt.minor
+			ServerMajorVersion = tt.major
+			if got := IsPSPSupported(); got != tt.want {
+				t.Errorf("IsPSPSupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/factory/psp/psp.go
+++ b/controllers/factory/psp/psp.go
@@ -17,8 +17,8 @@ import (
 )
 
 type CRDObject interface {
-	Annotations() map[string]string
-	Labels() map[string]string
+	AnnotationsFiltered() map[string]string
+	AllLabels() map[string]string
 	PrefixedName() string
 	GetServiceAccountName() string
 	GetPSPName() string
@@ -122,8 +122,8 @@ func buildSA(cr CRDObject) *v1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetServiceAccountName(),
 			Namespace:       cr.GetNSName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 		},
@@ -135,8 +135,8 @@ func buildClusterRoleForPSP(cr CRDObject) *v12.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       cr.GetNSName(),
 			Name:            cr.PrefixedName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
@@ -156,8 +156,8 @@ func buildClusterRoleBinding(cr CRDObject) *v12.ClusterRoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.GetNSName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
@@ -181,8 +181,8 @@ func BuildPSP(cr CRDObject) *v1beta1.PodSecurityPolicy {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetPSPName(),
 			Namespace:       cr.GetNSName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},

--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -207,8 +207,8 @@ func makeConfigSecret(cr *victoriametricsv1beta1.VMAgent, config *config.BaseOpe
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
-			Annotations:     cr.Annotations(),
-			Labels:          config.Labels.Merge(cr.Labels()),
+			Annotations:     cr.AnnotationsFiltered(),
+			Labels:          config.Labels.Merge(cr.AllLabels()),
 			Namespace:       cr.Namespace,
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -215,8 +215,8 @@ func newDeployForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOpera
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            cr.PrefixedName(),
 				Namespace:       cr.Namespace,
-				Labels:          c.Labels.Merge(cr.Labels()),
-				Annotations:     cr.Annotations(),
+				Labels:          c.Labels.Merge(cr.AllLabels()),
+				Annotations:     cr.AnnotationsFiltered(),
 				OwnerReferences: cr.AsOwner(),
 				Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 			},
@@ -249,8 +249,8 @@ func newDeployForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOpera
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          c.Labels.Merge(cr.Labels()),
-			Annotations:     cr.Annotations(),
+			Labels:          c.Labels.Merge(cr.AllLabels()),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 		},
@@ -538,8 +538,8 @@ func buildVMAgentRelabelingsAssets(ctx context.Context, cr *victoriametricsv1bet
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       cr.Namespace,
 			Name:            cr.RelabelingAssetName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 		},
 		Data: make(map[string]string),
@@ -649,8 +649,8 @@ func CreateOrUpdateTlsAssets(ctx context.Context, cr *victoriametricsv1beta1.VMA
 	tlsAssetsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.TLSAssetName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Namespace:       cr.Namespace,
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -73,8 +73,8 @@ func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *v12.ClusterRoleBindin
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
@@ -98,8 +98,8 @@ func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *v12.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -184,8 +184,8 @@ func newDeployForVMAlert(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOpera
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          c.Labels.Merge(cr.Labels()),
-			Annotations:     cr.Annotations(),
+			Labels:          c.Labels.Merge(cr.AllLabels()),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 		},
@@ -538,8 +538,8 @@ func CreateOrUpdateTlsAssetsForVMAlert(ctx context.Context, cr *victoriametricsv
 	tlsAssetsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.TLSAssetName(),
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Namespace:       cr.Namespace,
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},

--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -125,8 +125,8 @@ func newDeployForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperato
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          c.Labels.Merge(cr.Labels()),
-			Annotations:     cr.Annotations(),
+			Labels:          c.Labels.Merge(cr.AllLabels()),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -333,7 +333,7 @@ func makeVMAuthConfigSecret(cr *victoriametricsv1beta1.VMAuth) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   cr.ConfigSecretName(),
-			Labels: cr.Labels(),
+			Labels: cr.AllLabels(),
 			Annotations: map[string]string{
 				"generated": "true",
 			},

--- a/controllers/factory/vmauth/rbac.go
+++ b/controllers/factory/vmauth/rbac.go
@@ -68,8 +68,8 @@ func buildVMAuthRole(cr *v1beta12.VMAuth) *v1.Role {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsOwner(),
 		},
@@ -88,8 +88,8 @@ func buildVMAuthRoleBinding(cr *v1beta12.VMAuth) *v1.RoleBinding {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          cr.Labels(),
-			Annotations:     cr.Annotations(),
+			Labels:          cr.AllLabels(),
+			Annotations:     cr.AnnotationsFiltered(),
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsOwner(),
 		},

--- a/controllers/factory/vmcluster_test.go
+++ b/controllers/factory/vmcluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -146,7 +147,7 @@ func Test_waitForExpanding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fclient := k8stools.GetTestClientWithObjects(tt.predefinedObjects)
 
-			err := waitExpanding(context.Background(), fclient, tt.args.namespace, tt.args.lbs, tt.args.desiredCount)
+			err := waitExpanding(context.Background(), fclient, tt.args.namespace, tt.args.lbs, tt.args.desiredCount, time.Second*2)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("waitExpanding() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -126,8 +126,8 @@ func newDeployForVMSingle(cr *victoriametricsv1beta1.VMSingle, c *config.BaseOpe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.PrefixedName(),
 			Namespace:       cr.Namespace,
-			Labels:          c.Labels.Merge(cr.Labels()),
-			Annotations:     cr.Annotations(),
+			Labels:          c.Labels.Merge(cr.AllLabels()),
+			Annotations:     cr.AnnotationsFiltered(),
 			OwnerReferences: cr.AsOwner(),
 			Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 		},

--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -662,8 +662,8 @@ func buildVMUserSecret(src *v1beta1.VMUser) v1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            src.SecretName(),
 			Namespace:       src.Namespace,
-			Labels:          src.Labels(),
-			Annotations:     src.Annotations(),
+			Labels:          src.AllLabels(),
+			Annotations:     src.AnnotationsFiltered(),
 			OwnerReferences: src.AsOwner(),
 			Finalizers: []string{
 				v1beta1.FinalizerName,

--- a/controllers/vmcluster_controller.go
+++ b/controllers/vmcluster_controller.go
@@ -2,21 +2,20 @@ package controllers
 
 import (
 	"context"
-	"time"
-
-	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-
+	"fmt"
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/controllers/factory"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
+	"github.com/go-test/deep"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -62,29 +61,51 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	lastAppliedClusterSpec, err := instance.GetLastAppliedSpec()
+	if err != nil {
+		reqLogger.Error(err, "cannot parse last applied cluster spec")
+	}
+	clusterChanges := deep.Equal(lastAppliedClusterSpec, &instance.Spec)
+	if len(clusterChanges) > 0 && instance.Status.ClusterStatus != victoriametricsv1beta1.ClusterStatusFailed {
+		instance.Status.ClusterStatus = victoriametricsv1beta1.ClusterStatusExpanding
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot set expanding status for cluster: %w", err)
+		}
+	}
+
 	RegisterObject(instance.Name, instance.Namespace, "vmcluster")
 
 	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	status, err := factory.CreateOrUpdateVMCluster(ctx, instance, r.Client, config.MustGetBaseConfig())
+	err = factory.CreateOrUpdateVMCluster(ctx, instance, r.Client, config.MustGetBaseConfig())
 	if err != nil {
-		reqLogger.Error(err, "cannot update or create vmcluster")
-		return reconcile.Result{}, err
-	}
-	if status == victoriametricsv1beta1.ClusterStatusExpanding {
-		reqLogger.Info("cluster still expanding requeue request")
-		failCnt := instance.Status.UpdateFailCount
-		if failCnt > 5 {
-			failCnt = 5
+		instance.Status.Reason = err.Error()
+		instance.Status.ClusterStatus = victoriametricsv1beta1.ClusterStatusFailed
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
+			log.Error(err, "cannot update cluster status field")
 		}
-		backoff := time.Second * time.Duration(failCnt*5)
-		reqLogger.Info("requeuing cluster expanding with back-off", "fail update count", failCnt, "after", backoff.String())
-		// add requeue back-off
-		return reconcile.Result{
-			RequeueAfter: backoff,
-		}, nil
+		// update status
+		return reconcile.Result{}, fmt.Errorf("failed create or update vmcluster: %w", err)
+	}
+
+	instance.Status.Reason = ""
+	instance.Status.ClusterStatus = victoriametricsv1beta1.ClusterStatusOperational
+	if err := r.Client.Status().Update(ctx, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot update cluster status : %w", err)
+	}
+
+	if len(clusterChanges) > 0 {
+		specPatch, err := instance.LastAppliedSpecAsPatch()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("cannot parse last applied spec for cluster: %w", err)
+		}
+		// use patch instead of update, only 1 field must be changed.
+		if err := r.Client.Patch(ctx, instance, specPatch); err != nil {
+			reqLogger.Error(err, "cannot update cluster object")
+			return ctrl.Result{}, fmt.Errorf("cannot update cluster with last applied spec: %w", err)
+		}
 	}
 
 	reqLogger.Info("cluster was reconciled")


### PR DESCRIPTION
store last reconciled state and calculate diff before expanding.
It allows correctly manage cluster expanding status and better detect
changes. Maybe useful later for removing deleted configuration options.

format meanfull message for failed reason

improve reconcile time for cluster and fix possible bug, when vminsert
couldn't be update, after cluster change.
https://github.com/VictoriaMetrics/operator/issues/493
https://github.com/VictoriaMetrics/operator/issues/426