### PR TITLE
Fix crash on Kubernetes 1.25

### DIFF
--- a/controllers/vmalertmanager_controller.go
+++ b/controllers/vmalertmanager_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -117,7 +116,6 @@ func (r *VMAlertmanagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&victoriametricsv1beta1.VMServiceScrape{}, builder.OnlyMetadata).
 		Owns(&v1.Secret{}, builder.OnlyMetadata).
 		Owns(&v1.ServiceAccount{}, builder.OnlyMetadata).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
 		WithOptions(defaultOptions).
 		Complete(r)
 }


### PR DESCRIPTION
On Kubernetes 1.25, the operator gets into a crash loop, because it tries to get policyv1beta1.PodDisruptionBudget, but it is removed in 1.25. This PR fixes that issue.

Since other resources don't have `Owns(&policyv1beta1.PodDisruptionBudget{})`, I opted to remove it. In case that is not the direction we want to go about it, feel free to change it.