### PR TITLE
api: changes errors handling for objects unmarshal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,14 @@ fix118_yaml:
 	CRD_NAME=vmclusters YAML_DROP_PREFIX=$(YAML_DROP_PREFIX).vmselect.properties $(MAKE) patch_crd_yaml
 	CRD_NAME=vmclusters YAML_DROP_PREFIX=$(YAML_DROP_PREFIX).vmstorage.properties $(MAKE) patch_crd_yaml
 	docker run --rm -v "${PWD}":/workdir mikefarah/yq:2.2.0 /bin/sh -c " \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmsingles.yaml $(YAML_DROP_PREFIX).'-'   \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmclusters.yaml $(YAML_DROP_PREFIX).'-'   \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmauths.yaml $(YAML_DROP_PREFIX).'-'   \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalerts.yaml $(YAML_DROP_PREFIX).'-'   \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmagents.yaml $(YAML_DROP_PREFIX).'-'   \
+ 	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalertmanagers.yaml $(YAML_DROP_PREFIX).'-'   \
+  	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalertmanagerconfigs.yaml $(YAML_DROP_PREFIX).'-'   "
+	docker run --rm -v "${PWD}":/workdir mikefarah/yq:2.2.0 /bin/sh -c " \
         $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalertmanagerconfigs.yaml $(YAML_DROP_PREFIX).receivers.items.properties.opsgenie_configs.items.properties.http_config.properties &&\
 	    $(YAML_ADD) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalertmanagerconfigs.yaml $(YAML_DROP_PREFIX).receivers.items.properties.opsgenie_configs.items.properties.http_config.$(CRD_PRESERVE) &&\
 	    $(YAML_DROP) $(CRD_FIX_PATH)/operator.victoriametrics.com_vmalerts.yaml $(YAML_DROP_PREFIX).datasource.properties.OAuth2.properties &&\

