### PR TITLE
vmalertmanagerconfig: support sound field in pushover config

### DIFF
--- a/controllers/factory/alertmanager/config.go
+++ b/controllers/factory/alertmanager/config.go
@@ -769,6 +769,7 @@ func (cb *configBuilder) buildPushOver(po operatorv1beta1.PushoverConfig) error 
 	}
 
 	toYaml("url", po.URL)
+	toYaml("sound", po.Sound)
 	toYaml("priority", po.Priority)
 	toYaml("message", po.Message)
 	toYaml("expire", po.Expire)


### PR DESCRIPTION
Although [alertmanager doc](https://prometheus.io/docs/alerting/latest/configuration/#pushover_config) don't have the sound field, but it's supported in [code](https://github.com/prometheus/alertmanager/blob/9a8d1f976e12b325ec47b84987a78b7845738be6/config/notifiers.go#L684), so does [prometheus operator](https://github.com/prometheus-operator/prometheus-operator/blob/27943fe43862d313a63b518b6ee67b59d7680c1d/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go#L718).
<img width="758" alt="image" src="https://user-images.githubusercontent.com/39937150/232412444-b1f2ca55-9bdf-42f9-87f8-e157d8fcf2af.png">
