### PR TITLE
change logic for controllers/isSelectorsMatches()

### DIFF
--- a/controllers/vmalertmanagerconfig_controller.go
+++ b/controllers/vmalertmanagerconfig_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
@@ -75,7 +76,7 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 			continue
 		}
 		l := l.WithValues("alertmanager", am.Name)
-		ismatch, err := isSelectorsMatches(&instance, am, am.Spec.ConfigNamespaceSelector, am.Spec.ConfigSelector)
+		ismatch, err := isSelectorsMatches(&instance, am, am.Spec.ConfigSelector)
 		if err != nil {
 			l.Error(err, "cannot match alertmanager against selector, probably bug")
 			continue

--- a/controllers/vmnodescrape_controller.go
+++ b/controllers/vmnodescrape_controller.go
@@ -82,7 +82,7 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)
 		currentVMagent := &vmagent
-		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.NodeScrapeNamespaceSelector, currentVMagent.Spec.NodeScrapeSelector)
+		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.NodeScrapeSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmagent and vmProbe")
 			continue

--- a/controllers/vmpodscrape_controller.go
+++ b/controllers/vmpodscrape_controller.go
@@ -83,7 +83,7 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)
 		currentVMagent := &vmagent
-		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.PodScrapeNamespaceSelector, currentVMagent.Spec.PodScrapeSelector)
+		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.PodScrapeSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmagent and vmPodScrape")
 			continue

--- a/controllers/vmprobe_controller.go
+++ b/controllers/vmprobe_controller.go
@@ -79,7 +79,7 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		currentVMagent := &vmagent
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)
-		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.ProbeNamespaceSelector, currentVMagent.Spec.ProbeSelector)
+		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.ProbeSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmagent and vmProbe")
 			continue

--- a/controllers/vmrule_controller.go
+++ b/controllers/vmrule_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/VictoriaMetrics/operator/controllers/factory"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
@@ -81,7 +82,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		reqLogger.WithValues("vmalert", vmalert.Name)
 		currVMAlert := &vmalert
-		match, err := isSelectorsMatches(instance, currVMAlert, currVMAlert.Spec.RuleNamespaceSelector, currVMAlert.Spec.RuleSelector)
+		match, err := isSelectorsMatches(instance, currVMAlert, currVMAlert.Spec.RuleSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmalert and vmRule")
 			continue

--- a/controllers/vmservicescrape_controller.go
+++ b/controllers/vmservicescrape_controller.go
@@ -79,7 +79,7 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)
 		currentVMagent := &vmagent
-		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.ServiceScrapeNamespaceSelector, currentVMagent.Spec.ServiceScrapeSelector)
+		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.ServiceScrapeSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmagent and vmserviceScrape")
 			continue

--- a/controllers/vmstaticscrape_controller.go
+++ b/controllers/vmstaticscrape_controller.go
@@ -65,7 +65,7 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		reqLogger = reqLogger.WithValues("vmagent", vmagent.Name)
 		currentVMagent := &vmagent
-		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.StaticScrapeNamespaceSelector, currentVMagent.Spec.StaticScrapeSelector)
+		match, err := isSelectorsMatches(instance, currentVMagent, currentVMagent.Spec.StaticScrapeSelector)
 		if err != nil {
 			reqLogger.Error(err, "cannot match vmagent and VMStaticScrape")
 			continue

--- a/controllers/vmuser_controller.go
+++ b/controllers/vmuser_controller.go
@@ -218,7 +218,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// reconcile users for given vmauth.
 		currentVMAuth := &vmauth
 		l = l.WithValues("vmauth", vmauth.Name)
-		match, err := isSelectorsMatches(&instance, currentVMAuth, currentVMAuth.Spec.UserNamespaceSelector, currentVMAuth.Spec.UserSelector)
+		match, err := isSelectorsMatches(&instance, currentVMAuth, currentVMAuth.Spec.UserSelector)
 		if err != nil {
 			l.Error(err, "cannot match vmauth and VMUser")
 			continue


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

Make the condition judge more readable and use less code for the label selecotr , delete useless code for the namespace selector..

```
controllers/controllers.go
isSelectorsMatches

```