--- a/api/v1beta1/vmagent_webhook.go
+++ b/api/v1beta1/vmagent_webhook.go
@@ -76,12 +76,14 @@ func (cr *VMAgent) sanityCheck() error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAgent) ValidateCreate() error {
-	vmagentlog.Info("validate create", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAgent) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 
@@ -89,12 +91,14 @@ func (cr *VMAgent) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAgent) ValidateUpdate(old runtime.Object) error {
-	vmagentlog.Info("validate update", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAgent) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil

--- a/api/v1beta1/vmalert_webhook.go
+++ b/api/v1beta1/vmalert_webhook.go
@@ -47,8 +47,9 @@ func (r *VMAlert) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateCreate() error {
-	vmalertlog.Info("validate create", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -61,8 +62,9 @@ func (r *VMAlert) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateUpdate(old runtime.Object) error {
-	vmalertlog.Info("validate update", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -74,7 +76,6 @@ func (r *VMAlert) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateDelete() error {
-
 	// no-op
 	return nil
 }

--- a/api/v1beta1/vmalertmanager_webhook.go
+++ b/api/v1beta1/vmalertmanager_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -26,7 +27,9 @@ func (r *VMAlertmanager) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateCreate() error {
-	vmalertmanagerlog.Info("validate create", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -38,7 +41,9 @@ func (r *VMAlertmanager) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateUpdate(old runtime.Object) error {
-	vmalertmanagerlog.Info("validate update", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -50,7 +55,6 @@ func (r *VMAlertmanager) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateDelete() error {
-
 	// no-op
 	return nil
 }

--- a/api/v1beta1/vmalertmanagerconfig_webhook.go
+++ b/api/v1beta1/vmalertmanagerconfig_webhook.go
@@ -46,23 +46,33 @@ var _ webhook.Validator = &VMAlertmanagerConfig{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateCreate() error {
-	vmalertmanagerconfiglog.Info("validate create", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
+		return nil
+	}
+	if err := r.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateUpdate(old runtime.Object) error {
-	vmalertmanagerconfiglog.Info("validate update", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object update.
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
+		return nil
+	}
+	if err := r.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateDelete() error {
-	vmalertmanagerconfiglog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }

--- a/api/v1beta1/vmauth_webhook.go
+++ b/api/v1beta1/vmauth_webhook.go
@@ -39,6 +39,7 @@ func (r *VMAuth) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Validator = &VMAuth{}
 
 func (cr *VMAuth) sanityCheck() error {
+
 	if cr.Spec.Ingress != nil {
 		// check ingress
 		ing := cr.Spec.Ingress
@@ -50,24 +51,28 @@ func (cr *VMAuth) sanityCheck() error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAuth) ValidateCreate() error {
-	vmauthlog.Info("validate create", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAuth) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAuth) ValidateUpdate(old runtime.Object) error {
-	vmauthlog.Info("validate update", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAuth) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil
@@ -75,7 +80,5 @@ func (cr *VMAuth) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAuth) ValidateDelete() error {
-	vmauthlog.Info("validate delete", "name", r.Name)
-
 	return nil
 }

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -33,6 +33,8 @@ const (
 // VMClusterSpec defines the desired state of VMCluster
 // +k8s:openapi-gen=true
 type VMClusterSpec struct {
+	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingError string `json:"-,omitempty" yaml:"-,omitempty"`
 	// RetentionPeriod for the stored metrics
 	// Note VictoriaMetrics has data/ and indexdb/ folders
 	// metrics from data/ removed eventually as soon as partition leaves retention period
@@ -68,6 +70,16 @@ type VMClusterSpec struct {
 	VMInsert *VMInsert `json:"vminsert,omitempty"`
 	// +optional
 	VMStorage *VMStorage `json:"vmstorage,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMClusterSpec) UnmarshalJSON(src []byte) error {
+	type pcr VMClusterSpec
+	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
+		cr.ParsingError = fmt.Sprintf("cannot parse vmcluster spec: %s, err: %s", string(src), err)
+		return nil
+	}
+	return nil
 }
 
 // VMCluster is fast, cost-effective and scalable time-series database.

--- a/api/v1beta1/vmcluster_webhook.go
+++ b/api/v1beta1/vmcluster_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,6 +46,9 @@ func (r *VMCluster) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMCluster) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -57,6 +61,9 @@ func (r *VMCluster) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMCluster) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}

--- a/api/v1beta1/vmsingle_webhook.go
+++ b/api/v1beta1/vmsingle_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -27,7 +28,9 @@ func (r *VMSingle) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSingle) ValidateCreate() error {
-	vmsinglelog.Info("validate create", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -39,7 +42,9 @@ func (r *VMSingle) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSingle) ValidateUpdate(old runtime.Object) error {
-	vmsinglelog.Info("validate update", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}

--- a/api/v1beta1/vmuser_webhook.go
+++ b/api/v1beta1/vmuser_webhook.go
@@ -74,7 +74,6 @@ func (cr *VMUser) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (cr *VMUser) ValidateCreate() error {
-	vmuserlog.Info("validate create", "name", cr.Name)
 	if mustSkipValidation(cr) {
 		return nil
 	}
@@ -86,7 +85,6 @@ func (cr *VMUser) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (cr *VMUser) ValidateUpdate(old runtime.Object) error {
-	vmuserlog.Info("validate update", "name", cr.Name)
 	if mustSkipValidation(cr) {
 		return nil
 	}
@@ -98,7 +96,5 @@ func (cr *VMUser) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMUser) ValidateDelete() error {
-	vmuserlog.Info("validate delete", "name", r.Name)
-
 	return nil
 }

--- a/api/victoriametrics/v1beta1/vmagent_webhook.go
+++ b/api/victoriametrics/v1beta1/vmagent_webhook.go
@@ -76,12 +76,14 @@ func (cr *VMAgent) sanityCheck() error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAgent) ValidateCreate() error {
-	vmagentlog.Info("validate create", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAgent) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 
@@ -89,12 +91,14 @@ func (cr *VMAgent) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAgent) ValidateUpdate(old runtime.Object) error {
-	vmagentlog.Info("validate update", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAgent) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil

--- a/api/victoriametrics/v1beta1/vmalert_webhook.go
+++ b/api/victoriametrics/v1beta1/vmalert_webhook.go
@@ -47,8 +47,9 @@ func (r *VMAlert) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateCreate() error {
-	vmalertlog.Info("validate create", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -61,8 +62,9 @@ func (r *VMAlert) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateUpdate(old runtime.Object) error {
-	vmalertlog.Info("validate update", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -74,7 +76,6 @@ func (r *VMAlert) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlert) ValidateDelete() error {
-
 	// no-op
 	return nil
 }

--- a/api/victoriametrics/v1beta1/vmalertmanager_webhook.go
+++ b/api/victoriametrics/v1beta1/vmalertmanager_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -26,7 +27,9 @@ func (r *VMAlertmanager) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateCreate() error {
-	vmalertmanagerlog.Info("validate create", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -38,7 +41,9 @@ func (r *VMAlertmanager) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateUpdate(old runtime.Object) error {
-	vmalertmanagerlog.Info("validate update", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -50,7 +55,6 @@ func (r *VMAlertmanager) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanager) ValidateDelete() error {
-
 	// no-op
 	return nil
 }

--- a/api/victoriametrics/v1beta1/vmalertmanagerconfig_webhook.go
+++ b/api/victoriametrics/v1beta1/vmalertmanagerconfig_webhook.go
@@ -46,23 +46,33 @@ var _ webhook.Validator = &VMAlertmanagerConfig{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateCreate() error {
-	vmalertmanagerconfiglog.Info("validate create", "name", r.Name)
-
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
+		return nil
+	}
+	if err := r.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateUpdate(old runtime.Object) error {
-	vmalertmanagerconfiglog.Info("validate update", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object update.
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
+		return nil
+	}
+	if err := r.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAlertmanagerConfig) ValidateDelete() error {
-	vmalertmanagerconfiglog.Info("validate delete", "name", r.Name)
-
-	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }

--- a/api/victoriametrics/v1beta1/vmauth_webhook.go
+++ b/api/victoriametrics/v1beta1/vmauth_webhook.go
@@ -39,6 +39,7 @@ func (r *VMAuth) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Validator = &VMAuth{}
 
 func (cr *VMAuth) sanityCheck() error {
+
 	if cr.Spec.Ingress != nil {
 		// check ingress
 		ing := cr.Spec.Ingress
@@ -50,24 +51,28 @@ func (cr *VMAuth) sanityCheck() error {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAuth) ValidateCreate() error {
-	vmauthlog.Info("validate create", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAuth) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (cr *VMAuth) ValidateUpdate(old runtime.Object) error {
-	vmauthlog.Info("validate update", "name", cr.Name)
-	if mustSkipValidation(cr) {
+func (r *VMAuth) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
+	if mustSkipValidation(r) {
 		return nil
 	}
-	if err := cr.sanityCheck(); err != nil {
+	if err := r.sanityCheck(); err != nil {
 		return err
 	}
 	return nil
@@ -75,7 +80,5 @@ func (cr *VMAuth) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMAuth) ValidateDelete() error {
-	vmauthlog.Info("validate delete", "name", r.Name)
-
 	return nil
 }

--- a/api/victoriametrics/v1beta1/vmcluster_types.go
+++ b/api/victoriametrics/v1beta1/vmcluster_types.go
@@ -33,6 +33,8 @@ const (
 // VMClusterSpec defines the desired state of VMCluster
 // +k8s:openapi-gen=true
 type VMClusterSpec struct {
+	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingError string `json:"-,omitempty" yaml:"-,omitempty"`
 	// RetentionPeriod for the stored metrics
 	// Note VictoriaMetrics has data/ and indexdb/ folders
 	// metrics from data/ removed eventually as soon as partition leaves retention period
@@ -49,7 +51,7 @@ type VMClusterSpec struct {
 	PodSecurityPolicyName string `json:"podSecurityPolicyName,omitempty"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
-	// VMSelect Pods.
+	// VMSelect, VMStorage and VMInsert Pods.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
@@ -68,6 +70,16 @@ type VMClusterSpec struct {
 	VMInsert *VMInsert `json:"vminsert,omitempty"`
 	// +optional
 	VMStorage *VMStorage `json:"vmstorage,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMClusterSpec) UnmarshalJSON(src []byte) error {
+	type pcr VMClusterSpec
+	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
+		cr.ParsingError = fmt.Sprintf("cannot parse vmcluster spec: %s, err: %s", string(src), err)
+		return nil
+	}
+	return nil
 }
 
 // VMCluster is fast, cost-effective and scalable time-series database.

--- a/api/victoriametrics/v1beta1/vmcluster_webhook.go
+++ b/api/victoriametrics/v1beta1/vmcluster_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,6 +46,9 @@ func (r *VMCluster) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMCluster) ValidateCreate() error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -57,6 +61,9 @@ func (r *VMCluster) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMCluster) ValidateUpdate(old runtime.Object) error {
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}

--- a/api/victoriametrics/v1beta1/vmsingle_webhook.go
+++ b/api/victoriametrics/v1beta1/vmsingle_webhook.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -27,7 +28,9 @@ func (r *VMSingle) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSingle) ValidateCreate() error {
-	vmsinglelog.Info("validate create", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}
@@ -39,7 +42,9 @@ func (r *VMSingle) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *VMSingle) ValidateUpdate(old runtime.Object) error {
-	vmsinglelog.Info("validate update", "name", r.Name)
+	if r.Spec.ParsingError != "" {
+		return fmt.Errorf(r.Spec.ParsingError)
+	}
 	if mustSkipValidation(r) {
 		return nil
 	}

--- a/api/victoriametrics/v1beta1/vmuser_webhook.go
+++ b/api/victoriametrics/v1beta1/vmuser_webhook.go
@@ -74,7 +74,6 @@ func (cr *VMUser) sanityCheck() error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (cr *VMUser) ValidateCreate() error {
-	vmuserlog.Info("validate create", "name", cr.Name)
 	if mustSkipValidation(cr) {
 		return nil
 	}
@@ -86,7 +85,6 @@ func (cr *VMUser) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (cr *VMUser) ValidateUpdate(old runtime.Object) error {
-	vmuserlog.Info("validate update", "name", cr.Name)
 	if mustSkipValidation(cr) {
 		return nil
 	}
@@ -98,7 +96,5 @@ func (cr *VMUser) ValidateUpdate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *VMUser) ValidateDelete() error {
-	vmuserlog.Info("validate delete", "name", r.Name)
-
 	return nil
 }

--- a/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -35,6 +35,10 @@ spec:
           spec:
             description: VMAgentSpec defines the desired state of VMAgent
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               aPIServerConfig:
                 description: APIServerConfig allows specifying a host and auth methods
                   to access apiserver. If left empty, VMAgent is assumed to run inside

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
@@ -34,6 +34,10 @@ spec:
           spec:
             description: VMAlertmanagerConfigSpec defines configuration for VMAlertmanagerConfig
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               inhibit_rules:
                 description: InhibitRules will only apply for alerts matching the
                   resource's namespace.

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -48,6 +48,10 @@ spec:
             description: 'Specification of the desired behavior of the VMAlertmanager
               cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               additionalPeers:
                 description: AdditionalPeers allows injecting a set of additional
                   Alertmanagers to peer with to form a highly available cluster.

--- a/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -34,6 +34,10 @@ spec:
           spec:
             description: VMAlertSpec defines the desired state of VMAlert
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               affinity:
                 description: Affinity If specified, the pod's scheduling constraints.
                 type: object

--- a/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -33,6 +33,10 @@ spec:
           spec:
             description: VMAuthSpec defines the desired state of VMAuth
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               affinity:
                 description: Affinity If specified, the pod's scheduling constraints.
                 type: object

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -54,6 +54,10 @@ spec:
           spec:
             description: VMClusterSpec defines the desired state of VMCluster
             properties:
+              '-':
+                description: ParsingError contents error with context if operator
+                  was failed to parse json object from kubernetes api server
+                type: string
               clusterVersion:
                 description: ClusterVersion defines default images tag for all components.
                   it can be overwritten with component specific image.tag value.

--- a/config/crd/bases/operator.victoriametrics.com_vmnodescrapes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmnodescrapes.yaml
@@ -567,6 +567,8 @@ spec:
                     type: array
                   metric_relabel_debug:
                     type: boolean
+                  no_stale_markers:
+                    type: boolean
                   proxy_client_config:
                     description: ProxyClientConfig configures proxy auth settings
                       for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/config/crd/bases/operator.victoriametrics.com_vmpodscrapes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmpodscrapes.yaml
@@ -57,6 +57,16 @@ spec:
                   description: PodMetricsEndpoint defines a scrapeable endpoint of
                     a Kubernetes Pod serving Prometheus metrics.
                   properties:
+                    attach_metadata:
+                      description: AttachMetadata configures metadata attaching from
+                        service discovery
+                      properties:
+                        node:
+                          description: 'Node instructs vmagent to add node specific
+                            metadata from service discovery Valid for roles: pod,
+                            endpoints, endpointslice.'
+                          type: boolean
+                      type: object
                     authorization:
                       description: Authorization with http header Authorization
                       properties:
@@ -565,6 +575,8 @@ spec:
                             type: string
                           type: array
                         metric_relabel_debug:
+                          type: boolean
+                        no_stale_markers:
                           type: boolean
                         proxy_client_config:
                           description: ProxyClientConfig configures proxy auth settings

--- a/config/crd/bases/operator.victoriametrics.com_vmprobes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmprobes.yaml
@@ -596,6 +596,8 @@ spec:
                     type: array
                   metric_relabel_debug:
                     type: boolean
+                  no_stale_markers:
+                    type: boolean
                   proxy_client_config:
                     description: ProxyClientConfig configures proxy auth settings
                       for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/config/crd/bases/operator.victoriametrics.com_vmservicescrapes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmservicescrapes.yaml
@@ -51,6 +51,16 @@ spec:
                   description: Endpoint defines a scrapeable endpoint serving Prometheus
                     metrics.
                   properties:
+                    attach_metadata:
+                      description: AttachMetadata configures metadata attaching from
+                        service discovery
+                      properties:
+                        node:
+                          description: 'Node instructs vmagent to add node specific
+                            metadata from service discovery Valid for roles: pod,
+                            endpoints, endpointslice.'
+                          type: boolean
+                      type: object
                     authorization:
                       description: Authorization with http header Authorization
                       properties:
@@ -560,6 +570,8 @@ spec:
                             type: string
                           type: array
                         metric_relabel_debug:
+                          type: boolean
+                        no_stale_markers:
                           type: boolean
                         proxy_client_config:
                           description: ProxyClientConfig configures proxy auth settings

--- a/config/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmstaticscrapes.yaml
@@ -558,6 +558,8 @@ spec:
                           type: array
                         metric_relabel_debug:
                           type: boolean
+                        no_stale_markers:
+                          type: boolean
                         proxy_client_config:
                           description: ProxyClientConfig configures proxy auth settings
                             for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmagents.yaml
@@ -35,6 +35,10 @@ spec:
         spec:
           description: VMAgentSpec defines the desired state of VMAgent
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             aPIServerConfig:
               description: APIServerConfig allows specifying a host and auth methods
                 to access apiserver. If left empty, VMAgent is assumed to run inside

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagerconfigs.yaml
@@ -34,6 +34,10 @@ spec:
         spec:
           description: VMAlertmanagerConfigSpec defines configuration for VMAlertmanagerConfig
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             inhibit_rules:
               description: InhibitRules will only apply for alerts matching the resource's
                 namespace.

--- a/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -47,6 +47,10 @@ spec:
           description: 'Specification of the desired behavior of the VMAlertmanager
             cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             additionalPeers:
               description: AdditionalPeers allows injecting a set of additional Alertmanagers
                 to peer with to form a highly available cluster.

--- a/config/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmalerts.yaml
@@ -34,6 +34,10 @@ spec:
         spec:
           description: VMAlertSpec defines the desired state of VMAlert
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             affinity:
               description: Affinity If specified, the pod's scheduling constraints.
               type: object

--- a/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmauths.yaml
@@ -33,6 +33,10 @@ spec:
         spec:
           description: VMAuthSpec defines the desired state of VMAuth
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             affinity:
               description: Affinity If specified, the pod's scheduling constraints.
               type: object

--- a/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmclusters.yaml
@@ -54,6 +54,10 @@ spec:
         spec:
           description: VMClusterSpec defines the desired state of VMCluster
           properties:
+            '-':
+              description: ParsingError contents error with context if operator was
+                failed to parse json object from kubernetes api server
+              type: string
             clusterVersion:
               description: ClusterVersion defines default images tag for all components.
                 it can be overwritten with component specific image.tag value.

--- a/config/crd/legacy/operator.victoriametrics.com_vmnodescrapes.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmnodescrapes.yaml
@@ -558,6 +558,8 @@ spec:
                   type: array
                 metric_relabel_debug:
                   type: boolean
+                no_stale_markers:
+                  type: boolean
                 proxy_client_config:
                   description: ProxyClientConfig configures proxy auth settings for
                     scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/config/crd/legacy/operator.victoriametrics.com_vmpodscrapes.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmpodscrapes.yaml
@@ -57,6 +57,16 @@ spec:
                 description: PodMetricsEndpoint defines a scrapeable endpoint of a
                   Kubernetes Pod serving Prometheus metrics.
                 properties:
+                  attach_metadata:
+                    description: AttachMetadata configures metadata attaching from
+                      service discovery
+                    properties:
+                      node:
+                        description: 'Node instructs vmagent to add node specific
+                          metadata from service discovery Valid for roles: pod, endpoints,
+                          endpointslice.'
+                        type: boolean
+                    type: object
                   authorization:
                     description: Authorization with http header Authorization
                     properties:
@@ -560,6 +570,8 @@ spec:
                           type: string
                         type: array
                       metric_relabel_debug:
+                        type: boolean
+                      no_stale_markers:
                         type: boolean
                       proxy_client_config:
                         description: ProxyClientConfig configures proxy auth settings

--- a/config/crd/legacy/operator.victoriametrics.com_vmprobes.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmprobes.yaml
@@ -586,6 +586,8 @@ spec:
                   type: array
                 metric_relabel_debug:
                   type: boolean
+                no_stale_markers:
+                  type: boolean
                 proxy_client_config:
                   description: ProxyClientConfig configures proxy auth settings for
                     scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/config/crd/legacy/operator.victoriametrics.com_vmservicescrapes.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmservicescrapes.yaml
@@ -51,6 +51,16 @@ spec:
                 description: Endpoint defines a scrapeable endpoint serving Prometheus
                   metrics.
                 properties:
+                  attach_metadata:
+                    description: AttachMetadata configures metadata attaching from
+                      service discovery
+                    properties:
+                      node:
+                        description: 'Node instructs vmagent to add node specific
+                          metadata from service discovery Valid for roles: pod, endpoints,
+                          endpointslice.'
+                        type: boolean
+                    type: object
                   authorization:
                     description: Authorization with http header Authorization
                     properties:
@@ -555,6 +565,8 @@ spec:
                           type: string
                         type: array
                       metric_relabel_debug:
+                        type: boolean
+                      no_stale_markers:
                         type: boolean
                       proxy_client_config:
                         description: ProxyClientConfig configures proxy auth settings

--- a/config/crd/legacy/operator.victoriametrics.com_vmstaticscrapes.yaml
+++ b/config/crd/legacy/operator.victoriametrics.com_vmstaticscrapes.yaml
@@ -553,6 +553,8 @@ spec:
                         type: array
                       metric_relabel_debug:
                         type: boolean
+                      no_stale_markers:
+                        type: boolean
                       proxy_client_config:
                         description: ProxyClientConfig configures proxy auth settings
                           for scraping See feature description https://docs.victoriametrics.com/vmagent.html#scraping-targets-via-a-proxy

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -3,13 +3,18 @@ package controllers
 import (
 	"flag"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -18,6 +23,29 @@ var cacheSyncTimeout = flag.Duration("controller.cacheSyncTimeout", 3*time.Minut
 var defaultOptions = controller.Options{
 	RateLimiter:      workqueue.NewItemExponentialFailureRateLimiter(2*time.Second, 2*time.Minute),
 	CacheSyncTimeout: *cacheSyncTimeout,
+}
+
+var (
+	parseObjectErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "operator_controller_object_parsing_errors_total",
+		Help: "Counts number of objects, that was failed to parse from json",
+	}, []string{"controller"})
+	parseObjectErrorsInit = sync.Once{}
+)
+
+type objectWithParsingError interface {
+	GetObjectKind() schema.ObjectKind
+	GetObjectMeta() v1.Object
+}
+
+func handleParsingError(parsingErr string, obj objectWithParsingError) (ctrl.Result, error) {
+	parseObjectErrorsInit.Do(func() {
+		metrics.Registry.MustRegister(parseObjectErrorsTotal)
+	})
+	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
+	log.Error(fmt.Errorf(parsingErr), "cannot parse object", "name", obj.GetObjectMeta().GetName(), "namespace", obj.GetObjectMeta().GetNamespace(), "controller", kind)
+	parseObjectErrorsTotal.WithLabelValues(kind).Inc()
+	return ctrl.Result{}, nil
 }
 
 func isSelectorsMatches(sourceCRD, targetCRD client.Object, nsSelector, selector *v1.LabelSelector) (bool, error) {

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -591,6 +591,11 @@ func buildAlertmanagerConfigWithCRDs(ctx context.Context, rclient client.Client,
 			if !item.DeletionTimestamp.IsZero() {
 				continue
 			}
+			if item.Spec.ParsingError != "" {
+				badCfgCount++
+				l.Error(fmt.Errorf(item.Spec.ParsingError), "parsing failed for alertmanager config", "objectName", item.Name)
+				continue
+			}
 			if err := item.Validate(); err != nil {
 				l.Error(err, "validation failed for alertmanager config", "objectName", item.Name)
 				badCfgCount++

--- a/controllers/vmagent_controller.go
+++ b/controllers/vmagent_controller.go
@@ -85,6 +85,11 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		DeregisterObject(instance.Name, instance.Namespace, "vmagent")
 		return ctrl.Result{}, nil
 	}
+
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, instance)
+	}
+
 	RegisterObject(instance.Name, instance.Namespace, "vmagent")
 	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
 		return ctrl.Result{}, err

--- a/controllers/vmalert_controller.go
+++ b/controllers/vmalert_controller.go
@@ -78,6 +78,10 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, instance)
+	}
+
 	RegisterObject(instance.Name, instance.Namespace, "vmalert")
 
 	var needToRequeue bool

--- a/controllers/vmalertmanager_controller.go
+++ b/controllers/vmalertmanager_controller.go
@@ -73,6 +73,11 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		DeregisterObject(instance.Name, instance.Namespace, "vmalertmanager")
 		return ctrl.Result{}, nil
 	}
+
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, instance)
+	}
+
 	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/vmalertmanagerconfig_controller.go
+++ b/controllers/vmalertmanagerconfig_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
@@ -72,10 +71,10 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	l.Info("listed alertmanagers", "count", len(vmams.Items))
 	for _, item := range vmams.Items {
 		am := &item
-		l := l.WithValues("alertmanager", am.Name)
-		if !am.DeletionTimestamp.IsZero() {
+		if !am.DeletionTimestamp.IsZero() || am.Spec.ParsingError != "" {
 			continue
 		}
+		l := l.WithValues("alertmanager", am.Name)
 		ismatch, err := isSelectorsMatches(&instance, am, am.Spec.ConfigNamespaceSelector, am.Spec.ConfigSelector)
 		if err != nil {
 			l.Error(err, "cannot match alertmanager against selector, probably bug")

--- a/controllers/vmauth_controller.go
+++ b/controllers/vmauth_controller.go
@@ -71,6 +71,9 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		DeregisterObject(instance.Name, instance.Namespace, "vmauth")
 		return ctrl.Result{}, nil
 	}
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, &instance)
+	}
 
 	RegisterObject(instance.Name, instance.Namespace, "vmauth")
 

--- a/controllers/vmcluster_controller.go
+++ b/controllers/vmcluster_controller.go
@@ -56,6 +56,9 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		DeregisterObject(instance.Name, instance.Namespace, "vmcluster")
 		return ctrl.Result{}, nil
 	}
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, instance)
+	}
 
 	lastAppliedClusterSpec, err := instance.GetLastAppliedSpec()
 	if err != nil {

--- a/controllers/vmnodescrape_controller.go
+++ b/controllers/vmnodescrape_controller.go
@@ -77,7 +77,7 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	reqLogger.Info("found vmagent objects ", "vmagents count: ", len(vmAgentInstances.Items))
 
 	for _, vmagent := range vmAgentInstances.Items {
-		if vmagent.DeletionTimestamp != nil {
+		if !vmagent.DeletionTimestamp.IsZero() || vmagent.Spec.ParsingError != "" {
 			continue
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)

--- a/controllers/vmpodscrape_controller.go
+++ b/controllers/vmpodscrape_controller.go
@@ -78,7 +78,7 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	reqLogger.Info("found vmagent objects ", "vmagents count: ", len(vmAgentInstances.Items))
 
 	for _, vmagent := range vmAgentInstances.Items {
-		if vmagent.DeletionTimestamp != nil {
+		if !vmagent.DeletionTimestamp.IsZero() || vmagent.Spec.ParsingError != "" {
 			continue
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)

--- a/controllers/vmprobe_controller.go
+++ b/controllers/vmprobe_controller.go
@@ -74,7 +74,7 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	reqLogger.Info("found vmagent objects ", "vmagents count: ", len(vmAgentInstances.Items))
 
 	for _, vmagent := range vmAgentInstances.Items {
-		if vmagent.DeletionTimestamp != nil {
+		if !vmagent.DeletionTimestamp.IsZero() || vmagent.Spec.ParsingError != "" {
 			continue
 		}
 		currentVMagent := &vmagent

--- a/controllers/vmrule_controller.go
+++ b/controllers/vmrule_controller.go
@@ -76,7 +76,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	for _, vmalert := range alertMngs.Items {
-		if vmalert.DeletionTimestamp != nil {
+		if vmalert.DeletionTimestamp != nil || vmalert.Spec.ParsingError != "" {
 			continue
 		}
 		reqLogger.WithValues("vmalert", vmalert.Name)

--- a/controllers/vmservicescrape_controller.go
+++ b/controllers/vmservicescrape_controller.go
@@ -74,7 +74,7 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	for _, vmagent := range vmAgentInstances.Items {
-		if vmagent.DeletionTimestamp != nil {
+		if !vmagent.DeletionTimestamp.IsZero() || vmagent.Spec.ParsingError != "" {
 			continue
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)

--- a/controllers/vmsingle_controller.go
+++ b/controllers/vmsingle_controller.go
@@ -71,6 +71,9 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		DeregisterObject(instance.Name, instance.Namespace, "vmsingle")
 		return ctrl.Result{}, nil
 	}
+	if instance.Spec.ParsingError != "" {
+		return handleParsingError(instance.Spec.ParsingError, instance)
+	}
 	RegisterObject(instance.Name, instance.Namespace, "vmsingle")
 	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
 		return ctrl.Result{}, err

--- a/controllers/vmstaticscrape_controller.go
+++ b/controllers/vmstaticscrape_controller.go
@@ -60,7 +60,7 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	reqLogger.Info("found vmagent objects ", "len: ", len(vmAgentInstances.Items))
 
 	for _, vmagent := range vmAgentInstances.Items {
-		if !vmagent.DeletionTimestamp.IsZero() {
+		if !vmagent.DeletionTimestamp.IsZero() || vmagent.Spec.ParsingError != "" {
 			continue
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)

--- a/controllers/vmuser_controller.go
+++ b/controllers/vmuser_controller.go
@@ -212,6 +212,9 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 	for _, vmauth := range vmauthes.Items {
+		if !vmauth.DeletionTimestamp.IsZero() || vmauth.Spec.ParsingError != "" {
+			continue
+		}
 		// reconcile users for given vmauth.
 		currentVMAuth := &vmauth
 		l = l.WithValues("vmauth", vmauth.Name)


### PR DESCRIPTION
due to the user input errors and unmarshall errors, which prevents operator to work normally new ParsingError field was introduced for object Specs it must be checked before working with object and contains error with needed unmarshalling context