### PR TITLE
chore(vmalertmanager): remove default 200Mi request

### DIFF
--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -121,9 +121,6 @@ func newStsForAlertManager(cr *victoriametricsv1beta1.VMAlertmanager, c *config.
 	if cr.Spec.Resources.Requests == nil {
 		cr.Spec.Resources.Requests = v1.ResourceList{}
 	}
-	if _, ok := cr.Spec.Resources.Requests[v1.ResourceMemory]; !ok {
-		cr.Spec.Resources.Requests[v1.ResourceMemory] = resource.MustParse("200Mi")
-	}
 
 	spec, err := makeStatefulSetSpec(cr, c, amVersion)
 	if err != nil {


### PR DESCRIPTION
None of the other VM objects have this behaviour and it can cause problems if the memory limit is lower than the request.

Fixes: #706