### PR TITLE
vmalertmanagerconfig: fix panic when build webhook config

### DIFF
--- a/controllers/factory/alertmanager/config.go
+++ b/controllers/factory/alertmanager/config.go
@@ -632,7 +632,7 @@ func (cb *configBuilder) buildWebhook(wh operatorv1beta1.WebhookConfig) error {
 	if url == "" {
 		return nil
 	} else {
-		err := parseURL(*wh.URL)
+		err := parseURL(url)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Operator will panic when vmalertmanagerconfig use WebhookConfig.URLSecret instead of WebhookConfig.URL.

So sorry for bringing it in https://github.com/VictoriaMetrics/operator/commit/89373b3ee1421fef93ec33cddea6e8a39959d02f!
