### PR TITLE
add option to disable route continue enforce

### DIFF
--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -259,6 +259,10 @@ type VMAlertmanagerSpec struct {
 	// +optional
 	DisableNamespaceMatcher bool `json:"disableNamespaceMatcher,omitempty"`
 
+	// DisableRouteContinueEnforce cancel the behavior for VMAlertmanagerConfig that always enforce first-level route continue to true
+	// +optional
+	DisableRouteContinueEnforce bool `json:"disableRouteContinueEnforce,omitempty"`
+
 	// RollingUpdateStrategy defines strategy for application updates
 	// Default is OnDelete, in this case operator handles update process
 	// Can be changed for RollingUpdate
@@ -358,7 +362,6 @@ func (cr VMAlertmanager) PodLabels() map[string]string {
 		return lbls
 	}
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
-
 }
 
 func (cr VMAlertmanager) AllLabels() map[string]string {
@@ -375,6 +378,7 @@ func (cr VMAlertmanager) AllLabels() map[string]string {
 func (cr VMAlertmanager) ConfigSecretName() string {
 	return fmt.Sprintf("%s-config", cr.PrefixedName())
 }
+
 func (cr VMAlertmanager) PrefixedName() string {
 	return fmt.Sprintf("vmalertmanager-%s", cr.Name)
 }

--- a/api/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/v1beta1/vmalertmanagerconfig_types.go
@@ -20,12 +20,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // VMAlertmanagerConfigSpec defines configuration for VMAlertmanagerConfig
@@ -153,7 +153,7 @@ type Route struct {
 	// +optional
 	Matchers []string `json:"matchers,omitempty"`
 	// Continue indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be true for the first-level route.
+	// sibling nodes. It will always be true for the first-level route if disableRouteContinueEnforce for vmalertmanager not set.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.
@@ -800,6 +800,7 @@ type HTTPConfig struct {
 func (amc *VMAlertmanagerConfig) AsKey() string {
 	return fmt.Sprintf("%s/%s", amc.Namespace, amc.Name)
 }
+
 func init() {
 	SchemeBuilder.Register(&VMAlertmanagerConfig{}, &VMAlertmanagerConfigList{})
 }

--- a/api/victoriametrics/v1beta1/vmalertmanager_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanager_types.go
@@ -259,6 +259,10 @@ type VMAlertmanagerSpec struct {
 	// +optional
 	DisableNamespaceMatcher bool `json:"disableNamespaceMatcher,omitempty"`
 
+	// DisableRouteContinueEnforce cancel the behavior for VMAlertmanagerConfig that always enforce first-level route continue to true
+	// +optional
+	DisableRouteContinueEnforce bool `json:"disableRouteContinueEnforce,omitempty"`
+
 	// RollingUpdateStrategy defines strategy for application updates
 	// Default is OnDelete, in this case operator handles update process
 	// Can be changed for RollingUpdate
@@ -358,7 +362,6 @@ func (cr VMAlertmanager) PodLabels() map[string]string {
 		return lbls
 	}
 	return labels.Merge(cr.Spec.PodMetadata.Labels, lbls)
-
 }
 
 func (cr VMAlertmanager) AllLabels() map[string]string {
@@ -375,6 +378,7 @@ func (cr VMAlertmanager) AllLabels() map[string]string {
 func (cr VMAlertmanager) ConfigSecretName() string {
 	return fmt.Sprintf("%s-config", cr.PrefixedName())
 }
+
 func (cr VMAlertmanager) PrefixedName() string {
 	return fmt.Sprintf("vmalertmanager-%s", cr.Name)
 }

--- a/api/victoriametrics/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanagerconfig_types.go
@@ -19,10 +19,11 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // VMAlertmanagerConfigSpec defines configuration for VMAlertmanagerConfig
@@ -150,7 +151,7 @@ type Route struct {
 	// +optional
 	Matchers []string `json:"matchers,omitempty"`
 	// Continue indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be true for the first-level route.
+	// sibling nodes. It will always be true for the first-level route if disableRouteContinueEnforce for vmalertmanager not set.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.
@@ -762,6 +763,7 @@ type HTTPConfig struct {
 func (amc *VMAlertmanagerConfig) AsKey() string {
 	return fmt.Sprintf("%s/%s", amc.Namespace, amc.Name)
 }
+
 func init() {
 	SchemeBuilder.Register(&VMAlertmanagerConfig{}, &VMAlertmanagerConfigList{})
 }

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -101,7 +101,6 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *victoriametricsv1beta1.
 }
 
 func newStsForAlertManager(cr *victoriametricsv1beta1.VMAlertmanager, c *config.BaseOperatorConf, amVersion *version.Version) (*appsv1.StatefulSet, error) {
-
 	if cr.Spec.Image.Repository == "" {
 		cr.Spec.Image.Repository = c.VMAlertManager.AlertmanagerDefaultBaseImage
 	}
@@ -200,7 +199,6 @@ func CreateOrUpdateAlertManagerService(ctx context.Context, cr *victoriametricsv
 }
 
 func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.BaseOperatorConf, amVersion *version.Version) (*appsv1.StatefulSetSpec, error) {
-
 	cr = cr.DeepCopy()
 
 	image := fmt.Sprintf("%s:%s", formatContainerImage(c.ContainerRegistry, cr.Spec.Image.Repository), cr.Spec.Image.Tag)
@@ -650,7 +648,7 @@ func buildAlertmanagerConfigWithCRDs(ctx context.Context, rclient client.Client,
 		return nil, fmt.Errorf("cannot select alertmanager configs: %w", err)
 	}
 
-	parsedCfg, err := alertmanager.BuildConfig(ctx, rclient, !cr.Spec.DisableNamespaceMatcher, originConfig, amConfigs, tlsAssets)
+	parsedCfg, err := alertmanager.BuildConfig(ctx, rclient, !cr.Spec.DisableNamespaceMatcher, cr.Spec.DisableRouteContinueEnforce, originConfig, amConfigs, tlsAssets)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/factory/alertmanager/config_test.go
+++ b/controllers/factory/alertmanager/config_test.go
@@ -2,9 +2,10 @@ package alertmanager
 
 import (
 	"context"
+	"testing"
+
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
-	"testing"
 
 	operatorv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
@@ -16,10 +17,11 @@ import (
 
 func TestBuildConfig(t *testing.T) {
 	type args struct {
-		ctx                     context.Context
-		disableNamespaceMatcher bool
-		baseCfg                 []byte
-		amcfgs                  map[string]*operatorv1beta1.VMAlertmanagerConfig
+		ctx                         context.Context
+		disableNamespaceMatcher     bool
+		disableRouteContinueEnforce bool
+		baseCfg                     []byte
+		amcfgs                      map[string]*operatorv1beta1.VMAlertmanagerConfig
 	}
 	tests := []struct {
 		name              string
@@ -36,7 +38,7 @@ func TestBuildConfig(t *testing.T) {
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "base",
 							Namespace: "default",
@@ -96,7 +98,7 @@ templates: []
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "base",
 							Namespace: "default",
@@ -244,7 +246,7 @@ templates: []
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "base",
 							Namespace: "default",
@@ -329,7 +331,7 @@ templates: []
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "base",
 							Namespace: "default",
@@ -447,7 +449,7 @@ templates: []
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "tg",
 							Namespace: "default",
@@ -507,7 +509,7 @@ templates: []
  time_out: 1min
 `),
 				amcfgs: map[string]*operatorv1beta1.VMAlertmanagerConfig{
-					"default/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"default/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "tg",
 							Namespace: "default",
@@ -537,7 +539,7 @@ templates: []
 							},
 						},
 					},
-					"mon/base": &operatorv1beta1.VMAlertmanagerConfig{
+					"mon/base": {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "tg",
 							Namespace: "default",
@@ -586,7 +588,7 @@ templates: []
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testClient := k8stools.GetTestClientWithObjects(tt.predefinedObjects)
-			got, err := BuildConfig(tt.args.ctx, testClient, !tt.args.disableNamespaceMatcher, tt.args.baseCfg, tt.args.amcfgs, map[string]string{})
+			got, err := BuildConfig(tt.args.ctx, testClient, !tt.args.disableNamespaceMatcher, tt.args.disableNamespaceMatcher, tt.args.baseCfg, tt.args.amcfgs, map[string]string{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -783,7 +785,7 @@ func Test_configBuilder_buildHTTPConfig(t *testing.T) {
 				},
 			},
 			fields: fields{secretCache: map[string]*v1.Secret{
-				"secret-store": &v1.Secret{
+				"secret-store": {
 					Data: map[string][]byte{
 						"username": []byte("user-1"),
 					},
@@ -822,7 +824,7 @@ func Test_configBuilder_buildHTTPConfig(t *testing.T) {
 				},
 			},
 			fields: fields{secretCache: map[string]*v1.Secret{
-				"secret-store": &v1.Secret{
+				"secret-store": {
 					Data: map[string][]byte{
 						"cert": []byte("---PEM---"),
 						"ca":   []byte("---PEM-CA"),
@@ -877,20 +879,20 @@ authorization:
 			},
 			fields: fields{
 				secretCache: map[string]*v1.Secret{
-					"secret-store": &v1.Secret{
+					"secret-store": {
 						Data: map[string][]byte{
 							"cert": []byte("---PEM---"),
 							"key":  []byte("--KEY-PEM--"),
 						},
 					},
-					"secret-bearer": &v1.Secret{
+					"secret-bearer": {
 						Data: map[string][]byte{
 							"token": []byte("secret-token"),
 						},
 					},
 				},
 				configmapCache: map[string]*v1.ConfigMap{
-					"cm-store": &v1.ConfigMap{
+					"cm-store": {
 						Data: map[string]string{
 							"ca": "--CA-PEM--",
 						},


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/operator/issues/615
add option `disableRouteContinueEnforce` to allow canceling the behavior for VMAlertmanagerConfig that always enforce first-level route continue to true