### PR TITLE
vmauth/vmagent:implement configuration initiation for custom config reloader

### DIFF
--- a/internal/config-reloader/file_watch.go
+++ b/internal/config-reloader/file_watch.go
@@ -53,7 +53,7 @@ func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 			return errNotModified
 		}
 		if err := writeNewContent(newData); err != nil {
-			return fmt.Errorf("cannot write content to file: %s, err: %w", fileName, err)
+			return fmt.Errorf("cannot write content to file: %s, err: %w", *configFileDst, err)
 		}
 
 		prevContent = newData
@@ -65,7 +65,7 @@ func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 		return nil
 	}
 	if err := update(*configFileName); err != nil {
-		logger.Errorf("cannot update file on init")
+		logger.Errorf("cannot update file on init: %v", err)
 	}
 	go func() {
 		defer fw.wg.Done()

--- a/internal/config-reloader/file_watch.go
+++ b/internal/config-reloader/file_watch.go
@@ -34,11 +34,11 @@ func newFileWatcher(file string) (*fileWatcher, error) {
 }
 
 type watcher interface {
-	startWatch(ctx context.Context, updates chan struct{})
+	startWatch(ctx context.Context, updates chan struct{}) error
 	close()
 }
 
-func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) {
+func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) error {
 	fw.wg.Add(1)
 	logger.Infof("starting file watcher")
 	var prevContent []byte
@@ -65,6 +65,9 @@ func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 		return nil
 	}
 	if err := update(*configFileName); err != nil {
+		if *onlyInitConfig {
+			return err
+		}
 		logger.Errorf("cannot update file on init: %v", err)
 	}
 	go func() {
@@ -87,6 +90,7 @@ func (fw *fileWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 			}
 		}
 	}()
+	return nil
 }
 
 func (fw *fileWatcher) close() {

--- a/internal/config-reloader/k8s_watch.go
+++ b/internal/config-reloader/k8s_watch.go
@@ -85,7 +85,7 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 
 var errNotModified = fmt.Errorf("file content not modified")
 
-func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) {
+func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) error {
 	var prevContent []byte
 	updateSecret := func(secret *v1.Secret) error {
 		newData, ok := secret.Data[*configSecretKey]
@@ -118,6 +118,9 @@ func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 		logger.Fatalf("cannot get secret during init secretName: %s, namespace: %s, err: %s", k.secretName, k.namespace, err)
 	}
 	if err := updateSecret(&s); err != nil {
+		if *onlyInitConfig {
+			return err
+		}
 		logger.Errorf("cannot update secret: %s", err)
 	}
 	k.wg.Add(1)
@@ -141,6 +144,7 @@ func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 			}
 		}
 	}()
+	return nil
 }
 
 func (k *k8sWatcher) close() {

--- a/internal/config-reloader/k8s_watch.go
+++ b/internal/config-reloader/k8s_watch.go
@@ -86,7 +86,6 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 var errNotModified = fmt.Errorf("file content not modified")
 
 func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) {
-
 	var prevContent []byte
 	updateSecret := func(secret *v1.Secret) error {
 		newData, ok := secret.Data[*configSecretKey]
@@ -141,7 +140,6 @@ func (k *k8sWatcher) startWatch(ctx context.Context, updates chan struct{}) {
 				return
 			}
 		}
-
 	}()
 }
 


### PR DESCRIPTION
implement https://github.com/VictoriaMetrics/operator/issues/619
1. add one-shot mode for config-reloader
2. use one-shot mode in initContainer if `VM_CUSTOMCONFIGRELOADERIMAGE` enabled