### PR TITLE
api/vmalertmanagerconfig: fix parseNestedRoutes

### DIFF
--- a/api/v1beta1/vmalertmanagerconfig_webhook.go
+++ b/api/v1beta1/vmalertmanagerconfig_webhook.go
@@ -34,7 +34,7 @@ func (r *VMAlertmanagerConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 func (amc *VMAlertmanagerConfig) Validate() error {
-	if err := parseNestedRoutes(amc.Spec.Route); err != nil {
+	if _, err := parseNestedRoutes(amc.Spec.Route); err != nil {
 		return fmt.Errorf("cannot parse nested route for alertmanager config err: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Implements #554
The side effect of `parseNestedRoutes`  cause the problem, so I eliminate it and reassigned Route after parsing.

Signed-off-by: yamatcha <soju-yamashita@cybozu.co.jp>