### PR TITLE
controllers/vmagent: skips misconfiguration for user defined objects

### DIFF
--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/utils"
 	"github.com/VictoriaMetrics/metricsql"
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
-	v1 "k8s.io/api/core/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +21,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	vmagentSecretFetchErrsTotal prometheus.Counter
+)
+
+func init() {
+	vmagentSecretFetchErrsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "operator_vmagent_config_fetch_secret_errors_total",
+		Help: "Indicates if user defined objects contain missing link for secret",
+	})
+	prometheus.MustRegister(vmagentSecretFetchErrsTotal)
+}
+
 type scrapesSecretsCache struct {
 	bearerTokens         map[string]string
 	baSecrets            map[string]*BasicAuthCredentials
@@ -26,14 +40,15 @@ type scrapesSecretsCache struct {
 	authorizationSecrets map[string]string
 }
 
+// CreateOrUpdateConfigurationSecret builds scrape configuration for VMAgent
 func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client, c *config.BaseOperatorConf) (*scrapesSecretsCache, error) {
 
-	smons, err := SelectServiceScrapes(ctx, cr, rclient)
+	sScrapes, err := SelectServiceScrapes(ctx, cr, rclient)
 	if err != nil {
 		return nil, fmt.Errorf("selecting ServiceScrapes failed: %w", err)
 	}
 
-	pmons, err := SelectPodScrapes(ctx, cr, rclient)
+	pScrapes, err := SelectPodScrapes(ctx, cr, rclient)
 	if err != nil {
 		return nil, fmt.Errorf("selecting PodScrapes failed: %w", err)
 	}
@@ -53,9 +68,24 @@ func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv
 		return nil, fmt.Errorf("selecting PodScrapes failed: %w", err)
 	}
 
-	ssCache, err := loadScrapeSecrets(ctx, rclient, smons, nodes, pmons, probes, statics, cr.Spec.APIServerConfig, cr.Spec.RemoteWrite, cr.Namespace)
+	ssCache, err := loadScrapeSecrets(ctx, rclient, sScrapes, nodes, pScrapes, probes, statics, cr.Spec.APIServerConfig, cr.Spec.RemoteWrite, cr.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load basic secrets for ServiceMonitors: %w", err)
+		if _, ok := err.(*utils.ErrGroup); !ok {
+			return nil, fmt.Errorf("cannot load scrape target secrets for api server or remote writes: %w", err)
+		}
+		vmagentSecretFetchErrsTotal.Inc()
+		log.Error(err, "found invalid secret references at objects, excluding it from configuration")
+	}
+	assets, err := loadTLSAssets(ctx, rclient, cr, sScrapes, pScrapes, probes, nodes, statics)
+	if err != nil {
+		if _, ok := err.(*utils.ErrGroup); !ok {
+			return nil, fmt.Errorf("cannot load tls assets for api server or remote writes: %w", err)
+		}
+		vmagentSecretFetchErrsTotal.Inc()
+		log.Error(err, "cannot load tls assets for targets, excluding it from configuration")
+	}
+	if err := createOrUpdateTlsAssets(ctx, cr, rclient, assets); err != nil {
+		return nil, fmt.Errorf("cannot create tls assets secret for vmagent: %w", err)
 	}
 
 	additionalScrapeConfigs, err := loadAdditionalScrapeConfigsSecret(ctx, rclient, cr.Spec.AdditionalScrapeConfigs, cr.Namespace)
@@ -66,8 +96,8 @@ func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv
 	// Update secret based on the most recent configuration.
 	generatedConfig, err := generateConfig(
 		cr,
-		smons,
-		pmons,
+		sScrapes,
+		pScrapes,
 		probes,
 		nodes,
 		statics,
@@ -90,11 +120,13 @@ func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv
 	}
 	s.Data[vmagentGzippedFilename] = buf.Bytes()
 
-	curSecret := &v1.Secret{}
-	err = rclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: s.Name}, curSecret)
-	if errors.IsNotFound(err) {
-		log.Info("creating new configuration secret for vmagent")
-		return ssCache, rclient.Create(ctx, s)
+	curSecret := &corev1.Secret{}
+	if err := rclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: s.Name}, curSecret); err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("creating new configuration secret for vmagent")
+			return ssCache, rclient.Create(ctx, s)
+		}
+		return nil, fmt.Errorf("cannot ")
 	}
 
 	s.Annotations = labels.Merge(curSecret.Annotations, s.Annotations)
@@ -308,6 +340,9 @@ func SelectStaticScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent
 	return res, nil
 }
 
