### PR TITLE
configure resource requests for config reloader container

### DIFF
--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -406,12 +406,14 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 
 	amVolumeMounts = append(amVolumeMounts, cr.Spec.VolumeMounts...)
 
-	resources := v1.ResourceRequirements{Limits: v1.ResourceList{}}
+	resources := v1.ResourceRequirements{Limits: v1.ResourceList{}, Requests: v1.ResourceList{}}
 	if c.VMAlertManager.ConfigReloaderCPU != "0" && c.VMAgentDefault.UseDefaultResources {
 		resources.Limits[v1.ResourceCPU] = resource.MustParse(c.VMAlertManager.ConfigReloaderCPU)
+		resources.Requests[v1.ResourceCPU] = resource.MustParse(c.VMAlertManager.ConfigReloaderCPU)
 	}
 	if c.VMAlertManager.ConfigReloaderMemory != "0" && c.VMAgentDefault.UseDefaultResources {
 		resources.Limits[v1.ResourceMemory] = resource.MustParse(c.VMAlertManager.ConfigReloaderMemory)
+		resources.Requests[v1.ResourceMemory] = resource.MustParse(c.VMAlertManager.ConfigReloaderMemory)
 	}
 
 	terminationGracePeriod := int64(120)

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -1241,9 +1241,11 @@ func buildConfigReloaderContainer(cr *victoriametricsv1beta1.VMAgent, c *config.
 	}
 	if c.VMAgentDefault.ConfigReloaderCPU != "0" && c.VMAgentDefault.UseDefaultResources {
 		configReloaderResources.Limits[corev1.ResourceCPU] = resource.MustParse(c.VMAgentDefault.ConfigReloaderCPU)
+		configReloaderResources.Requests[corev1.ResourceCPU] = resource.MustParse(c.VMAgentDefault.ConfigReloaderCPU)
 	}
 	if c.VMAgentDefault.ConfigReloaderMemory != "0" && c.VMAgentDefault.UseDefaultResources {
 		configReloaderResources.Limits[corev1.ResourceMemory] = resource.MustParse(c.VMAgentDefault.ConfigReloaderMemory)
+		configReloaderResources.Requests[corev1.ResourceMemory] = resource.MustParse(c.VMAgentDefault.ConfigReloaderMemory)
 	}
 
 	configReloadArgs := buildConfigReloaderArgs(cr, c)

--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -390,12 +390,14 @@ func vmAlertSpecGen(cr *victoriametricsv1beta1.VMAlert, c *config.BaseOperatorCo
 		})
 	}
 
-	resources := corev1.ResourceRequirements{Limits: corev1.ResourceList{}}
+	resources := corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}}
 	if c.VMAlertDefault.ConfigReloaderCPU != "0" && c.VMAgentDefault.UseDefaultResources {
 		resources.Limits[corev1.ResourceCPU] = resource.MustParse(c.VMAlertDefault.ConfigReloaderCPU)
+		resources.Requests[corev1.ResourceCPU] = resource.MustParse(c.VMAlertDefault.ConfigReloaderCPU)
 	}
 	if c.VMAlertDefault.ConfigReloaderMemory != "0" && c.VMAgentDefault.UseDefaultResources {
 		resources.Limits[corev1.ResourceMemory] = resource.MustParse(c.VMAlertDefault.ConfigReloaderMemory)
+		resources.Requests[corev1.ResourceMemory] = resource.MustParse(c.VMAlertDefault.ConfigReloaderMemory)
 	}
 
 	var ports []corev1.ContainerPort

--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -465,9 +465,11 @@ func buildVMAuthConfigReloaderContainer(cr *victoriametricsv1beta1.VMAuth, c *co
 	}
 	if c.VMAuthDefault.ConfigReloaderCPU != "0" && c.VMAuthDefault.UseDefaultResources {
 		configReloaderResources.Limits[corev1.ResourceCPU] = resource.MustParse(c.VMAuthDefault.ConfigReloaderCPU)
+		configReloaderResources.Requests[corev1.ResourceCPU] = resource.MustParse(c.VMAuthDefault.ConfigReloaderCPU)
 	}
 	if c.VMAgentDefault.ConfigReloaderMemory != "0" && c.VMAuthDefault.UseDefaultResources {
 		configReloaderResources.Limits[corev1.ResourceMemory] = resource.MustParse(c.VMAuthDefault.ConfigReloaderMemory)
+		configReloaderResources.Requests[corev1.ResourceMemory] = resource.MustParse(c.VMAuthDefault.ConfigReloaderMemory)
 	}
 
 	configReloader := corev1.Container{


### PR DESCRIPTION
As per the kubernetes docs (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), 

> If you specify a limit for a resource, but do not specify any request, and no admission-time mechanism has applied a default request for that resource, then Kubernetes copies the limit you specified and uses it as the requested value for the resource.

In the kubernetes cluster I use, there is an admission controller preventing the pods from getting created/updated if they don't have resource requests set. This change should help to fix the problem. Here is the error currently logged by victoriametrics operator that this commit should help fix:

```
cannot update deployment for app: vmagent-obs-vm, err: deployments.apps \"vmagent-obs-vm\" is forbidden: container config-reloader is missing resource requests values for all
```