### PR TITLE
[feature] Add more default securityContext

### DIFF
--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -528,13 +528,18 @@ func addStrictSecuritySettingsToPod(p *v1.PodSecurityContext, enableStrictSecuri
 	if !enableStrictSecurity || p != nil {
 		return p
 	}
-	return &v1.PodSecurityContext{
+	securityContext := v1.PodSecurityContext{
 		RunAsNonRoot: pointer.Bool(true),
 		// '65534' refers to 'nobody' in all the used default images like alpine, busybox
 		RunAsUser:  pointer.Int64(65534),
 		RunAsGroup: pointer.Int64(65534),
 		FSGroup:    pointer.Int64(65534),
 	}
+	if k8stools.IsFSGroupChangePolicySupported() {
+		onRootMismatch := v1.FSGroupChangeOnRootMismatch
+		securityContext.FSGroupChangePolicy = &onRootMismatch
+	}
+	return &securityContext
 }
 
 func addStrictSecuritySettingsToContainers(containers []v1.Container, enableStrictSecurity bool) []v1.Container {

--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -534,6 +534,9 @@ func addStrictSecuritySettingsToPod(p *v1.PodSecurityContext, enableStrictSecuri
 		RunAsUser:  pointer.Int64(65534),
 		RunAsGroup: pointer.Int64(65534),
 		FSGroup:    pointer.Int64(65534),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 	if k8stools.IsFSGroupChangePolicySupported() {
 		onRootMismatch := v1.FSGroupChangeOnRootMismatch
@@ -552,6 +555,11 @@ func addStrictSecuritySettingsToContainers(containers []v1.Container, enableStri
 			container.SecurityContext = &v1.SecurityContext{
 				ReadOnlyRootFilesystem:   pointer.Bool(true),
 				AllowPrivilegeEscalation: pointer.Bool(false),
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{
+						"ALL",
+					},
+				},
 			}
 		}
 	}

--- a/controllers/factory/builders_test.go
+++ b/controllers/factory/builders_test.go
@@ -656,6 +656,9 @@ func TestAddStrictSecuritySettingsToPod(t *testing.T) {
 					RunAsGroup:          pointer.Int64(65534),
 					FSGroup:             pointer.Int64(65534),
 					FSGroupChangePolicy: (*v1.PodFSGroupChangePolicy)(pointer.StringPtr("OnRootMismatch")),
+					SeccompProfile: &v1.SeccompProfile{
+						Type: v1.SeccompProfileTypeRuntimeDefault,
+					},
 				},
 				kubeletVersion: version.Info{Major: "1", Minor: "27"},
 			},
@@ -727,6 +730,11 @@ func TestAddStrictSecuritySettingsToContainers(t *testing.T) {
 						SecurityContext: &v1.SecurityContext{
 							ReadOnlyRootFilesystem:   pointer.Bool(true),
 							AllowPrivilegeEscalation: pointer.Bool(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
 						},
 					},
 				},

--- a/controllers/factory/k8stools/version.go
+++ b/controllers/factory/k8stools/version.go
@@ -69,6 +69,16 @@ func IsHPAV2BetaSupported() bool {
 	return false
 }
 
+// IsFSGroupChangePolicySupported checks if `fsGroupChangePolicy` is supported,
+// Supported since 1.20
+// https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recursive-permission-changes-on-mount
+func IsFSGroupChangePolicySupported() bool {
+	if ServerMajorVersion == 1 && ServerMinorVersion >= 20 {
+		return true
+	}
+	return false
+}
+
 // NewHPAEmptyObject returns HorizontalPodAutoscaler object for given kubernetes version
 func NewHPAEmptyObject(opts ...func(obj client.Object)) client.Object {
 	var hpa client.Object = &v2beta2.HorizontalPodAutoscaler{}

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -34,7 +34,8 @@
 - [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmagent): add [example config](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmcluster_with_additional_claim.yaml) for cluster with custom storage claims.
 - [vmrule](https://docs.victoriametrics.com/operator/api.html#vmrule): support `update_entries_limit` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert.html#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/691) for details.
 - [vmrule](https://docs.victoriametrics.com/operator/api.html#vmrule): support `keep_firing_for` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert.html#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/711) for details.
-- [vmoperator parameters](https://docs.victoriametrics.com/operator/vars.html): Add option `VM_ENABLESTRICTSECURITY` and enable strict security context by default. See [this issue](https://github.com/VictoriaMetrics/operator/issues/637) and [this PR](https://github.com/VictoriaMetrics/operator/pull/692/) for details.
+- [vmoperator parameters](https://docs.victoriametrics.com/operator/vars.html): Add option `VM_ENABLESTRICTSECURITY` and enable strict security context by default. See [this issue](https://github.com/VictoriaMetrics/operator/issues/637), [this](https://github.com/VictoriaMetrics/operator/pull/692/) and [this](https://github.com/VictoriaMetrics/operator/pull/712) PR for details.
+
 
 <a name="v0.35.1"></a>
 ## [v0.35.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.35.1) - 12 Jul 2023

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,10 @@ type BaseOperatorConf struct {
 	// 2. RunAsUser/RunAsGroup/FSGroup: 65534
 	// '65534' refers to 'nobody' in all the used default images like alpine, busybox.
 	// If you're using customize image, please make sure '65534' is a valid uid in there or specify SecurityContext.
+	// 3. FSGroupChangePolicy: FSGroupChangePolicy: &onRootMismatch
+	// If KubeVersion>=1.20, use `FSGroupChangePolicy` to skip the recursive permission change
+	// when the root of the volume already has the correct permissions
+	//
 	// Default container SecurityContext include:
 	// 1. AllowPrivilegeEscalation: false
 	// 2. ReadOnlyRootFilesystem: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,13 +254,20 @@ type BaseOperatorConf struct {
 	// 2. RunAsUser/RunAsGroup/FSGroup: 65534
 	// '65534' refers to 'nobody' in all the used default images like alpine, busybox.
 	// If you're using customize image, please make sure '65534' is a valid uid in there or specify SecurityContext.
-	// 3. FSGroupChangePolicy: FSGroupChangePolicy: &onRootMismatch
-	// If KubeVersion>=1.20, use `FSGroupChangePolicy` to skip the recursive permission change
+	// 3. FSGroupChangePolicy: &onRootMismatch
+	// If KubeVersion>=1.20, use `FSGroupChangePolicy="onRootMismatch"` to skip the recursive permission change
 	// when the root of the volume already has the correct permissions
+	// 4. SeccompProfile:
+	//      type: RuntimeDefault
+	// Use `RuntimeDefault` seccomp profile by default, which is defined by the container runtime,
+	// instead of using the Unconfined (seccomp disabled) mode.
 	//
 	// Default container SecurityContext include:
 	// 1. AllowPrivilegeEscalation: false
 	// 2. ReadOnlyRootFilesystem: true
+	// 3. Capabilities:
+	//      drop:
+	//        - all
 	EnableStrictSecurity bool `default:"true"`
 }
 


### PR DESCRIPTION
Part of https://github.com/VictoriaMetrics/operator/issues/637
1. If KubeVersion>=1.20, set `FSGroupChangePolicy: onRootMismatch`to skip the recursive permission change when the root of the volume already has the correct permissions in default PodSecurityContext.
2. SeccompProfile: Use `RuntimeDefault` seccomp profile by default, which is defined by the container runtime, instead of using the Unconfined (seccomp disabled) mode.
3. Capabilities: {Drop: []v1.Capability{"ALL"}}