### PR TITLE
add ability for config-reload to supply authKey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Go parameters
 GOCMD=GO111MODULE=on go
-TAG  ?= 0.1.0
+TAG  ?= 0.2.0
 VERSION=$(TAG)
 VERSION_TRIM=$(VERSION:v%=%)
 GOOS ?= $(shell go env GOOS)

--- a/internal/config-reloader/main.go
+++ b/internal/config-reloader/main.go
@@ -31,6 +31,7 @@ var (
 	watchedDir       = flagutil.NewArray("watched-dir", "directory to watch non-recursively")
 	rulesDir         = flagutil.NewArray("rules-dir", "the same as watched-dir, legacy")
 	reloadURL        = flag.String("reload-url", "http://127.0.0.1:8429/-/reload", "reload URL to trigger config reload")
+	authKey          = flag.String("authKey", "", "authKey for reload endpoint")
 	listenAddr       = flag.String("http.listenAddr", ":8435", "http server listen addr")
 )
 
@@ -88,7 +89,13 @@ type reloader struct {
 }
 
 func (r *reloader) reload(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", *reloadURL, nil)
+	var url string
+	if *authKey != "" {
+		url = fmt.Sprintf("%s?authKey=%s", *reloadURL, *authKey)
+	} else {
+		url = *reloadURL
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ type BaseOperatorConf struct {
 	// enables custom config reloader for vmauth and vmagent,
 	// it should speed-up config reloading process.
 	UseCustomConfigReloader   bool   `default:"false"`
-	CustomConfigReloaderImage string `default:"victoriametrics/operator:config-reloader-0.1.0"`
+	CustomConfigReloaderImage string `default:"victoriametrics/operator:config-reloader-0.2.0"`
 	PSPAutoCreateEnabled      bool   `default:"true"`
 	VMAlertDefault            struct {
 		Image               string `default:"victoriametrics/vmalert"`


### PR DESCRIPTION
VMAgent and VMAuth allow authKeys for the reload endpoint. This adds the ability for the config-reload to supply such an authKey.