### PR TITLE
vmalertmanager: fix extraArgs, add two dashes

### DIFF
--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -238,11 +238,11 @@ type VMAlertmanagerSpec struct {
 	// If both nil - behaviour controlled by selectAllByDefault
 	// +optional
 	ConfigNamespaceSelector *metav1.LabelSelector `json:"configNamespaceSelector,omitempty"`
-	// ExtraArgs that will be passed to  VMAuth pod
-	// for example remoteWrite.tmpDataPath: /tmp
+	// ExtraArgs that will be passed to  VMAlertmanager pod
+	// for example log.level: debug
 	// +optional
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
-	// ExtraEnvs that will be added to VMAuth pod
+	// ExtraEnvs that will be added to VMAlertmanager pod
 	// +optional
 	ExtraEnvs []v1.EnvVar `json:"extraEnvs,omitempty"`
 

--- a/api/victoriametrics/v1beta1/vmalertmanager_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanager_types.go
@@ -238,11 +238,11 @@ type VMAlertmanagerSpec struct {
 	// If both nil - behaviour controlled by selectAllByDefault
 	// +optional
 	ConfigNamespaceSelector *metav1.LabelSelector `json:"configNamespaceSelector,omitempty"`
-	// ExtraArgs that will be passed to  VMAuth pod
+	// ExtraArgs that will be passed to  VMAlertManager pod
 	// for example remoteWrite.tmpDataPath: /tmp
 	// +optional
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
-	// ExtraEnvs that will be added to VMAuth pod
+	// ExtraEnvs that will be added to VMAlertManager pod
 	// +optional
 	ExtraEnvs []v1.EnvVar `json:"extraEnvs,omitempty"`
 

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -246,11 +246,11 @@ spec:
               extraArgs:
                 additionalProperties:
                   type: string
-                description: 'ExtraArgs that will be passed to  VMAuth pod for example
-                  remoteWrite.tmpDataPath: /tmp'
+                description: 'ExtraArgs that will be passed to  VMAlertmanager pod for example
+                  log.level: debug'
                 type: object
               extraEnvs:
-                description: ExtraEnvs that will be added to VMAuth pod
+                description: ExtraEnvs that will be added to VMAlertmanager pod
                 items:
                   description: EnvVar represents an environment variable present in
                     a Container.

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -242,11 +242,11 @@ spec:
             extraArgs:
               additionalProperties:
                 type: string
-              description: 'ExtraArgs that will be passed to  VMAuth pod for example
-                remoteWrite.tmpDataPath: /tmp'
+              description: 'ExtraArgs that will be passed to  VMAlertmanager pod for example
+                log.level: debug'
               type: object
             extraEnvs:
-              description: ExtraEnvs that will be added to VMAuth pod
+              description: ExtraEnvs that will be added to VMAlertmanager pod
               items:
                 description: EnvVar represents an environment variable present in
                   a Container.

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -391,7 +391,7 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 		return path.Clean(webRoutePrefix + "/-/healthy")
 	}
 
-	amArgs = addExtraArgsOverrideDefaults(amArgs, cr.Spec.ExtraArgs)
+	amArgs = addExtraArgsOverrideDefaults(amArgs, cr.Spec.ExtraArgs, "--")
 	sort.Strings(amArgs)
 
 	envs := []v1.EnvVar{

--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -430,14 +430,15 @@ func CreateOrUpdatePodDisruptionBudget(ctx context.Context, rclient client.Clien
 // addExtraArgsOverrideDefaults adds extraArgs for given source args
 // it trims in-place args if it was set via extraArgs
 // no need to check for extraEnvs, it has priority over args at VictoriaMetrics apps
-func addExtraArgsOverrideDefaults(args []string, extraArgs map[string]string) []string {
+// dashes is either "-" or "--", depending on the process. altermanager needs two dashes.
+func addExtraArgsOverrideDefaults(args []string, extraArgs map[string]string, dashes string) []string {
 	if len(extraArgs) == 0 {
 		// fast path
 		return args
 	}
 	cleanArg := func(arg string) string {
-		if idx := strings.IndexByte(arg, '-'); idx >= 0 {
-			arg = arg[idx+1:]
+		if idx := strings.Index(arg, dashes); idx == 0 {
+			arg = arg[len(dashes):]
 		}
 		idx := strings.IndexByte(arg, '=')
 		if idx > 0 {
@@ -460,9 +461,9 @@ func addExtraArgsOverrideDefaults(args []string, extraArgs map[string]string) []
 	for argKey, argValue := range extraArgs {
 		// special hack for https://github.com/VictoriaMetrics/VictoriaMetrics/issues/1145
 		if argKey == "rule" {
-			args = append(args, fmt.Sprintf("-%s=%q", argKey, argValue))
+			args = append(args, fmt.Sprintf("%s%s=%q", dashes, argKey, argValue))
 		} else {
-			args = append(args, fmt.Sprintf("-%s=%s", argKey, argValue))
+			args = append(args, fmt.Sprintf("%s%s=%s", dashes, argKey, argValue))
 		}
 	}
 	return args

--- a/controllers/factory/builders_test.go
+++ b/controllers/factory/builders_test.go
@@ -505,6 +505,7 @@ func Test_addExtraArgsOverrideDefaults(t *testing.T) {
 	type args struct {
 		args      []string
 		extraArgs map[string]string
+		dashes    string
 	}
 	tests := []struct {
 		name string
@@ -514,7 +515,8 @@ func Test_addExtraArgsOverrideDefaults(t *testing.T) {
 		{
 			name: "no changes",
 			args: args{
-				args: []string{"-http.ListenAddr=:8081"},
+				args:   []string{"-http.ListenAddr=:8081"},
+				dashes: "-",
 			},
 			want: []string{"-http.ListenAddr=:8081"},
 		},
@@ -523,6 +525,7 @@ func Test_addExtraArgsOverrideDefaults(t *testing.T) {
 			args: args{
 				args:      []string{"-http.ListenAddr=:8081"},
 				extraArgs: map[string]string{"http.ListenAddr": "127.0.0.1:8085"},
+				dashes:    "-",
 			},
 			want: []string{"-http.ListenAddr=127.0.0.1:8085"},
 		},
@@ -531,13 +534,36 @@ func Test_addExtraArgsOverrideDefaults(t *testing.T) {
 			args: args{
 				args:      []string{"-http.ListenAddr=:8081", "-promscrape.config=/opt/vmagent.yml"},
 				extraArgs: map[string]string{"http.ListenAddr": "127.0.0.1:8085"},
+				dashes:    "-",
 			},
 			want: []string{"-promscrape.config=/opt/vmagent.yml", "-http.ListenAddr=127.0.0.1:8085"},
+		},
+		{
+			name: "two dashes, extend",
+			args: args{
+				args:      []string{"--web.timeout=0"},
+				extraArgs: map[string]string{"log.level": "debug"},
+				dashes:    "--",
+			},
+			want: []string{"--web.timeout=0", "--log.level=debug"},
+		},
+		{
+			name: "two dashes, override default",
+			args: args{
+				args:      []string{"--log.level=info"},
+				extraArgs: map[string]string{"log.level": "debug"},
+				dashes:    "--",
+			},
+			want: []string{"--log.level=debug"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, addExtraArgsOverrideDefaults(tt.args.args, tt.args.extraArgs), "addExtraArgsOverrideDefaults(%v, %v)", tt.args.args, tt.args.extraArgs)
+			assert.Equalf(
+				t,
+				tt.want,
+				addExtraArgsOverrideDefaults(tt.args.args, tt.args.extraArgs, tt.args.dashes),
+				"addExtraArgsOverrideDefaults(%v, %v)", tt.args.args, tt.args.extraArgs)
 		})
 	}
 }

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -440,7 +440,7 @@ func makeSpecForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOperat
 		// limit to 1GB
 		args = append(args, "-remoteWrite.maxDiskUsagePerURL=1073741824")
 	}
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs, "-")
 	sort.Strings(args)
 
 	vmagentContainer := corev1.Container{

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -479,7 +479,7 @@ func buildVMAlertArgs(cr *victoriametricsv1beta1.VMAlert, ruleConfigMapNames []s
 	if len(cr.Spec.ExtraEnvs) > 0 {
 		args = append(args, "-envflag.enable=true")
 	}
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs, "-")
 	sort.Strings(args)
 	return args
 }

--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -227,7 +227,7 @@ func makeSpecForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperator
 		})
 	}
 
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs, "-")
 	sort.Strings(args)
 
 	vmauthContainer := corev1.Container{

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -480,7 +480,7 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		})
 	}
 
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMSelect.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMSelect.ExtraArgs, "-")
 	sort.Strings(args)
 	vmselectContainer := corev1.Container{
 		Name:                     "vmselect",
@@ -750,7 +750,7 @@ func makePodSpecForVMInsert(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 			MountPath: path.Join(ConfigMapsDir, c),
 		})
 	}
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMInsert.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMInsert.ExtraArgs, "-")
 	sort.Strings(args)
 
 	vminsertContainer := corev1.Container{
@@ -1037,7 +1037,7 @@ func makePodSpecForVMStorage(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) 
 		})
 	}
 
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMStorage.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.VMStorage.ExtraArgs, "-")
 	sort.Strings(args)
 	vmstorageContainer := corev1.Container{
 		Name:                     "vmstorage",

--- a/controllers/factory/vmsingle.go
+++ b/controllers/factory/vmsingle.go
@@ -253,7 +253,7 @@ func makeSpecForVMSingle(cr *victoriametricsv1beta1.VMSingle, c *config.BaseOper
 		})
 	}
 
-	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs)
+	args = addExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs, "-")
 	sort.Strings(args)
 	vmsingleContainer := corev1.Container{
 		Name:                     "vmsingle",


### PR DESCRIPTION
    addExtraArgsOverrideDefaults: add dashes argument
    
    Set it to `-` for all VictoriaMetrics processes, and to `--` for
    alertmanager.
    
    This fixes ExtraArgs in the VMAlertmanager resource. Previously, their
    keys had to start with an extra `-`.

--

    api/*/vmalertmanager_types.go: fix description for ExtraArgs, ExtraEnvs
    
    This is not about VMAuth, but VMAlertmanager.


Fixes #502.