### PR TITLE
vmuser: remove rate limit on delete

### DIFF
--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -97,7 +97,7 @@ func CreateOrUpdateVMAuth(ctx context.Context, cr *victoriametricsv1beta1.VMAuth
 	}
 	newDeploy, err := newDeployForVMAuth(cr, c)
 	if err != nil {
-		return fmt.Errorf("cannot build new deploy for vmagent: %w", err)
+		return fmt.Errorf("cannot build new deploy for vmauth: %w", err)
 	}
 
 	return k8stools.HandleDeployUpdate(ctx, rclient, newDeploy)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,10 @@ var (
 	initNamespace sync.Once
 )
 
-const prefixVar = "VM"
-const UnLimitedResource = "unlimited"
+const (
+	prefixVar         = "VM"
+	UnLimitedResource = "unlimited"
+)
 
 // WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 // which specifies the Namespace to watch.
@@ -244,7 +246,7 @@ type BaseOperatorConf struct {
 	PodWaitReadyTimeout                         time.Duration `default:"80s"`
 	PodWaitReadyIntervalCheck                   time.Duration `default:"5s"`
 	PodWaitReadyInitDelay                       time.Duration `default:"10s"`
-	// configures force resync interval for VMAgent, VMAlert and VMAlertmanager
+	// configures force resync interval for VMAgent, VMAlert, VMAlertmanager and VMAuth
 	ForceResyncInterval time.Duration `default:"60s"`
 }
 


### PR DESCRIPTION
If a lot of vmusers got deleted in short term, it will be rate limited now. 
So most of them will stay there until manager resync or operator restart, along with their secret.
