### PR TITLE
Remove single quotes from remote write headers

### DIFF
--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -1134,7 +1134,7 @@ func BuildRemoteWrites(cr *victoriametricsv1beta1.VMAgent, ssCache *scrapesSecre
 			}
 			value = strings.TrimSuffix(value, "^^")
 		}
-		headers.flagSetting += fmt.Sprintf("'%s',", value)
+		headers.flagSetting += fmt.Sprintf("%s,", value)
 		value = ""
 		var oaturl, oascopes, oaclientID, oaSecretKeyFile string
 		if rws.OAuth2 != nil {


### PR DESCRIPTION
The operator adds single quotes to the headers inside remote write, resulting that the headers is identified as a whole string, not key:value, and when using this header to send to remote write server, the tenant that matches this header is not found.