### PR TITLE
Add config for vmrule in validating webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -165,3 +165,23 @@ webhooks:
     resources:
     - vmusers
   sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: vm-operator
+      namespace: victoriametrics-system
+      path: /validate-operator-victoriametrics-com-v1beta1-vmrule
+  failurePolicy: Fail
+  name: vvmrule.kb.io
+  rules:
+    - apiGroups:
+        - operator.victoriametrics.com
+      apiVersions:
+        - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - vmrules
+  sideEffects: None


### PR DESCRIPTION
This was missing in the `ValidatingWebhookConfiguration`