### PR TITLE
vmrule: support `keep_firing_for` field

### DIFF
--- a/api/v1beta1/vmrule_types.go
+++ b/api/v1beta1/vmrule_types.go
@@ -95,6 +95,11 @@ type Rule struct {
 	// 30s, 1m, 1h  or nanoseconds
 	// +optional
 	For string `json:"for,omitempty" yaml:"for,omitempty"`
+	// KeepFiringFor will make alert continue firing for this long
+	// even when the alerting expression no longer has results.
+	// Use time.Duration format, 30s, 1m, 1h  or nanoseconds
+	// +optional
+	KeepFiringFor string `json:"keep_firing_for,omitempty" yaml:"keep_firing_for,omitempty"`
 	// Labels will be added to rule configuration
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/api/victoriametrics/v1beta1/vmrule_types.go
+++ b/api/victoriametrics/v1beta1/vmrule_types.go
@@ -95,6 +95,11 @@ type Rule struct {
 	// 30s, 1m, 1h  or nanoseconds
 	// +optional
 	For string `json:"for,omitempty" yaml:"for,omitempty"`
+	// KeepFiringFor will make alert continue firing for this long
+	// even when the alerting expression no longer has results.
+	// Use time.Duration format, 30s, 1m, 1h  or nanoseconds
+	// +optional
+	KeepFiringFor string `json:"keep_firing_for,omitempty" yaml:"keep_firing_for,omitempty"`
 	// Labels will be added to rule configuration
 	// +optional
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/config/crd/bases/operator.victoriametrics.com_vmrules.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmrules.yaml
@@ -117,6 +117,12 @@ spec:
                             description: For evaluation interval in time.Duration
                               format 30s, 1m, 1h  or nanoseconds
                             type: string
+                          keep_firing_for:
+                            description: KeepFiringFor will make alert continue firing
+                              for this long even when the alerting expression no longer
+                              has results. Use time.Duration format, 30s, 1m, 1h  or
+                              nanoseconds
+                            type: string
                           labels:
                             additionalProperties:
                               type: string

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -29,6 +29,7 @@
 - [vmagent](https://docs.victoriametrics.com/operator/api.html#vmagent): add [example config](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmagent_stateful_with_sharding.yaml) for vmagent statefulmode.
 - [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmagent): add [example config](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmcluster_with_additional_claim.yaml) for cluster with custom storage claims.
 - [vmrule](https://docs.victoriametrics.com/operator/api.html#vmrule): support `update_entries_limit` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert.html#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/691) for details.
+- [vmrule](https://docs.victoriametrics.com/operator/api.html#vmrule): support `keep_firing_for` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert.html#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/711) for details.
 - [vmoperator parameters](https://docs.victoriametrics.com/operator/vars.html): Add option `VM_ENABLESTRICTSECURITY` and enable strict security context by default. See [this issue](https://github.com/VictoriaMetrics/operator/issues/637) and [this PR](https://github.com/VictoriaMetrics/operator/pull/692/) for details.
 
 <a name="v0.35.1"></a>


### PR DESCRIPTION
Add `keep_firing_for` field for vmrule, releated to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/4669