### PR TITLE
operator: allows to properly run operator with single namespace

### DIFF
--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -29,6 +29,8 @@ const (
 	SkipValidationAnnotation = "operator.victoriametrics.com/skip-validation"
 	SkipValidationValue      = "true"
 	AdditionalServiceLabel   = "operator.victoriametrics.com/additional-service"
+	// PVCExpandableLabel controls checks for storageClass
+	PVCExpandableLabel = "operator.victoriametrics.com/pvc/allow-volume-expansion"
 )
 
 var (

--- a/api/victoriametrics/v1beta1/additional.go
+++ b/api/victoriametrics/v1beta1/additional.go
@@ -29,6 +29,8 @@ const (
 	SkipValidationAnnotation = "operator.victoriametrics.com/skip-validation"
 	SkipValidationValue      = "true"
 	AdditionalServiceLabel   = "operator.victoriametrics.com/additional-service"
+	// PVCExpandableLabel controls checks for storageClass
+	PVCExpandableLabel = "operator.victoriametrics.com/pvc/allow-volume-expansion"
 )
 
 var (

--- a/config/examples/operator_rbac_for_single_namespace.yaml
+++ b/config/examples/operator_rbac_for_single_namespace.yaml
@@ -1,0 +1,188 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-operator-single-ns-only
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vm-operator-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-operator-single-ns-only
+subjects:
+  - kind: ServiceAccount
+    name: vm-operator-single-ns-only
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vm-operator-single-ns-only
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - endpointslices
+    verbs:
+      - 'list'
+      - 'watch'
+      - 'get'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - configmaps/finalizers
+      - persistentvolumeclaims
+      - persistentvolumeclaims/finalizers
+      - secrets
+      - secrets/finalizers
+      - services
+      - services/finalizers
+      - serviceaccounts
+      - serviceaccounts/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/finalizers
+      - replicasets
+      - statefulsets
+      - statefulsets/finalizers
+      - statefulsets/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+      - poddisruptionbudgets/finalizers
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmagents
+      - vmagents/finalizers
+      - vmalerts
+      - vmalerts/finalizers
+      - vmalertmanagers
+      - vmalertmanagers/finalizers
+      - vmclusters
+      - vmclusters/finalizers
+      - vmpodscrapes
+      - vmpodscrapes/finalizers
+      - vmrules
+      - vmrules/finalizers
+      - vmusers
+      - vmusers/finalizers
+      - vmauths
+      - vmauths/finalizers
+      - vmprobes
+      - vmsingles
+      - vmsingles/finalizers
+      - vmnodescrapes
+      - vmnodescrapes/finalizers
+      - vmalertmanagerconfigs
+      - vmalertmanagerconfigs/finalizers
+      - vmstaticscrapes
+      - vmstaticscrapes/finalizers
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmagents/status
+      - vmalerts/status
+      - vmalertmanagers/status
+      - vmclusters/status
+      - vmpodscrapes/status
+      - vmrules/status
+      - vmusers/status
+      - vmauths/status
+      - vmservicescrapes/status
+      - vmprobes/status
+      - vmsingles/status
+      - vmnodescrapes/status
+      - vmalertmanagerconfigs/status
+      - vmstaticscrapes/status
+    verbs:
+      - get
+      - patch
+      - update
+
+  - apiGroups:
+      - operator.victoriametrics.com
+    resources:
+      - vmservicescrapes
+    verbs:
+      - '*'
+  - apiGroups:
+      - extensions
+      - "extensions"
+      - networking.k8s.io
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+      - extensions
+    resources:
+      - ingresses
+      - ingresses/finalizers
+    verbs:
+      - create
+      - get
+      - patch
+      - update
+      - watch
+      - delete
+

--- a/controllers/factory/finalize/vmalertmanager.go
+++ b/controllers/factory/finalize/vmalertmanager.go
@@ -6,7 +6,6 @@ import (
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,8 +44,5 @@ func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, crd *vic
 		return err
 	}
 
-	if err := deleteSA(ctx, rclient, crd); err != nil {
-		return err
-	}
 	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
 }

--- a/controllers/factory/rulescm.go
+++ b/controllers/factory/rulescm.go
@@ -11,7 +11,6 @@ import (
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
-	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -195,13 +194,7 @@ func selectNamespaces(ctx context.Context, rclient client.Client, selector label
 		return nil, err
 	}
 
-	watchNamespace := config.MustGetWatchNamespace()
-
 	for _, n := range ns.Items {
-		if watchNamespace != "" && n.Name != watchNamespace {
-			continue
-		}
-
 		matchedNs = append(matchedNs, n.Name)
 	}
 

--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -50,7 +50,7 @@ func generateConfig(
 
 	cfg := yaml.MapSlice{}
 	if !config.IsClusterWideAccessAllowed() && cr.IsOwnsServiceAccount() {
-		log.Info("Setting discovery for the single namespace only, since operator launched with set WATCH_NAMESPACE param. Set customer ServiceAccount for VMAgent if needed.", "vmagent", cr.Name, "namespace", cr.Namespace)
+		log.Info("Setting discovery for the single namespace only, since operator launched with set WATCH_NAMESPACE param. Set custom ServiceAccountName property for VMAgent if needed.", "vmagent", cr.Name, "namespace", cr.Namespace)
 		cr.Spec.IgnoreNamespaceSelectors = true
 	}
 

--- a/controllers/factory/scrapes_build.go
+++ b/controllers/factory/scrapes_build.go
@@ -49,6 +49,10 @@ func generateConfig(
 ) ([]byte, error) {
 
 	cfg := yaml.MapSlice{}
+	if !config.IsClusterWideAccessAllowed() && cr.IsOwnsServiceAccount() {
+		log.Info("Setting discovery for the single namespace only, since operator launched with set WATCH_NAMESPACE param. Set customer ServiceAccount for VMAgent if needed.", "vmagent", cr.Name, "namespace", cr.Namespace)
+		cr.Spec.IgnoreNamespaceSelectors = true
+	}
 
 	if cr.Spec.ScrapeInterval == "" {
 		cr.Spec.ScrapeInterval = defaultScrapeInterval

--- a/controllers/factory/selectors.go
+++ b/controllers/factory/selectors.go
@@ -22,7 +22,8 @@ func getNSWithSelector(ctx context.Context, rclient client.Client, nsSelector, o
 	// for each namespace apply list with  selector
 	// combine result
 	switch {
-	case nsSelector == nil:
+	// in single namespace mode, return object ns
+	case nsSelector == nil || watchNS != "":
 		namespaces = append(namespaces, objNS)
 	default:
 		nsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
@@ -65,13 +66,7 @@ func visitObjectsWithSelector(ctx context.Context, rclient client.Client, ns []s
 		return nil
 	}
 
-	watchNamespace := config.MustGetWatchNamespace()
-	// list only for given namespaces
 	for i := range ns {
-		if watchNamespace != "" && ns[i] != watchNamespace {
-			continue
-		}
-
 		if err := rclient.List(ctx, objectListType, &client.ListOptions{LabelSelector: selector, Namespace: ns[i]}); err != nil {
 			return err
 		}

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -84,8 +84,14 @@ func CreateOrUpdateVMAgent(ctx context.Context, cr *victoriametricsv1beta1.VMAge
 		}
 	}
 	if cr.GetServiceAccountName() == cr.PrefixedName() {
-		if err := vmagent.CreateVMAgentClusterAccess(ctx, cr, rclient); err != nil {
-			return fmt.Errorf("cannot create vmagent clusterole and binding for it, err: %w", err)
+		var err error
+		if config.IsClusterWideAccessAllowed() {
+			err = vmagent.CreateVMAgentClusterAccess(ctx, cr, rclient)
+		} else {
+			err = vmagent.CreateVMAgentNamespaceAccess(ctx, cr, rclient)
+		}
+		if err != nil {
+			return fmt.Errorf("cannot create vmagent role and binding for it, err: %w", err)
 		}
 	}
 	// we have to create empty or full cm first

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -83,14 +83,8 @@ func CreateOrUpdateVMAgent(ctx context.Context, cr *victoriametricsv1beta1.VMAge
 			return fmt.Errorf("cannot create podsecurity policy for vmagent, err: %w", err)
 		}
 	}
-	if cr.GetServiceAccountName() == cr.PrefixedName() {
-		var err error
-		if config.IsClusterWideAccessAllowed() {
-			err = vmagent.CreateVMAgentClusterAccess(ctx, cr, rclient)
-		} else {
-			err = vmagent.CreateVMAgentNamespaceAccess(ctx, cr, rclient)
-		}
-		if err != nil {
+	if cr.IsOwnsServiceAccount() {
+		if err := vmagent.CreateVMAgentK8sAPIAccess(ctx, cr, rclient, config.IsClusterWideAccessAllowed()); err != nil {
 			return fmt.Errorf("cannot create vmagent role and binding for it, err: %w", err)
 		}
 	}

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -4,34 +4,103 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	v1beta12 "github.com/VictoriaMetrics/operator/api/v1beta1"
-	v12 "k8s.io/api/rbac/v1"
+	rbacV1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// CreateVMAgentClusterAccess - create cluster access for vmagent
-// with clusterrole and clusterrolebinding.
-func CreateVMAgentClusterAccess(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
-	if err := ensureVMAgentCRExist(ctx, cr, rclient); err != nil {
-		return fmt.Errorf("cannot ensure state of vmagent's cluster role: %w", err)
+var (
+	singleNSPolicyRules = []rbacV1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"services",
+				"endpoints",
+				"pods",
+				"endpointslices",
+			},
+		},
+		{
+			APIGroups: []string{"networking.k8s.io", "extensions"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"ingresses",
+			},
+		},
 	}
-	if err := ensureVMAgentCRBExist(ctx, cr, rclient); err != nil {
-		return fmt.Errorf("cannot ensure state of vmagent's cluster role binding: %w", err)
+	clusterWidePolicyRules = []rbacV1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"nodes",
+				"nodes/metrics",
+				"nodes/proxy",
+				"services",
+				"endpoints",
+				"pods",
+				"endpointslices",
+				"configmaps",
+				"namespaces",
+				"secrets",
+			},
+		},
+		{
+			APIGroups: []string{"networking.k8s.io", "extensions"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"ingresses",
+			},
+		},
+		{
+			NonResourceURLs: []string{"/metrics", "/metrics/resources"},
+			Verbs:           []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"route.openshift.io", "image.openshift.io"},
+			Verbs: []string{
+				"get",
+			},
+			Resources: []string{
+				"routers/metrics", "registry/metrics",
+			},
+		},
+	}
+)
+
+// CreateVMAgentK8sAPIAccess - creates RBAC access rules for vmagent
+func CreateVMAgentK8sAPIAccess(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client, clusterWide bool) error {
+	if clusterWide {
+		if err := ensureVMAgentCRExist(ctx, cr, rclient); err != nil {
+			return fmt.Errorf("cannot ensure state of vmagent's cluster role: %w", err)
+		}
+		if err := ensureVMAgentCRBExist(ctx, cr, rclient); err != nil {
+			return fmt.Errorf("cannot ensure state of vmagent's cluster role binding: %w", err)
+		}
+		return nil
 	}
 
-	return nil
-}
-
-// CreateVMAgentNamespaceAccess - creates single namespace access for vmagent
-// with role and rolebinding.
-func CreateVMAgentNamespaceAccess(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
 	if err := ensureVMAgentRExist(ctx, cr, rclient); err != nil {
 		return fmt.Errorf("cannot ensure state of vmagent's cluster role: %w", err)
 	}
@@ -44,7 +113,7 @@ func CreateVMAgentNamespaceAccess(ctx context.Context, cr *v1beta12.VMAgent, rcl
 
 func ensureVMAgentCRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
 	clusterRole := buildVMAgentClusterRole(cr)
-	var existsClusterRole v12.ClusterRole
+	var existsClusterRole rbacV1.ClusterRole
 
 	if err := rclient.Get(ctx, types.NamespacedName{Name: clusterRole.Name, Namespace: cr.Namespace}, &existsClusterRole); err != nil {
 		if errors.IsNotFound(err) {
@@ -63,7 +132,7 @@ func ensureVMAgentCRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cli
 
 func ensureVMAgentCRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
 	clusterRoleBinding := buildVMAgentClusterRoleBinding(cr)
-	var existsClusterRoleBinding v12.ClusterRoleBinding
+	var existsClusterRoleBinding rbacV1.ClusterRoleBinding
 
 	if err := rclient.Get(ctx, types.NamespacedName{Name: clusterRoleBinding.Name, Namespace: cr.Namespace}, &existsClusterRoleBinding); err != nil {
 		if errors.IsNotFound(err) {
@@ -81,8 +150,8 @@ func ensureVMAgentCRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cl
 	return rclient.Update(ctx, &existsClusterRoleBinding)
 }
 
-func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *v12.ClusterRoleBinding {
-	return &v12.ClusterRoleBinding{
+func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *rbacV1.ClusterRoleBinding {
+	return &rbacV1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
@@ -91,23 +160,23 @@ func buildVMAgentClusterRoleBinding(cr *v1beta12.VMAgent) *v12.ClusterRoleBindin
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
-		Subjects: []v12.Subject{
+		Subjects: []rbacV1.Subject{
 			{
-				Kind:      v12.ServiceAccountKind,
+				Kind:      rbacV1.ServiceAccountKind,
 				Name:      cr.GetServiceAccountName(),
 				Namespace: cr.GetNamespace(),
 			},
 		},
-		RoleRef: v12.RoleRef{
-			APIGroup: v12.GroupName,
+		RoleRef: rbacV1.RoleRef{
+			APIGroup: rbacV1.GroupName,
 			Name:     cr.GetClusterRoleName(),
 			Kind:     "ClusterRole",
 		},
 	}
 }
 
-func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *v12.ClusterRole {
-	return &v12.ClusterRole{
+func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *rbacV1.ClusterRole {
+	return &rbacV1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
@@ -116,58 +185,13 @@ func buildVMAgentClusterRole(cr *v1beta12.VMAgent) *v12.ClusterRole {
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
-		Rules: []v12.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-				Resources: []string{
-					"nodes",
-					"nodes/metrics",
-					"nodes/proxy",
-					"services",
-					"endpoints",
-					"pods",
-					"endpointslices",
-					"configmaps",
-					"namespaces",
-					"secrets",
-				},
-			},
-			{
-				APIGroups: []string{"networking.k8s.io", "extensions"},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-				Resources: []string{
-					"ingresses",
-				},
-			},
-			{
-				NonResourceURLs: []string{"/metrics", "/metrics/resources"},
-				Verbs:           []string{"get", "list", "watch"},
-			},
-			{
-				APIGroups: []string{"route.openshift.io", "image.openshift.io"},
-				Verbs: []string{
-					"get",
-				},
-				Resources: []string{
-					"routers/metrics", "registry/metrics",
-				},
-			},
-		},
+		Rules: clusterWidePolicyRules,
 	}
 }
 
 func ensureVMAgentRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
 	nr := buildVMAgentNamespaceRole(cr)
-	var existsClusterRole v12.Role
+	var existsClusterRole rbacV1.Role
 
 	if err := rclient.Get(ctx, types.NamespacedName{Name: nr.Name, Namespace: cr.Namespace}, &existsClusterRole); err != nil {
 		if errors.IsNotFound(err) {
@@ -186,7 +210,7 @@ func ensureVMAgentRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient clie
 
 func ensureVMAgentRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient client.Client) error {
 	rb := buildVMAgentNamespaceRoleBinding(cr)
-	var existsRB v12.RoleBinding
+	var existsRB rbacV1.RoleBinding
 
 	if err := rclient.Get(ctx, types.NamespacedName{Name: rb.Name, Namespace: cr.Namespace}, &existsRB); err != nil {
 		if errors.IsNotFound(err) {
@@ -205,8 +229,8 @@ func ensureVMAgentRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cli
 	return rclient.Update(ctx, &existsRB)
 }
 
-func buildVMAgentNamespaceRole(cr *v1beta12.VMAgent) *v12.Role {
-	return &v12.Role{
+func buildVMAgentNamespaceRole(cr *v1beta12.VMAgent) *rbacV1.Role {
+	return &rbacV1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
@@ -215,38 +239,12 @@ func buildVMAgentNamespaceRole(cr *v1beta12.VMAgent) *v12.Role {
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
-		Rules: []v12.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-				Resources: []string{
-					"services",
-					"endpoints",
-					"pods",
-					"endpointslices",
-				},
-			},
-			{
-				APIGroups: []string{"networking.k8s.io", "extensions"},
-				Verbs: []string{
-					"get",
-					"list",
-					"watch",
-				},
-				Resources: []string{
-					"ingresses",
-				},
-			},
-		},
+		Rules: singleNSPolicyRules,
 	}
 }
 
-func buildVMAgentNamespaceRoleBinding(cr *v1beta12.VMAgent) *v12.RoleBinding {
-	return &v12.RoleBinding{
+func buildVMAgentNamespaceRoleBinding(cr *v1beta12.VMAgent) *rbacV1.RoleBinding {
+	return &rbacV1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            cr.GetClusterRoleName(),
 			Namespace:       cr.GetNamespace(),
@@ -255,15 +253,15 @@ func buildVMAgentNamespaceRoleBinding(cr *v1beta12.VMAgent) *v12.RoleBinding {
 			Finalizers:      []string{v1beta12.FinalizerName},
 			OwnerReferences: cr.AsCRDOwner(),
 		},
-		Subjects: []v12.Subject{
+		Subjects: []rbacV1.Subject{
 			{
-				Kind:      v12.ServiceAccountKind,
+				Kind:      rbacV1.ServiceAccountKind,
 				Name:      cr.GetServiceAccountName(),
 				Namespace: cr.GetNamespace(),
 			},
 		},
-		RoleRef: v12.RoleRef{
-			APIGroup: v12.GroupName,
+		RoleRef: rbacV1.RoleRef{
+			APIGroup: rbacV1.GroupName,
 			Name:     cr.GetClusterRoleName(),
 			Kind:     "Role",
 		},

--- a/controllers/factory/vmagent/rbac_test.go
+++ b/controllers/factory/vmagent/rbac_test.go
@@ -91,7 +91,7 @@ func TestCreateVMAgentClusterAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fclient := k8stools.GetTestClientWithObjects(tt.predefinedObjects)
-			if err := CreateVMAgentK8sAPIAccess(tt.args.ctx, tt.args.cr, fclient); (err != nil) != tt.wantErr {
+			if err := CreateVMAgentK8sAPIAccess(tt.args.ctx, tt.args.cr, fclient, true); (err != nil) != tt.wantErr {
 				t.Errorf("CreateVMAgentK8sAPIAccess() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/controllers/factory/vmagent/rbac_test.go
+++ b/controllers/factory/vmagent/rbac_test.go
@@ -91,8 +91,8 @@ func TestCreateVMAgentClusterAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fclient := k8stools.GetTestClientWithObjects(tt.predefinedObjects)
-			if err := CreateVMAgentClusterAccess(tt.args.ctx, tt.args.cr, fclient); (err != nil) != tt.wantErr {
-				t.Errorf("CreateVMAgentClusterAccess() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CreateVMAgentK8sAPIAccess(tt.args.ctx, tt.args.cr, fclient); (err != nil) != tt.wantErr {
+				t.Errorf("CreateVMAgentK8sAPIAccess() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"github.com/VictoriaMetrics/operator/internal/config"
 	"math/big"
 	"net/url"
 	"path"
@@ -280,6 +281,11 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 		for j := range user.Spec.TargetRefs {
 			ref := user.Spec.TargetRefs[j]
 			if ref.CRD == nil {
+				continue
+			}
+			// namespace mismatch
+			if !config.IsClusterWideAccessAllowed() && ref.CRD.Namespace != config.MustGetWatchNamespace() {
+				log.Info("cannot discover CRD component on whole kubernetes cluster. Operator started with single namespace", "watch_namespace", config.MustGetWatchNamespace(), "crd_ref_name", ref.CRD.Name, "crd_ref_namespace", ref.CRD.Namespace)
 				continue
 			}
 			if _, ok := crdCacheUrlCache[ref.CRD.AsKey()]; ok {

--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"github.com/VictoriaMetrics/operator/internal/config"
 	"math/big"
 	"net/url"
 	"path"
 	"sort"
 	"strings"
 
-	"github.com/VictoriaMetrics/operator/api/v1beta1"
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/config"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,7 +22,7 @@ import (
 )
 
 // builds vmauth config.
-func buildVMAuthConfig(ctx context.Context, rclient client.Client, vmauth *v1beta1.VMAuth) ([]byte, error) {
+func buildVMAuthConfig(ctx context.Context, rclient client.Client, vmauth *victoriametricsv1beta1.VMAuth) ([]byte, error) {
 
 	// fetch exist users for vmauth.
 	users, err := selectVMUsers(ctx, vmauth, rclient)
@@ -86,7 +85,7 @@ func buildVMAuthConfig(ctx context.Context, rclient client.Client, vmauth *v1bet
 
 }
 
-func addCredentialsToCreateSecrets(src []*v1beta1.VMUser, dst []v1.Secret) []v1.Secret {
+func addCredentialsToCreateSecrets(src []*victoriametricsv1beta1.VMUser, dst []corev1.Secret) []corev1.Secret {
 	for i := range dst {
 		secret := &dst[i]
 		for j := range src {
@@ -112,7 +111,7 @@ func addCredentialsToCreateSecrets(src []*v1beta1.VMUser, dst []v1.Secret) []v1.
 	return dst
 }
 
-func createVMUserSecrets(ctx context.Context, rclient client.Client, secrets []v1.Secret) error {
+func createVMUserSecrets(ctx context.Context, rclient client.Client, secrets []corev1.Secret) error {
 	for i := range secrets {
 		secret := secrets[i]
 		if err := rclient.Create(ctx, &secret); err != nil {
@@ -122,7 +121,7 @@ func createVMUserSecrets(ctx context.Context, rclient client.Client, secrets []v
 	return nil
 }
 
-func injectSecretValueByRef(src []*v1beta1.VMUser, secretValueCacheByRef map[string]string) {
+func injectSecretValueByRef(src []*victoriametricsv1beta1.VMUser, secretValueCacheByRef map[string]string) {
 	for i := range src {
 		user := src[i]
 		switch {
@@ -137,8 +136,8 @@ func injectSecretValueByRef(src []*v1beta1.VMUser, secretValueCacheByRef map[str
 	}
 }
 
-func injectAuthSettings(src []v1.Secret, dst []*v1beta1.VMUser) []v1.Secret {
-	var toUpdate []v1.Secret
+func injectAuthSettings(src []corev1.Secret, dst []*victoriametricsv1beta1.VMUser) []corev1.Secret {
+	var toUpdate []corev1.Secret
 	if len(src) == 0 || len(dst) == 0 {
 		return nil
 	}
@@ -202,7 +201,7 @@ func injectAuthSettings(src []v1.Secret, dst []*v1beta1.VMUser) []v1.Secret {
 	return toUpdate
 }
 
-func isUsersUniq(users []*v1beta1.VMUser) []string {
+func isUsersUniq(users []*victoriametricsv1beta1.VMUser) []string {
 	uniq := make(map[string]struct{}, len(users))
 	var dupUsers []string
 	for i := range users {
@@ -241,9 +240,9 @@ func getAsURLObject(ctx context.Context, rclient client.Client, obj objectWithUr
 	return obj.AsURL(), nil
 }
 
-func fetchVMUserSecretCacheByRef(ctx context.Context, rclient client.Client, users []*v1beta1.VMUser) (map[string]string, error) {
+func fetchVMUserSecretCacheByRef(ctx context.Context, rclient client.Client, users []*victoriametricsv1beta1.VMUser) (map[string]string, error) {
 	passwordCache := make(map[string]string, len(users))
-	var fetchSecret v1.Secret
+	var fetchSecret corev1.Secret
 	for i := range users {
 		user := users[i]
 		var secretName, secretKey, refValue string
@@ -274,7 +273,7 @@ func fetchVMUserSecretCacheByRef(ctx context.Context, rclient client.Client, use
 	return passwordCache, nil
 }
 
-func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.VMUser) (map[string]string, error) {
+func FetchCRDCache(ctx context.Context, rclient client.Client, users []*victoriametricsv1beta1.VMUser) (map[string]string, error) {
 	crdCacheUrlCache := make(map[string]string)
 	for i := range users {
 		user := users[i]
@@ -293,7 +292,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 			}
 			switch name := ref.CRD.Kind; name {
 			case "VMAgent":
-				var crd v1beta1.VMAgent
+				var crd victoriametricsv1beta1.VMAgent
 				ref.CRD.AddRefToObj(&crd)
 				url, err := getAsURLObject(ctx, rclient, &crd)
 				if err != nil {
@@ -301,7 +300,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 				}
 				crdCacheUrlCache[ref.CRD.AsKey()] = url
 			case "VMAlert":
-				var crd v1beta1.VMAlert
+				var crd victoriametricsv1beta1.VMAlert
 				ref.CRD.AddRefToObj(&crd)
 				url, err := getAsURLObject(ctx, rclient, &crd)
 				if err != nil {
@@ -310,7 +309,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 				crdCacheUrlCache[ref.CRD.AsKey()] = url
 
 			case "VMSingle":
-				var crd v1beta1.VMSingle
+				var crd victoriametricsv1beta1.VMSingle
 				ref.CRD.AddRefToObj(&crd)
 				url, err := getAsURLObject(ctx, rclient, &crd)
 				if err != nil {
@@ -318,7 +317,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 				}
 				crdCacheUrlCache[ref.CRD.AsKey()] = url
 			case "VMAlertmanager":
-				var crd v1beta1.VMAlertmanager
+				var crd victoriametricsv1beta1.VMAlertmanager
 				ref.CRD.AddRefToObj(&crd)
 				url, err := getAsURLObject(ctx, rclient, &crd)
 				if err != nil {
@@ -327,7 +326,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 				crdCacheUrlCache[ref.CRD.AsKey()] = url
 
 			case "VMCluster/vmselect", "VMCluster/vminsert", "VMCluster/vmstorage":
-				var crd v1beta1.VMCluster
+				var crd victoriametricsv1beta1.VMCluster
 				ref.CRD.AddRefToObj(&crd)
 				url, err := getAsURLObject(ctx, rclient, &crd)
 				if err != nil {
@@ -359,7 +358,7 @@ func FetchCRDCache(ctx context.Context, rclient client.Client, users []*v1beta1.
 }
 
 // generateVMAuthConfig create VMAuth cfg for given Users.
-func generateVMAuthConfig(cr *v1beta1.VMAuth, users []*v1beta1.VMUser, crdCache map[string]string) ([]byte, error) {
+func generateVMAuthConfig(cr *victoriametricsv1beta1.VMAuth, users []*victoriametricsv1beta1.VMUser, crdCache map[string]string) ([]byte, error) {
 	var cfg yaml.MapSlice
 
 	var cfgUsers []yaml.MapSlice
@@ -416,7 +415,7 @@ func generateVMAuthConfig(cr *v1beta1.VMAuth, users []*v1beta1.VMUser, crdCache 
 }
 
 // AddToYaml conditionally adds ip filters to dst yaml
-func addIPFiltersToYaml(dst yaml.MapSlice, ipf v1beta1.VMUserIPFilters) yaml.MapSlice {
+func addIPFiltersToYaml(dst yaml.MapSlice, ipf victoriametricsv1beta1.VMUserIPFilters) yaml.MapSlice {
 	ipFilters := yaml.MapSlice{}
 	if len(ipf.AllowList) > 0 {
 		ipFilters = append(ipFilters, yaml.MapItem{
@@ -437,9 +436,9 @@ func addIPFiltersToYaml(dst yaml.MapSlice, ipf v1beta1.VMUserIPFilters) yaml.Map
 }
 
 // generates routing config for given target refs
-func genUrlMaps(userName string, refs []v1beta1.TargetRef, result yaml.MapSlice, crdUrlCache map[string]string) (yaml.MapSlice, error) {
+func genUrlMaps(userName string, refs []victoriametricsv1beta1.TargetRef, result yaml.MapSlice, crdUrlCache map[string]string) (yaml.MapSlice, error) {
 	var urlMaps []yaml.MapSlice
-	handleRef := func(ref v1beta1.TargetRef) ([]string, error) {
+	handleRef := func(ref victoriametricsv1beta1.TargetRef) ([]string, error) {
 		var urlPrefixes []string
 		switch {
 		case ref.CRD != nil:
@@ -569,7 +568,7 @@ func genUrlMaps(userName string, refs []v1beta1.TargetRef, result yaml.MapSlice,
 
 // this function mutates user and fills missing fields,
 // such password or username.
-func genUserCfg(user *v1beta1.VMUser, crdUrlCache map[string]string) (yaml.MapSlice, error) {
+func genUserCfg(user *victoriametricsv1beta1.VMUser, crdUrlCache map[string]string) (yaml.MapSlice, error) {
 	var r yaml.MapSlice
 
 	r, err := genUrlMaps(user.Name, user.Spec.TargetRefs, r, crdUrlCache)
@@ -660,9 +659,9 @@ func genPassword() (string, error) {
 }
 
 // selects vmusers for given vmauth.
-func selectVMUsers(ctx context.Context, cr *v1beta1.VMAuth, rclient client.Client) ([]*v1beta1.VMUser, error) {
+func selectVMUsers(ctx context.Context, cr *victoriametricsv1beta1.VMAuth, rclient client.Client) ([]*victoriametricsv1beta1.VMUser, error) {
 
-	var res []*v1beta1.VMUser
+	var res []*victoriametricsv1beta1.VMUser
 	namespaces, userSelector, err := getNSWithSelector(ctx, rclient, cr.Spec.UserNamespaceSelector, cr.Spec.UserSelector, cr.Namespace)
 	if err != nil {
 		return nil, err
@@ -691,12 +690,12 @@ func selectVMUsers(ctx context.Context, cr *v1beta1.VMAuth, rclient client.Clien
 
 // select existing vmusers secrets.
 // returns secrets, that need to be create and exist secrets.
-func selectVMUserSecrets(ctx context.Context, rclient client.Client, vmUsers []*v1beta1.VMUser) ([]v1.Secret, []v1.Secret, error) {
-	var existsSecrets []v1.Secret
-	var needToCreateSecrets []v1.Secret
+func selectVMUserSecrets(ctx context.Context, rclient client.Client, vmUsers []*victoriametricsv1beta1.VMUser) ([]corev1.Secret, []corev1.Secret, error) {
+	var existsSecrets []corev1.Secret
+	var needToCreateSecrets []corev1.Secret
 	for i := range vmUsers {
 		vmUser := vmUsers[i]
-		var vmus v1.Secret
+		var vmus corev1.Secret
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: vmUser.Namespace, Name: vmUser.SecretName()}, &vmus); err != nil {
 			if errors.IsNotFound(err) {
 				needToCreateSecrets = append(needToCreateSecrets, buildVMUserSecret(vmUser))
@@ -712,8 +711,8 @@ func selectVMUserSecrets(ctx context.Context, rclient client.Client, vmUsers []*
 
 // note, username and password must be filled by operator
 // with default values if need.
-func buildVMUserSecret(src *v1beta1.VMUser) v1.Secret {
-	s := v1.Secret{
+func buildVMUserSecret(src *victoriametricsv1beta1.VMUser) corev1.Secret {
+	s := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            src.SecretName(),
 			Namespace:       src.Namespace,
@@ -721,7 +720,7 @@ func buildVMUserSecret(src *v1beta1.VMUser) v1.Secret {
 			Annotations:     src.AnnotationsFiltered(),
 			OwnerReferences: src.AsOwner(),
 			Finalizers: []string{
-				v1beta1.FinalizerName,
+				victoriametricsv1beta1.FinalizerName,
 			},
 		},
 		Data: map[string][]byte{},

--- a/controllers/vmprometheusconverter_controller.go
+++ b/controllers/vmprometheusconverter_controller.go
@@ -243,7 +243,6 @@ func (c *ConverterController) Run(ctx context.Context, group *errgroup.Group) {
 			return c.runInformerWithDiscovery(ctx, alpha1.SchemeGroupVersion.String(), alpha1.AlertmanagerConfigKind, c.amConfigInf.Run)
 		})
 	}
-
 }
 
 // CreatePrometheusRule converts prometheus rule to vmrule

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -351,6 +351,11 @@ func MustGetWatchNamespace() string {
 	return opNamespace
 }
 
+// IsClusterWideAccessAllowed checks if cluster wide access for components is needed
+func IsClusterWideAccessAllowed() bool {
+	return MustGetWatchNamespace() == ""
+}
+
 func MustGetNamespaceListOptions() *client.ListOptions {
 	return &client.ListOptions{
 		Namespace: MustGetWatchNamespace(),

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -116,7 +116,7 @@ func RunManager(ctx context.Context) error {
 		LeaderElectionID: "57410f0d.victoriametrics.com",
 		ClientDisableCacheFor: []client.Object{&v1.Secret{}, &v1.ConfigMap{}, &v1.Pod{}, &v12.Deployment{},
 			&v12.StatefulSet{},
-			&v1beta1.PodSecurityPolicy{}, &v1beta1.PodDisruptionBudget{}},
+			&v1beta1.PodSecurityPolicy{}, &v1beta1.PodDisruptionBudget{}, &v1.Namespace{}},
 		Namespace: config.MustGetWatchNamespace(),
 	})
 	if err != nil {
@@ -152,7 +152,7 @@ func RunManager(ctx context.Context) error {
 		setupLog.Info("operator is running in single namespace mode", "namespace", opNs)
 	}
 
-	if !*disableCRDOwnership {
+	if !*disableCRDOwnership && opNs == "" {
 		initC, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
 		if err != nil {
 			return err


### PR DESCRIPTION
disables cluster wide kubernetes API call with WATCH_NAMESPACE set for specific namespace. It allows to securely use operator without need to assign additional permissions for it. https://github.com/VictoriaMetrics/operator/issues/641