### PR TITLE
Expose no_stale_markers through vm_scrape_params

### DIFF
--- a/api/v1beta1/vmservicescrape_types.go
+++ b/api/v1beta1/vmservicescrape_types.go
@@ -193,6 +193,8 @@ type VMScrapeParams struct {
 	// +optional
 	DisableKeepAlive *bool `json:"disable_keep_alive,omitempty"`
 	// +optional
+	DisableStaleMarkers *bool `json:"no_stale_markers,omitempty"`
+	// +optional
 	StreamParse *bool `json:"stream_parse,omitempty"`
 	// +optional
 	ScrapeAlignInterval *string `json:"scrape_align_interval,omitempty"`

--- a/api/victoriametrics/v1beta1/vmservicescrape_types.go
+++ b/api/victoriametrics/v1beta1/vmservicescrape_types.go
@@ -193,6 +193,8 @@ type VMScrapeParams struct {
 	// +optional
 	DisableKeepAlive *bool `json:"disable_keep_alive,omitempty"`
 	// +optional
+	DisableStaleMarkers *bool `json:"no_stale_markers,omitempty"`
+	// +optional
 	StreamParse *bool `json:"stream_parse,omitempty"`
 	// +optional
 	ScrapeAlignInterval *string `json:"scrape_align_interval,omitempty"`

--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -1337,6 +1337,7 @@ func buildVMScrapeParams(namespace, cacheKey string, cfg *victoriametricsv1beta1
 	toYaml("stream_parse", cfg.StreamParse)
 	toYaml("disable_compression", cfg.DisableCompression)
 	toYaml("scrape_offset", cfg.ScrapeOffset)
+	toYaml("no_stale_markers", cfg.DisableStaleMarkers)
 	toYaml("disable_keep_alive", cfg.DisableKeepAlive)
 	toYaml("relabel_debug", cfg.RelabelDebug)
 	toYaml("metric_relabel_debug", cfg.MetricRelabelDebug)


### PR DESCRIPTION
Small attempt to implement VictoriaMetrics/VictoriaMetrics#3292 myself.

Gave it a shot by deploying
```yaml
apiVersion: operator.victoriametrics.com/v1beta1
kind: VMStaticScrape
metadata:
  name: no-stale-marker-test
spec:
  targetEndpoints:
  - path: /metrics
    targets:
    - test.de:1234
    vm_scrape_params:
      no_stale_markers: false
```
and got 
```yaml
scrape_configs:
...
- job_name: staticScrape/default/no-stale-marker-test/0
  metrics_path: /metrics
  static_configs:
  - targets:
    - test.de:1234
  no_stale_markers: false
```
in my VMAgent's config.