+// TODO: @f41gh7
+// refactor it, use victoriametricsv1beta1.HTTPAuth for objects as embed struct
+// it should remove boilerplate code
 func loadScrapeSecrets(
 	ctx context.Context,
 	rclient client.Client,
@@ -325,14 +360,17 @@ func loadScrapeSecrets(
 	authorizationSecrets := make(map[string]string)
 	baSecrets := make(map[string]*BasicAuthCredentials)
 	bearerSecrets := make(map[string]string)
-	nsSecretCache := make(map[string]*v1.Secret)
-	nsCMCache := make(map[string]*v1.ConfigMap)
-	for _, mon := range mons {
+	nsSecretCache := make(map[string]*corev1.Secret)
+	nsCMCache := make(map[string]*corev1.ConfigMap)
+	var errG utils.ErrGroup
+	for key, mon := range mons {
+		var epCnt int
 		for i, ep := range mon.Spec.Endpoints {
 			if ep.BasicAuth != nil {
 				credentials, err := loadBasicAuthSecretFromAPI(ctx, rclient, ep.BasicAuth, mon.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("could not generate basicAuth for vmservicescrape %s. %w", mon.Name, err)
+					errG.Add(fmt.Errorf("cannot load secret for VMServiceScrape: %w", err))
+					continue
 				}
 				baSecrets[mon.AsMapKey(i)] = credentials
 			}
@@ -340,39 +378,52 @@ func loadScrapeSecrets(
 			if ep.OAuth2 != nil {
 				oauth2, err := loadOAuthSecrets(ctx, rclient, ep.OAuth2, mon.Namespace, nsSecretCache, nsCMCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", mon.Name, mon.Namespace, err)
+					errG.Add(fmt.Errorf("cannot load secret for VMServiceScrape: %w", err))
+					continue
 				}
 				oauth2Secret[mon.AsMapKey(i)] = oauth2
 			}
 			if ep.BearerTokenSecret != nil && ep.BearerTokenSecret.Name != "" {
 				token, err := getCredFromSecret(ctx, rclient, mon.Namespace, ep.BearerTokenSecret, buildCacheKey(mon.Namespace, ep.BearerTokenSecret.Name), nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("cannot load secret for VMServiceScrape: %w", err))
+					continue
 				}
 				bearerSecrets[mon.AsMapKey(i)] = token
 			}
 			if ep.Authorization != nil && ep.Authorization.Credentials != nil {
 				secretValue, err := getCredFromSecret(ctx, rclient, mon.Namespace, ep.Authorization.Credentials, buildCacheKey(mon.Namespace, ep.Authorization.Credentials.Name), nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot fetch authorization secret value: %w", err)
+					errG.Add(fmt.Errorf("cannot load secret for VMServiceScrape: %w", err))
+					continue
 				}
 				authorizationSecrets[mon.AsMapKey(i)] = secretValue
 			}
 			if ep.VMScrapeParams != nil && ep.VMScrapeParams.ProxyClientConfig != nil {
 				ba, token, err := loadProxySecrets(ctx, rclient, ep.VMScrapeParams.ProxyClientConfig, mon.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("cannot load secret for VMServiceScrape: %w", err))
+					continue
 				}
 				if ba != nil {
 					baSecrets[mon.AsProxyKey(i)] = ba
 				}
 				bearerSecrets[mon.AsProxyKey(i)] = token
 			}
-
+			mon.Spec.Endpoints[epCnt] = ep
+			epCnt++
+		}
+		mon.Spec.Endpoints = mon.Spec.Endpoints[:epCnt]
+		if len(mon.Spec.Endpoints) == 0 {
+			delete(mons, key)
 		}
 	}
 
-	for _, node := range nodes {
+	for key, node := range nodes {
+		onErr := func(err error) {
+			delete(nodes, key)
+			errG.Add(fmt.Errorf("cannot load secret for VMNodeScrape: %w", err))
+		}
 		if node.Spec.BasicAuth != nil {
 			credentials, err := loadBasicAuthSecretFromAPI(ctx,
 				rclient,
@@ -380,7 +431,8 @@ func loadScrapeSecrets(
 				node.Namespace,
 				nsSecretCache)
 			if err != nil {
-				return nil, fmt.Errorf("could not generate basicAuth for vmNodeScrape %s. %w", node.Name, err)
+				onErr(err)
+				continue
 			}
 			baSecrets[node.AsMapKey()] = credentials
 
@@ -388,57 +440,63 @@ func loadScrapeSecrets(
 		if node.Spec.OAuth2 != nil {
 			oauth2, err := loadOAuthSecrets(ctx, rclient, node.Spec.OAuth2, node.Namespace, nsSecretCache, nsCMCache)
 			if err != nil {
-				return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", node.Name, node.Namespace, err)
+				onErr(err)
+				continue
 			}
 			oauth2Secret[node.AsMapKey()] = oauth2
 		}
 		if node.Spec.BearerTokenSecret != nil && node.Spec.BearerTokenSecret.Name != "" {
 			token, err := getCredFromSecret(ctx, rclient, node.Namespace, node.Spec.BearerTokenSecret, buildCacheKey(node.Namespace, node.Spec.BearerTokenSecret.Name), nsSecretCache)
 			if err != nil {
-				return nil, err
+				onErr(err)
+				continue
 			}
 			bearerSecrets[node.AsMapKey()] = token
 		}
 		if node.Spec.VMScrapeParams != nil && node.Spec.VMScrapeParams.ProxyClientConfig != nil {
 			ba, token, err := loadProxySecrets(ctx, rclient, node.Spec.VMScrapeParams.ProxyClientConfig, node.Namespace, nsSecretCache)
 			if err != nil {
-				return nil, err
+				onErr(err)
+				continue
 			}
 			if ba != nil {
 				baSecrets[node.AsProxyKey()] = ba
 			}
 			bearerSecrets[node.AsProxyKey()] = token
-
 		}
-
 	}
-	for _, pod := range pods {
+	for key, pod := range pods {
+		var epCnt int
 		for i, ep := range pod.Spec.PodMetricsEndpoints {
 			if ep.BasicAuth != nil {
 				credentials, err := loadBasicAuthSecretFromAPI(ctx, rclient, ep.BasicAuth, pod.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("could not generate basicAuth for vmpodscrapee %s. %w", pod.Name, err)
+					errG.Add(fmt.Errorf("cannot load secret for VMPodScrape: %w", err))
+					continue
 				}
 				baSecrets[pod.AsMapKey(i)] = credentials
 			}
 			if ep.OAuth2 != nil {
 				oauth2, err := loadOAuthSecrets(ctx, rclient, ep.OAuth2, pod.Namespace, nsSecretCache, nsCMCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", pod.Name, pod.Namespace, err)
+					errG.Add(fmt.Errorf("cannot load secret for VMPodScrape: %w", err))
+					continue
 				}
 				oauth2Secret[pod.AsMapKey(i)] = oauth2
 			}
 			if ep.BearerTokenSecret != nil && ep.BearerTokenSecret.Name != "" {
 				token, err := getCredFromSecret(ctx, rclient, pod.Namespace, ep.BearerTokenSecret, buildCacheKey(pod.Namespace, ep.BearerTokenSecret.Name), nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("cannot load secret for VMPodScrape: %w", err))
+					continue
 				}
 				bearerSecrets[pod.AsMapKey(i)] = token
 			}
 			if ep.VMScrapeParams != nil && ep.VMScrapeParams.ProxyClientConfig != nil {
 				ba, token, err := loadProxySecrets(ctx, rclient, ep.VMScrapeParams.ProxyClientConfig, pod.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("cannot load secret for VMPodScrape: %w", err))
+					continue
 				}
 				if ba != nil {
 					baSecrets[pod.AsProxyKey(i)] = ba
@@ -448,39 +506,54 @@ func loadScrapeSecrets(
 			if ep.Authorization != nil && ep.Authorization.Credentials != nil {
 				secretValue, err := getCredFromSecret(ctx, rclient, pod.Namespace, ep.Authorization.Credentials, buildCacheKey(pod.Namespace, ep.Authorization.Credentials.Name), nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot fetch authorization secret value: %w", err)
+					errG.Add(fmt.Errorf("cannot load secret for VMPodScrape: %w", err))
+					continue
 				}
 				authorizationSecrets[pod.AsMapKey(i)] = secretValue
 			}
+			pod.Spec.PodMetricsEndpoints[epCnt] = ep
+			epCnt++
+		}
+		pod.Spec.PodMetricsEndpoints = pod.Spec.PodMetricsEndpoints[:epCnt]
+		if len(pod.Spec.PodMetricsEndpoints) == 0 {
+			delete(pods, key)
 		}
 	}
 
-	for _, probe := range probes {
+	for key, probe := range probes {
+		onErr := func(err error) {
+			delete(nodes, key)
+			errG.Add(fmt.Errorf("cannot load secret for VMProbe: %w", err))
+		}
 		if probe.Spec.BasicAuth != nil {
 			credentials, err := loadBasicAuthSecretFromAPI(ctx, rclient, probe.Spec.BasicAuth, probe.Namespace, nsSecretCache)
 			if err != nil {
-				return nil, fmt.Errorf("could not generate basicAuth for vmstaticScrape %s. %w", probe.Name, err)
+				onErr(fmt.Errorf("could not generate basicAuth for vmstaticScrape %s. %w", probe.Name, err))
+				continue
 			}
 			baSecrets[probe.AsMapKey()] = credentials
 		}
 		if probe.Spec.OAuth2 != nil {
 			oauth2, err := loadOAuthSecrets(ctx, rclient, probe.Spec.OAuth2, probe.Namespace, nsSecretCache, nsCMCache)
 			if err != nil {
-				return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", probe.Name, probe.Namespace, err)
+				onErr(err)
+				continue
 			}
 			oauth2Secret[probe.AsMapKey()] = oauth2
 		}
 		if probe.Spec.BearerTokenSecret != nil && probe.Spec.BearerTokenSecret.Name != "" {
 			token, err := getCredFromSecret(ctx, rclient, probe.Namespace, probe.Spec.BearerTokenSecret, buildCacheKey(probe.Namespace, probe.Spec.BearerTokenSecret.Name), nsSecretCache)
 			if err != nil {
-				return nil, err
+				onErr(err)
+				continue
 			}
 			bearerSecrets[probe.AsMapKey()] = token
 		}
 		if probe.Spec.VMScrapeParams != nil && probe.Spec.VMScrapeParams.ProxyClientConfig != nil {
 			ba, token, err := loadProxySecrets(ctx, rclient, probe.Spec.VMScrapeParams.ProxyClientConfig, probe.Namespace, nsSecretCache)
 			if err != nil {
-				return nil, err
+				onErr(err)
+				continue
 			}
 			if ba != nil {
 				baSecrets[probe.AsProxyKey()] = ba
@@ -490,39 +563,45 @@ func loadScrapeSecrets(
 		if probe.Spec.Authorization != nil && probe.Spec.Authorization.Credentials != nil {
 			secretValue, err := getCredFromSecret(ctx, rclient, probe.Namespace, probe.Spec.Authorization.Credentials, buildCacheKey(probe.Namespace, probe.Spec.Authorization.Credentials.Name), nsSecretCache)
 			if err != nil {
-				return nil, fmt.Errorf("cannot fetch authorization secret value: %w", err)
+				onErr(err)
+				continue
 			}
 			authorizationSecrets[probe.AsMapKey()] = secretValue
 		}
 	}
 
-	for _, staticCfg := range statics {
+	for key, staticCfg := range statics {
+		var epCnt int
 		for i, ep := range staticCfg.Spec.TargetEndpoints {
 			if ep.BasicAuth != nil {
 				credentials, err := loadBasicAuthSecretFromAPI(ctx, rclient, ep.BasicAuth, staticCfg.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("could not generate basicAuth for vmstaticScrape %s. %w", staticCfg.Name, err)
+					errG.Add(fmt.Errorf("could not load secret for vmstaticScrape:  %w", err))
+					continue
 				}
 				baSecrets[staticCfg.AsMapKey(i)] = credentials
 			}
 			if ep.OAuth2 != nil {
 				oauth2, err := loadOAuthSecrets(ctx, rclient, ep.OAuth2, staticCfg.Namespace, nsSecretCache, nsCMCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", staticCfg.Name, staticCfg.Namespace, err)
+					errG.Add(fmt.Errorf("could not load secret for vmstaticScrape:  %w", err))
+					continue
 				}
 				oauth2Secret[staticCfg.AsMapKey(i)] = oauth2
 			}
 			if ep.BearerTokenSecret != nil && ep.BearerTokenSecret.Name != "" {
 				token, err := getCredFromSecret(ctx, rclient, staticCfg.Namespace, ep.BearerTokenSecret, buildCacheKey(staticCfg.Namespace, ep.BearerTokenSecret.Name), nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("could not load secret for vmstaticScrape:  %w", err))
+					continue
 				}
 				bearerSecrets[staticCfg.AsMapKey(i)] = token
 			}
 			if ep.VMScrapeParams != nil && ep.VMScrapeParams.ProxyClientConfig != nil {
 				ba, token, err := loadProxySecrets(ctx, rclient, ep.VMScrapeParams.ProxyClientConfig, staticCfg.Namespace, nsSecretCache)
 				if err != nil {
-					return nil, err
+					errG.Add(fmt.Errorf("could not load secret for vmstaticScrape:  %w", err))
+					continue
 				}
 				if ba != nil {
 					baSecrets[staticCfg.AsProxyKey(i)] = ba
@@ -532,14 +611,23 @@ func loadScrapeSecrets(
 			if ep.Authorization != nil && ep.Authorization.Credentials != nil {
 				secretValue, err := getCredFromSecret(ctx, rclient, staticCfg.Namespace, ep.Authorization.Credentials, buildCacheKey(staticCfg.Namespace, ep.Authorization.Credentials.Name), nsSecretCache)
 				if err != nil {
-					return nil, fmt.Errorf("cannot fetch authorization secret value: %w", err)
+					errG.Add(fmt.Errorf("could not load secret for vmstaticScrape:  %w", err))
+					continue
 				}
 				authorizationSecrets[staticCfg.AsMapKey(i)] = secretValue
 			}
+			staticCfg.Spec.TargetEndpoints[epCnt] = ep
+			epCnt++
+		}
+		staticCfg.Spec.TargetEndpoints = staticCfg.Spec.TargetEndpoints[:epCnt]
+		if len(staticCfg.Spec.TargetEndpoints) == 0 {
+			delete(statics, key)
 		}
 	}
 
 	// load apiserver basic auth secret
+	// no need to filter out misconfiguration
+	// it's VMAgent owner responsibility
 	if apiserverConfig != nil {
 		if apiserverConfig.BasicAuth != nil {
 			credentials, err := loadBasicAuthSecret(ctx, rclient, namespace, apiserverConfig.BasicAuth)
@@ -558,6 +646,8 @@ func loadScrapeSecrets(
 	}
 
 	// load basic auth for remote write configuration
+	// no need to filter out misconfiguration
+	// it's VMAgent owner responsibility
 	for _, rws := range remoteWriteSpecs {
 		if rws.BasicAuth != nil {
 			credentials, err := loadBasicAuthSecret(ctx, rclient, namespace, rws.BasicAuth)
@@ -583,12 +673,12 @@ func loadScrapeSecrets(
 		}
 	}
 
-	return &scrapesSecretsCache{baSecrets: baSecrets, oauth2Secrets: oauth2Secret, bearerTokens: bearerSecrets, authorizationSecrets: authorizationSecrets}, nil
+	return &scrapesSecretsCache{baSecrets: baSecrets, oauth2Secrets: oauth2Secret, bearerTokens: bearerSecrets, authorizationSecrets: authorizationSecrets}, errG.Err()
 }
 
 func loadBasicAuthSecret(ctx context.Context, rclient client.Client, ns string, basicAuth *victoriametricsv1beta1.BasicAuth) (BasicAuthCredentials, error) {
 	var err error
-	var bas v1.Secret
+	var bas corev1.Secret
 	var bac BasicAuthCredentials
 	if err := rclient.Get(ctx, types.NamespacedName{Namespace: ns, Name: basicAuth.Username.Name}, &bas); err != nil {
 		if errors.IsNotFound(err) {
@@ -620,7 +710,7 @@ func loadBasicAuthSecret(ctx context.Context, rclient client.Client, ns string, 
 
 }
 
-func extractCredKey(secret *v1.Secret, sel v1.SecretKeySelector) (string, error) {
+func extractCredKey(secret *corev1.Secret, sel corev1.SecretKeySelector) (string, error) {
 	if s, ok := secret.Data[sel.Key]; ok {
 		return string(s), nil
 	}
@@ -631,45 +721,42 @@ func getCredFromSecret(
 	ctx context.Context,
 	rclient client.Client,
 	ns string,
-	sel *v1.SecretKeySelector,
+	sel *corev1.SecretKeySelector,
 	cacheKey string,
-	cache map[string]*v1.Secret,
+	cache map[string]*corev1.Secret,
 ) (string, error) {
-	var s *v1.Secret
+	var s *corev1.Secret
 	var ok bool
 	if sel == nil {
 		return "", fmt.Errorf("BUG, secret key selector must be non nil for cache key: %s, ns: %s", cacheKey, ns)
 	}
 	if s, ok = cache[cacheKey]; !ok {
-		s = &v1.Secret{}
+		s = &corev1.Secret{}
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: ns, Name: sel.Name}, s); err != nil {
-			return "", fmt.Errorf("unable to fetch key from secret%s: %w", sel.Name, err)
+			return "", fmt.Errorf("unable to fetch key from secret: %q for object: %q : %w", sel.Name, cacheKey, err)
 		}
 		cache[cacheKey] = s
 	}
-
-	l := make(chan struct{})
-	select {
-	case l <- struct{}{}:
-	default:
-
+	v, err := extractCredKey(s, *sel)
+	if err != nil {
+		return "", fmt.Errorf("cannot find key: %q at secret: %q for object: %q", sel.Key, s.Name, cacheKey)
 	}
-	return extractCredKey(s, *sel)
+	return v, nil
 }
 
 func getCredFromConfigMap(
 	ctx context.Context,
 	rclient client.Client,
 	ns string,
-	sel v1.ConfigMapKeySelector,
+	sel corev1.ConfigMapKeySelector,
 	cacheKey string,
-	cache map[string]*v1.ConfigMap,
+	cache map[string]*corev1.ConfigMap,
 ) (string, error) {
-	var s *v1.ConfigMap
+	var s *corev1.ConfigMap
 	var ok bool
 
 	if s, ok = cache[cacheKey]; !ok {
-		s = &v1.ConfigMap{}
+		s = &corev1.ConfigMap{}
 		err := rclient.Get(ctx, types.NamespacedName{Namespace: ns, Name: sel.Name}, s)
 		if err != nil {
 			return "", fmt.Errorf("cannot get configmap: %s at namespace %s, err: %s", sel.Name, ns, err)
@@ -683,7 +770,7 @@ func getCredFromConfigMap(
 	return "", fmt.Errorf("key not found at configmap, key: %s, configmap %s ", sel.Key, sel.Name)
 }
 
-func loadBasicAuthSecretFromAPI(ctx context.Context, rclient client.Client, basicAuth *victoriametricsv1beta1.BasicAuth, ns string, cache map[string]*v1.Secret) (*BasicAuthCredentials, error) {
+func loadBasicAuthSecretFromAPI(ctx context.Context, rclient client.Client, basicAuth *victoriametricsv1beta1.BasicAuth, ns string, cache map[string]*corev1.Secret) (*BasicAuthCredentials, error) {
 	var username string
 	var password string
 	var err error
@@ -708,11 +795,12 @@ func buildCacheKey(ns, keyName string) string {
 	return fmt.Sprintf("%s/%s", ns, keyName)
 }
 
-func loadProxySecrets(ctx context.Context, rclient client.Client, proxyCfg *victoriametricsv1beta1.ProxyAuth, ns string, cache map[string]*v1.Secret) (ba *BasicAuthCredentials, token string, err error) {
+func loadProxySecrets(ctx context.Context, rclient client.Client, proxyCfg *victoriametricsv1beta1.ProxyAuth, ns string, cache map[string]*corev1.Secret) (ba *BasicAuthCredentials, token string, err error) {
 
 	if proxyCfg.BasicAuth != nil {
 		ba, err = loadBasicAuthSecretFromAPI(ctx, rclient, proxyCfg.BasicAuth, ns, cache)
 		if err != nil {
+			err = fmt.Errorf("cannot load basic auth proxy secret: %w", err)
 			return
 		}
 
@@ -727,12 +815,14 @@ func loadProxySecrets(ctx context.Context, rclient client.Client, proxyCfg *vict
 			cache,
 		)
 		if err != nil {
+			err = fmt.Errorf("cannot load bearer token proxy secret: %w", err)
 			return
 		}
 	}
 	return
 }
-func loadOAuthSecrets(ctx context.Context, rclient client.Client, oauth2 *victoriametricsv1beta1.OAuth2, ns string, cache map[string]*v1.Secret, cmCache map[string]*v1.ConfigMap) (*oauthCreds, error) {
+
+func loadOAuthSecrets(ctx context.Context, rclient client.Client, oauth2 *victoriametricsv1beta1.OAuth2, ns string, cache map[string]*corev1.Secret, cmCache map[string]*corev1.ConfigMap) (*oauthCreds, error) {
 	var r oauthCreds
 	if oauth2.ClientSecret != nil {
 		s, err := getCredFromSecret(ctx, rclient, ns, oauth2.ClientSecret, buildCacheKey(ns, oauth2.ClientSecret.Name), cache)
@@ -758,9 +848,9 @@ func loadOAuthSecrets(ctx context.Context, rclient client.Client, oauth2 *victor
 	return &r, nil
 }
 
-func loadAdditionalScrapeConfigsSecret(ctx context.Context, rclient client.Client, additionalScrapeConfigs *v1.SecretKeySelector, namespace string) ([]byte, error) {
+func loadAdditionalScrapeConfigsSecret(ctx context.Context, rclient client.Client, additionalScrapeConfigs *corev1.SecretKeySelector, namespace string) ([]byte, error) {
 	if additionalScrapeConfigs != nil {
-		var s v1.Secret
+		var s corev1.Secret
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: additionalScrapeConfigs.Name}, &s); err != nil {
 			if errors.IsNotFound(err) {
 				return nil, fmt.Errorf("cannot find secret with additional config for vmagent, secret: %s, namespace: %s", additionalScrapeConfigs.Name, namespace)
@@ -807,7 +897,7 @@ func gzipConfig(buf *bytes.Buffer, conf []byte) error {
 	return nil
 }
 
-func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client, service *v1.Service, serviceScrapeSpec *victoriametricsv1beta1.VMServiceScrapeSpec, metricPath string, filterPortNames ...string) error {
+func CreateVMServiceScrapeFromService(ctx context.Context, rclient client.Client, service *corev1.Service, serviceScrapeSpec *victoriametricsv1beta1.VMServiceScrapeSpec, metricPath string, filterPortNames ...string) error {
 	endPoints := []victoriametricsv1beta1.Endpoint{}
 	for _, servicePort := range service.Spec.Ports {
 		var nameMatched bool

--- a/controllers/factory/scrapes_test.go
+++ b/controllers/factory/scrapes_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -73,12 +73,12 @@ func TestSelectServiceMonitors(t *testing.T) {
 				l: logf.Log.WithName("unit-test"),
 			},
 			predefinedObjects: []runtime.Object{
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 				&victoriametricsv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "default-monitor"},
 					Spec:       victoriametricsv1beta1.VMServiceScrapeSpec{},
 				},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "stg", Labels: map[string]string{"name": "stage"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "stg", Labels: map[string]string{"name": "stage"}}},
 				&victoriametricsv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "stg", Name: "default-monitor"},
 					Spec:       victoriametricsv1beta1.VMServiceScrapeSpec{},
@@ -163,7 +163,7 @@ func TestSelectPodMonitors(t *testing.T) {
 				l: logf.Log.WithName("unit-test"),
 			},
 			predefinedObjects: []runtime.Object{
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitor", Labels: map[string]string{"name": "monitoring"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitor", Labels: map[string]string{"name": "monitoring"}}},
 				&victoriametricsv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod2",
@@ -171,7 +171,7 @@ func TestSelectPodMonitors(t *testing.T) {
 					},
 					Spec: victoriametricsv1beta1.VMPodScrapeSpec{},
 				},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 				&victoriametricsv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pod1",
@@ -207,9 +207,9 @@ func TestSelectPodMonitors(t *testing.T) {
 func Test_getCredFromConfigMap(t *testing.T) {
 	type args struct {
 		ns       string
-		sel      v1.ConfigMapKeySelector
+		sel      corev1.ConfigMapKeySelector
 		cacheKey string
-		cache    map[string]*v1.ConfigMap
+		cache    map[string]*corev1.ConfigMap
 	}
 	tests := []struct {
 		name              string
@@ -222,11 +222,11 @@ func Test_getCredFromConfigMap(t *testing.T) {
 			name: "extract key from cm",
 			args: args{
 				ns:    "default",
-				sel:   v1.ConfigMapKeySelector{Key: "tls-conf", LocalObjectReference: v1.LocalObjectReference{Name: "tls-cm"}},
-				cache: map[string]*v1.ConfigMap{},
+				sel:   corev1.ConfigMapKeySelector{Key: "tls-conf", LocalObjectReference: corev1.LocalObjectReference{Name: "tls-cm"}},
+				cache: map[string]*corev1.ConfigMap{},
 			},
 			predefinedObjects: []runtime.Object{
-				&v1.ConfigMap{
+				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: "tls-cm", Namespace: "default"},
 					Data:       map[string]string{"tls-conf": "secret-data"},
 				},
@@ -254,9 +254,9 @@ func Test_getCredFromConfigMap(t *testing.T) {
 func Test_getCredFromSecret(t *testing.T) {
 	type args struct {
 		ns       string
-		sel      v1.SecretKeySelector
+		sel      corev1.SecretKeySelector
 		cacheKey string
-		cache    map[string]*v1.Secret
+		cache    map[string]*corev1.Secret
 	}
 	tests := []struct {
 		name              string
@@ -269,16 +269,16 @@ func Test_getCredFromSecret(t *testing.T) {
 			name: "extract tls key data from secret",
 			args: args{
 				ns: "default",
-				sel: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
+				sel: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{
 					Name: "tls-secret"},
 					Key: "key.pem"},
 				cacheKey: "tls-secret",
-				cache:    map[string]*v1.Secret{},
+				cache:    map[string]*corev1.Secret{},
 			},
 			want:    "tls-key-data",
 			wantErr: false,
 			predefinedObjects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "tls-secret",
 						Namespace: "default",
@@ -291,16 +291,16 @@ func Test_getCredFromSecret(t *testing.T) {
 			name: "fail extract missing tls cert data from secret",
 			args: args{
 				ns: "default",
-				sel: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{
+				sel: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{
 					Name: "tls-secret"},
 					Key: "cert.pem"},
 				cacheKey: "tls-secret",
-				cache:    map[string]*v1.Secret{},
+				cache:    map[string]*corev1.Secret{},
 			},
 			want:    "",
 			wantErr: true,
 			predefinedObjects: []runtime.Object{
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "tls-secret",
 						Namespace: "default",
@@ -418,12 +418,12 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 				c: config.MustGetBaseConfig(),
 			},
 			predefinedObjects: []runtime.Object{
-				&v1.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "default",
 					},
 				},
-				&v1.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "kube-system",
 					},
@@ -441,9 +441,9 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 							{
 								Path: "/metrics",
 								Port: "8085",
-								BearerTokenSecret: &v1.SecretKeySelector{
+								BearerTokenSecret: &corev1.SecretKeySelector{
 									Key: "bearer",
-									LocalObjectReference: v1.LocalObjectReference{
+									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "access-creds",
 									},
 								},
@@ -496,21 +496,21 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 									ProxyClientConfig: &victoriametricsv1beta1.ProxyAuth{
 										TLSConfig: &victoriametricsv1beta1.TLSConfig{
 											InsecureSkipVerify: true,
-											KeySecret: &v1.SecretKeySelector{
+											KeySecret: &corev1.SecretKeySelector{
 												Key: "key",
-												LocalObjectReference: v1.LocalObjectReference{
+												LocalObjectReference: corev1.LocalObjectReference{
 													Name: "access-creds",
 												},
 											},
-											Cert: victoriametricsv1beta1.SecretOrConfigMap{Secret: &v1.SecretKeySelector{
+											Cert: victoriametricsv1beta1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
 												Key: "cert",
-												LocalObjectReference: v1.LocalObjectReference{
+												LocalObjectReference: corev1.LocalObjectReference{
 													Name: "access-creds",
 												},
 											}},
-											CA: victoriametricsv1beta1.SecretOrConfigMap{Secret: &v1.SecretKeySelector{
+											CA: victoriametricsv1beta1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
 												Key: "ca",
-												LocalObjectReference: v1.LocalObjectReference{
+												LocalObjectReference: corev1.LocalObjectReference{
 													Name: "access-creds",
 												},
 											},
@@ -524,21 +524,21 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 								Path: "/metrics-5",
 								TLSConfig: &victoriametricsv1beta1.TLSConfig{
 									InsecureSkipVerify: true,
-									KeySecret: &v1.SecretKeySelector{
+									KeySecret: &corev1.SecretKeySelector{
 										Key: "key",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "access-creds",
 										},
 									},
-									Cert: victoriametricsv1beta1.SecretOrConfigMap{Secret: &v1.SecretKeySelector{
+									Cert: victoriametricsv1beta1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
 										Key: "cert",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "access-creds",
 										},
 									}},
-									CA: victoriametricsv1beta1.SecretOrConfigMap{Secret: &v1.SecretKeySelector{
+									CA: victoriametricsv1beta1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
 										Key: "ca",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "access-creds",
 										},
 									},
@@ -555,15 +555,15 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 					},
 					Spec: victoriametricsv1beta1.VMNodeScrapeSpec{
 						BasicAuth: &victoriametricsv1beta1.BasicAuth{
-							Username: v1.SecretKeySelector{
+							Username: corev1.SecretKeySelector{
 								Key: "username",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "access-creds",
 								},
 							},
-							Password: v1.SecretKeySelector{
+							Password: corev1.SecretKeySelector{
 								Key: "password",
-								LocalObjectReference: v1.LocalObjectReference{
+								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "access-creds",
 								},
 							},
@@ -584,16 +584,16 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 								ProxyURL: pointer.String("https://some-proxy-1"),
 								OAuth2: &victoriametricsv1beta1.OAuth2{
 									TokenURL: "https://some-tr",
-									ClientSecret: &v1.SecretKeySelector{
+									ClientSecret: &corev1.SecretKeySelector{
 										Key: "cs",
-										LocalObjectReference: v1.LocalObjectReference{
+										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "access-creds",
 										},
 									},
 									ClientID: victoriametricsv1beta1.SecretOrConfigMap{
-										Secret: &v1.SecretKeySelector{
+										Secret: &corev1.SecretKeySelector{
 											Key: "cid",
-											LocalObjectReference: v1.LocalObjectReference{
+											LocalObjectReference: corev1.LocalObjectReference{
 												Name: "access-creds",
 											},
 										},
@@ -603,7 +603,7 @@ func TestCreateOrUpdateConfigurationSecret(t *testing.T) {
 						},
 					},
 				},
-				&v1.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "access-creds",
 						Namespace: "default",
@@ -861,6 +861,297 @@ scrape_configs:
     token_url: https://some-tr
 `,
 		},
+		{
+			name: "with missing secret references",
+			args: args{
+
+				cr: &victoriametricsv1beta1.VMAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: victoriametricsv1beta1.VMAgentSpec{
+						ServiceScrapeNamespaceSelector: &metav1.LabelSelector{},
+						ServiceScrapeSelector:          &metav1.LabelSelector{},
+						PodScrapeSelector:              &metav1.LabelSelector{},
+						PodScrapeNamespaceSelector:     &metav1.LabelSelector{},
+						NodeScrapeNamespaceSelector:    &metav1.LabelSelector{},
+						NodeScrapeSelector:             &metav1.LabelSelector{},
+						StaticScrapeNamespaceSelector:  &metav1.LabelSelector{},
+						StaticScrapeSelector:           &metav1.LabelSelector{},
+						ProbeNamespaceSelector:         &metav1.LabelSelector{},
+						ProbeSelector:                  &metav1.LabelSelector{},
+					},
+				},
+				c: config.MustGetBaseConfig(),
+			},
+
+			predefinedObjects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				},
+
+				&victoriametricsv1beta1.VMNodeScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-bad-0",
+					},
+					Spec: victoriametricsv1beta1.VMNodeScrapeSpec{
+						BasicAuth: &victoriametricsv1beta1.BasicAuth{
+							Username: corev1.SecretKeySelector{
+								Key: "username",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "access-creds",
+								},
+							},
+							Password: corev1.SecretKeySelector{
+								Key: "password",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "access-creds",
+								},
+							},
+						},
+					},
+				},
+
+				&victoriametricsv1beta1.VMNodeScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-good",
+					},
+					Spec: victoriametricsv1beta1.VMNodeScrapeSpec{},
+				},
+
+				&victoriametricsv1beta1.VMNodeScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "bad-1",
+					},
+					Spec: victoriametricsv1beta1.VMNodeScrapeSpec{
+						BearerTokenSecret: &corev1.SecretKeySelector{
+							Key: "username",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "access-creds",
+							},
+						},
+					},
+				},
+				&victoriametricsv1beta1.VMPodScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-vps-mixed",
+					},
+					Spec: victoriametricsv1beta1.VMPodScrapeSpec{
+						JobLabel:          "app",
+						NamespaceSelector: victoriametricsv1beta1.NamespaceSelector{},
+						Selector: metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"prod"},
+								},
+							},
+						},
+						SampleLimit: 10,
+						PodMetricsEndpoints: []victoriametricsv1beta1.PodMetricsEndpoint{
+							{
+								Path: "/metrics-3",
+								Port: "805",
+								VMScrapeParams: &victoriametricsv1beta1.VMScrapeParams{
+									StreamParse: pointer.Bool(true),
+									ProxyClientConfig: &victoriametricsv1beta1.ProxyAuth{
+										BearerToken: &corev1.SecretKeySelector{
+											Key: "username",
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "access-creds",
+											},
+										},
+									},
+								},
+							},
+							{
+								Port: "801",
+								Path: "/metrics-5",
+								BasicAuth: &victoriametricsv1beta1.BasicAuth{
+									Username: corev1.SecretKeySelector{
+										Key: "username",
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "access-creds",
+										},
+									},
+									Password: corev1.SecretKeySelector{
+										Key: "password",
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "access-creds",
+										},
+									},
+								},
+							},
+							{
+								Port: "801",
+								Path: "/metrics-5-good",
+							},
+						},
+					},
+				},
+				&victoriametricsv1beta1.VMPodScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-vps-good",
+					},
+					Spec: victoriametricsv1beta1.VMPodScrapeSpec{
+						JobLabel:          "app",
+						NamespaceSelector: victoriametricsv1beta1.NamespaceSelector{},
+						Selector: metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"prod"},
+								},
+							},
+						},
+						PodMetricsEndpoints: []victoriametricsv1beta1.PodMetricsEndpoint{
+							{
+								Port: "8011",
+								Path: "/metrics-1-good",
+							},
+						},
+					},
+				},
+				&victoriametricsv1beta1.VMStaticScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-vmstatic-bad",
+					},
+					Spec: victoriametricsv1beta1.VMStaticScrapeSpec{
+						TargetEndpoints: []*victoriametricsv1beta1.TargetEndpoint{
+							{
+								Path:     "/metrics-3",
+								Port:     "3031",
+								Scheme:   "https",
+								ProxyURL: pointer.String("https://some-proxy-1"),
+								OAuth2: &victoriametricsv1beta1.OAuth2{
+									TokenURL: "https://some-tr",
+									ClientSecret: &corev1.SecretKeySelector{
+										Key: "cs",
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "access-creds",
+										},
+									},
+									ClientID: victoriametricsv1beta1.SecretOrConfigMap{
+										Secret: &corev1.SecretKeySelector{
+											Key: "cid",
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "access-creds",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantConfig: `global:
+  scrape_interval: 30s
+  external_labels:
+    prometheus: default/test
+scrape_configs:
+- job_name: podScrape/default/test-vps-good/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - default
+  metrics_path: /metrics-1-good
+  relabel_configs:
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_label_app
+    regex: prod
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: "8011"
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - target_label: job
+    replacement: default/test-vps-good
+  - source_labels:
+    - __meta_kubernetes_pod_label_app
+    target_label: job
+    regex: (.+)
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: "8011"
+- job_name: podScrape/default/test-vps-mixed/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - default
+  metrics_path: /metrics-5-good
+  relabel_configs:
+  - action: drop
+    source_labels:
+    - __meta_kubernetes_pod_phase
+    regex: (Failed|Succeeded)
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_label_app
+    regex: prod
+  - action: keep
+    source_labels:
+    - __meta_kubernetes_pod_container_port_name
+    regex: "801"
+  - source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
+  - source_labels:
+    - __meta_kubernetes_pod_container_name
+    target_label: container
+  - source_labels:
+    - __meta_kubernetes_pod_name
+    target_label: pod
+  - target_label: job
+    replacement: default/test-vps-mixed
+  - source_labels:
+    - __meta_kubernetes_pod_label_app
+    target_label: job
+    regex: (.+)
+    replacement: ${1}
+  - target_label: endpoint
+    replacement: "801"
+  sample_limit: 10
+- job_name: nodeScrape/default/test-good/0
+  honor_labels: false
+  kubernetes_sd_configs:
+  - role: node
+  relabel_configs:
+  - source_labels:
+    - __meta_kubernetes_node_name
+    target_label: node
+  - target_label: job
+    replacement: default/test-good
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -868,7 +1159,7 @@ scrape_configs:
 			if _, err := CreateOrUpdateConfigurationSecret(context.TODO(), tt.args.cr, testClient, tt.args.c); (err != nil) != tt.wantErr {
 				t.Errorf("CreateOrUpdateConfigurationSecret() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			var expectSecret v1.Secret
+			var expectSecret corev1.Secret
 			if err := testClient.Get(context.TODO(), types.NamespacedName{Namespace: tt.args.cr.Namespace, Name: tt.args.cr.PrefixedName()}, &expectSecret); err != nil {
 				t.Fatalf("cannot get vmagent config secret: %s", err)
 			}
@@ -892,7 +1183,7 @@ scrape_configs:
 
 func TestCreateVMServiceScrapeFromService(t *testing.T) {
 	type args struct {
-		service                   *v1.Service
+		service                   *corev1.Service
 		serviceScrapeSpecTemplate *victoriametricsv1beta1.VMServiceScrapeSpec
 		metricPath                string
 		filterPortNames           []string
@@ -908,13 +1199,13 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 			args: args{
 				metricPath:      "/metrics",
 				filterPortNames: []string{"http"},
-				service: &v1.Service{
+				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "vmagent-svc",
 						Labels: map[string]string{"my-label": "value"},
 					},
-					Spec: v1.ServiceSpec{
-						Ports: []v1.ServicePort{
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
 							{
 								Name: "http",
 							},
@@ -940,12 +1231,12 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 			args: args{
 				metricPath:      "/metrics",
 				filterPortNames: []string{"http"},
-				service: &v1.Service{
+				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "vmagent-svc",
 					},
-					Spec: v1.ServiceSpec{
-						Ports: []v1.ServicePort{
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
 							{
 								Name: "http",
 							},
@@ -971,15 +1262,15 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 			args: args{
 				metricPath:      "/metrics",
 				filterPortNames: []string{"http"},
-				service: &v1.Service{
+				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "vmagent-svc",
 						Labels: map[string]string{
 							"key": "value",
 						},
 					},
-					Spec: v1.ServiceSpec{
-						Ports: []v1.ServicePort{
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
 							{
 								Name: "http",
 							},
@@ -1006,15 +1297,15 @@ func TestCreateVMServiceScrapeFromService(t *testing.T) {
 			args: args{
 				metricPath:      "/metrics",
 				filterPortNames: []string{"http"},
-				service: &v1.Service{
+				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "vmagent-svc",
 						Labels: map[string]string{
 							"key": "value",
 						},
 					},
-					Spec: v1.ServiceSpec{
-						Ports: []v1.ServicePort{
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
 							{
 								Name: "http",
 							},

--- a/controllers/factory/scrapes_test.go
+++ b/controllers/factory/scrapes_test.go
@@ -1055,6 +1055,32 @@ scrape_configs:
 						},
 					},
 				},
+				&victoriametricsv1beta1.VMStaticScrape{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "test-vmstatic-bad-tls",
+					},
+					Spec: victoriametricsv1beta1.VMStaticScrapeSpec{
+						TargetEndpoints: []*victoriametricsv1beta1.TargetEndpoint{
+							{
+								Path:     "/metrics-3",
+								Port:     "3031",
+								Scheme:   "https",
+								ProxyURL: pointer.String("https://some-proxy-1"),
+								TLSConfig: &victoriametricsv1beta1.TLSConfig{
+									Cert: victoriametricsv1beta1.SecretOrConfigMap{
+										Secret: &corev1.SecretKeySelector{
+											Key: "cert",
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "tls-creds",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			wantConfig: `global:
   scrape_interval: 30s


### PR DESCRIPTION
End users may misconfigure VMPodScrape, VMServiceScrape or other object. And it breaks entire VMAgent service until admin fixes it. With those changes such objects will be skipped and VMAgent continues it's work. https://github.com/VictoriaMetrics/operator/issues/648