### PR TITLE
.github/workflows: Update golangci version to latest v1.50.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           go install  golang.org/x/lint/golint@latest
           go install github.com/kisielk/errcheck@latest
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
           curl -L -o operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v1.0.0/operator-sdk-v1.0.0-x86_64-linux-gnu"
           chmod +x operator-sdk
           sudo mv operator-sdk /bin/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           go install golang.org/x/lint/golint@latest
           go install github.com/kisielk/errcheck@latest
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
           curl -L -o operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v1.0.0/operator-sdk-v1.0.0-x86_64-linux-gnu"
           chmod +x operator-sdk
           sudo mv operator-sdk /bin/


### PR DESCRIPTION
This PR will update golangci-lint version to the latest [v1.50.1](https://github.com/golangci/golangci-lint/releases/tag/v1.50.1)