### PR TITLE
Add global setting to override container registry

### DIFF
--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -203,7 +203,7 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 
 	cr = cr.DeepCopy()
 
-	image := fmt.Sprintf("%s:%s", cr.Spec.Image.Repository, cr.Spec.Image.Tag)
+	image := fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.Image.Repository, cr.Spec.Image.Tag)
 
 	amArgs := []string{
 		fmt.Sprintf("--config.file=%s", alertmanagerConfFile),
@@ -423,7 +423,7 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 		vmaContainer,
 		{
 			Name:  "config-reloader",
-			Image: c.VMAlertManager.ConfigReloaderImage,
+			Image: fmt.Sprintf("%s/%s", c.ContainerRegistry, c.VMAlertManager.ConfigReloaderImage),
 			Args: []string{
 				fmt.Sprintf("-webhook-url=%s", localReloadURL),
 				fmt.Sprintf("-volume-dir=%s", alertmanagerConfDir),

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -445,7 +445,7 @@ func makeSpecForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOperat
 
 	vmagentContainer := corev1.Container{
 		Name:                     "vmagent",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.Image.Repository, cr.Spec.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.Image.Repository, cr.Spec.Image.Tag),
 		ImagePullPolicy:          cr.Spec.Image.PullPolicy,
 		Ports:                    ports,
 		Args:                     args,
@@ -1094,7 +1094,7 @@ func buildConfigReloaderContainer(cr *victoriametricsv1beta1.VMAgent, c *config.
 	configReloadArgs := buildConfigReloaderArgs(cr, c)
 	cntr := corev1.Container{
 		Name:                     "config-reloader",
-		Image:                    c.VMAgentDefault.ConfigReloadImage,
+		Image:                    fmt.Sprintf("%s/%s", c.ContainerRegistry, c.VMAgentDefault.ConfigReloadImage),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		Env: []corev1.EnvVar{
 			{
@@ -1110,7 +1110,7 @@ func buildConfigReloaderContainer(cr *victoriametricsv1beta1.VMAgent, c *config.
 		Resources:    configReloaderResources,
 	}
 	if c.UseCustomConfigReloader {
-		cntr.Image = c.CustomConfigReloaderImage
+		cntr.Image = fmt.Sprintf("%s/%s", c.ContainerRegistry, c.CustomConfigReloaderImage)
 		cntr.Command = []string{"/usr/local/bin/config-reloader"}
 	}
 	return cntr

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -317,7 +317,7 @@ func vmAlertSpecGen(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOperatorCo
 	vmalertContainer := corev1.Container{
 		Args:                     args,
 		Name:                     "vmalert",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.Image.Repository, cr.Spec.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.Image.Repository, cr.Spec.Image.Tag),
 		ImagePullPolicy:          cr.Spec.Image.PullPolicy,
 		Ports:                    ports,
 		VolumeMounts:             volumeMounts,
@@ -329,7 +329,7 @@ func vmAlertSpecGen(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOperatorCo
 
 	vmalertContainers := []corev1.Container{vmalertContainer, {
 		Name:                     "config-reloader",
-		Image:                    c.VMAlertDefault.ConfigReloadImage,
+		Image:                    fmt.Sprintf("%s/%s", c.ContainerRegistry, c.VMAlertDefault.ConfigReloadImage),
 		Args:                     confReloadArgs,
 		Resources:                resources,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,

--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -232,7 +232,7 @@ func makeSpecForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperator
 
 	vmauthContainer := corev1.Container{
 		Name:                     "vmauth",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.Image.Repository, cr.Spec.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.Image.Repository, cr.Spec.Image.Tag),
 		Ports:                    ports,
 		Args:                     args,
 		VolumeMounts:             vmMounts,
@@ -462,7 +462,7 @@ func buildVMAuthConfigReloaderContainer(cr *victoriametricsv1beta1.VMAuth, c *co
 
 	configReloader := corev1.Container{
 		Name:                     "config-reloader",
-		Image:                    c.VMAuthDefault.ConfigReloadImage,
+		Image:                    fmt.Sprintf("%s/%s", c.ContainerRegistry, c.VMAuthDefault.ConfigReloadImage),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		Env: []corev1.EnvVar{
 			{
@@ -479,7 +479,7 @@ func buildVMAuthConfigReloaderContainer(cr *victoriametricsv1beta1.VMAuth, c *co
 	}
 
 	if c.UseCustomConfigReloader {
-		configReloader.Image = c.CustomConfigReloaderImage
+		configReloader.Image = fmt.Sprintf("%s/%s", c.ContainerRegistry, c.CustomConfigReloaderImage)
 		configReloader.Command = []string{"/usr/local/bin/config-reloader"}
 	}
 	return configReloader

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -484,7 +484,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 	sort.Strings(args)
 	vmselectContainer := corev1.Container{
 		Name:                     "vmselect",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.VMSelect.Image.Repository, cr.Spec.VMSelect.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.VMSelect.Image.Repository, cr.Spec.VMSelect.Image.Tag),
 		ImagePullPolicy:          cr.Spec.VMSelect.Image.PullPolicy,
 		Ports:                    ports,
 		Args:                     args,
@@ -755,7 +755,7 @@ func makePodSpecForVMInsert(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 
 	vminsertContainer := corev1.Container{
 		Name:                     "vminsert",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.VMInsert.Image.Repository, cr.Spec.VMInsert.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.VMInsert.Image.Repository, cr.Spec.VMInsert.Image.Tag),
 		ImagePullPolicy:          cr.Spec.VMInsert.Image.PullPolicy,
 		Ports:                    ports,
 		Args:                     args,
@@ -1041,7 +1041,7 @@ func makePodSpecForVMStorage(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) 
 	sort.Strings(args)
 	vmstorageContainer := corev1.Container{
 		Name:                     "vmstorage",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.VMStorage.Image.Repository, cr.Spec.VMStorage.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.VMStorage.Image.Repository, cr.Spec.VMStorage.Image.Tag),
 		ImagePullPolicy:          cr.Spec.VMStorage.Image.PullPolicy,
 		Ports:                    ports,
 		Args:                     args,

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -257,7 +257,7 @@ func makeSpecForVMSingle(cr *victoriametricsv1beta1.VMSingle, c *config.BaseOper
 	sort.Strings(args)
 	vmsingleContainer := corev1.Container{
 		Name:                     "vmsingle",
-		Image:                    fmt.Sprintf("%s:%s", cr.Spec.Image.Repository, cr.Spec.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Spec.Image.Repository, cr.Spec.Image.Tag),
 		Ports:                    ports,
 		Args:                     args,
 		VolumeMounts:             vmMounts,
@@ -488,7 +488,7 @@ func makeSpecForVMBackuper(
 	sort.Strings(args)
 	vmBackuper := &corev1.Container{
 		Name:                     "vmbackuper",
-		Image:                    fmt.Sprintf("%s:%s", cr.Image.Repository, cr.Image.Tag),
+		Image:                    fmt.Sprintf("%s/%s:%s", c.ContainerRegistry, cr.Image.Repository, cr.Image.Tag),
 		Ports:                    ports,
 		Args:                     args,
 		Env:                      extraEnvs,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type BaseOperatorConf struct {
 	// enables custom config reloader for vmauth and vmagent,
 	// it should speed-up config reloading process.
 	UseCustomConfigReloader   bool   `default:"false"`
+	ContainerRegistry         string `default:"docker.io"`
 	CustomConfigReloaderImage string `default:"victoriametrics/operator:config-reloader-0.1.0"`
 	PSPAutoCreateEnabled      bool   `default:"true"`
 	VMAlertDefault            struct {


### PR DESCRIPTION
This adresses #498. Tested by deploying the compiled operator with
```
      env:
      - name: VM_CONTAINERREGISTRY
        value: harbor.local/docker.io
```
and then deploying a VMSingle instance copy&paste from https://docs.victoriametrics.com/operator/quick-start.html, resulting in
```
philipp@ ~ $ k get deployment vmsingle-example-vmsingle-persisted -o yaml | grep image:
        image: harbor.local/docker.io/victoriametrics/victoria-metrics:v1.77.2
philipp@ ~ $
```