### PR TITLE
fix vmselect cache dir mount when enableStrictSecurity

### DIFF
--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -225,7 +225,8 @@ type VMSelect struct {
 	// +optional
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
-	// CacheMountPath allows to add cache persistent for VMSelect
+	// CacheMountPath allows to add cache persistent for VMSelect,
+	// will use "/cache" as default if not specified.
 	// +optional
 	CacheMountPath string `json:"cacheMountPath,omitempty"`
 
@@ -235,7 +236,7 @@ type VMSelect struct {
 	// +deprecated
 	// +optional
 	Storage *StorageSpec `json:"persistentVolume,omitempty"`
-	// StorageSpec - add persistent volume claim for cacheMounthPath
+	// StorageSpec - add persistent volume claim for cacheMountPath
 	// its needed for persistent cache
 	// +optional
 	StorageSpec *StorageSpec `json:"storage,omitempty"`

--- a/api/victoriametrics/v1beta1/vmcluster_types.go
+++ b/api/victoriametrics/v1beta1/vmcluster_types.go
@@ -225,7 +225,8 @@ type VMSelect struct {
 	// +optional
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
-	// CacheMountPath allows to add cache persistent for VMSelect
+	// CacheMountPath allows to add cache persistent for VMSelect,
+	// will use "/cache" as default if not specified.
 	// +optional
 	CacheMountPath string `json:"cacheMountPath,omitempty"`
 
@@ -235,7 +236,7 @@ type VMSelect struct {
 	// +deprecated
 	// +optional
 	Storage *StorageSpec `json:"persistentVolume,omitempty"`
-	// StorageSpec - add persistent volume claim for cacheMounthPath
+	// StorageSpec - add persistent volume claim for cacheMountPath
 	// its needed for persistent cache
 	// +optional
 	StorageSpec *StorageSpec `json:"storage,omitempty"`

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -645,7 +645,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   cacheMountPath:
                     description: CacheMountPath allows to add cache persistent for
-                      VMSelect
+                      VMSelect, will use "/cache" as default if not specified.
                     type: string
                   claimTemplates:
                     description: ClaimTemplates allows adding additional VolumeClaimTemplates
@@ -1346,7 +1346,7 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   storage:
-                    description: StorageSpec - add persistent volume claim for cacheMounthPath
+                    description: StorageSpec - add persistent volume claim for cacheMountPath
                       its needed for persistent cache
                     properties:
                       disableMountSubPath:

--- a/controllers/factory/scrapes.go
+++ b/controllers/factory/scrapes.go
@@ -22,9 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	vmagentSecretFetchErrsTotal prometheus.Counter
-)
+var vmagentSecretFetchErrsTotal prometheus.Counter
 
 func init() {
 	vmagentSecretFetchErrsTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -43,7 +41,6 @@ type scrapesSecretsCache struct {
 
 // CreateOrUpdateConfigurationSecret builds scrape configuration for VMAgent
 func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client, c *config.BaseOperatorConf) (*scrapesSecretsCache, error) {
-
 	sScrapes, err := SelectServiceScrapes(ctx, cr, rclient)
 	if err != nil {
 		return nil, fmt.Errorf("selecting ServiceScrapes failed: %w", err)
@@ -138,7 +135,6 @@ func CreateOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv
 }
 
 func SelectServiceScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client) (map[string]*victoriametricsv1beta1.VMServiceScrape, error) {
-
 	res := make(map[string]*victoriametricsv1beta1.VMServiceScrape)
 
 	var servScrapesCombined []victoriametricsv1beta1.VMServiceScrape
@@ -193,7 +189,6 @@ func SelectServiceScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgen
 }
 
 func SelectPodScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client) (map[string]*victoriametricsv1beta1.VMPodScrape, error) {
-
 	res := make(map[string]*victoriametricsv1beta1.VMPodScrape)
 
 	var podScrapesCombined []victoriametricsv1beta1.VMPodScrape
@@ -230,7 +225,6 @@ func SelectPodScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, r
 }
 
 func SelectVMProbes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client) (map[string]*victoriametricsv1beta1.VMProbe, error) {
-
 	res := make(map[string]*victoriametricsv1beta1.VMProbe)
 	var probesCombined []victoriametricsv1beta1.VMProbe
 	namespaces, objSelector, err := getNSWithSelector(ctx, rclient, cr.Spec.ProbeNamespaceSelector, cr.Spec.ProbeSelector, cr.Namespace)
@@ -265,7 +259,6 @@ func SelectVMProbes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rcl
 }
 
 func SelectVMNodeScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client) (map[string]*victoriametricsv1beta1.VMNodeScrape, error) {
-
 	l := log.WithValues("vmagent", cr.Name)
 	if !config.IsClusterWideAccessAllowed() && cr.IsOwnsServiceAccount() {
 		l.Info("cannot use VMNodeScrape at operator in single namespace mode with default permissions. Create ServiceAccount for VMAgent manually if needed. Skipping config generation for it")
@@ -308,7 +301,6 @@ func SelectVMNodeScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent
 }
 
 func SelectStaticScrapes(ctx context.Context, cr *victoriametricsv1beta1.VMAgent, rclient client.Client) (map[string]*victoriametricsv1beta1.VMStaticScrape, error) {
-
 	res := make(map[string]*victoriametricsv1beta1.VMStaticScrape)
 	var staticScrapesCombined []victoriametricsv1beta1.VMStaticScrape
 
@@ -358,7 +350,6 @@ func loadScrapeSecrets(
 	remoteWriteSpecs []victoriametricsv1beta1.VMAgentRemoteWriteSpec,
 	namespace string,
 ) (*scrapesSecretsCache, error) {
-
 	oauth2Secret := make(map[string]*oauthCreds)
 	authorizationSecrets := make(map[string]string)
 	baSecrets := make(map[string]*BasicAuthCredentials)
@@ -661,7 +652,6 @@ func loadScrapeSecrets(
 		}
 		if rws.OAuth2 != nil {
 			oauth2, err := loadOAuthSecrets(ctx, rclient, rws.OAuth2, namespace, nsSecretCache, nsCMCache)
-
 			if err != nil {
 				return nil, fmt.Errorf("cannot load oauth2 creds for :%s, ns: %s, err: %w", "remoteWrite", namespace, err)
 			}
@@ -710,7 +700,6 @@ func loadBasicAuthSecret(ctx context.Context, rclient client.Client, ns string, 
 	}
 
 	return bac, nil
-
 }
 
 func extractCredKey(secret *corev1.Secret, sel corev1.SecretKeySelector) (string, error) {
@@ -799,7 +788,6 @@ func buildCacheKey(ns, keyName string) string {
 }
 
 func loadProxySecrets(ctx context.Context, rclient client.Client, proxyCfg *victoriametricsv1beta1.ProxyAuth, ns string, cache map[string]*corev1.Secret) (ba *BasicAuthCredentials, token string, err error) {
-
 	if proxyCfg.BasicAuth != nil {
 		ba, err = loadBasicAuthSecretFromAPI(ctx, rclient, proxyCfg.BasicAuth, ns, cache)
 		if err != nil {

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -341,8 +341,9 @@ func genVMSelectSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv1
 	if cr.Spec.VMSelect.Image.PullPolicy == "" {
 		cr.Spec.VMSelect.Image.PullPolicy = corev1.PullIfNotPresent
 	}
-	if cr.Spec.VMSelect.SecurityContext == nil {
-		cr.Spec.VMSelect.SecurityContext = &corev1.PodSecurityContext{}
+	// use "/cache" as default cache dir instead of "/tmp" if `CacheMountPath` not set
+	if cr.Spec.VMSelect.CacheMountPath == "" {
+		cr.Spec.VMSelect.CacheMountPath = "/cache"
 	}
 	podSpec, err := makePodSpecForVMSelect(cr, c)
 	if err != nil {
@@ -972,9 +973,6 @@ func GenVMStorageSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv
 	}
 	if cr.Spec.VMStorage.SchedulerName == "" {
 		cr.Spec.VMStorage.SchedulerName = "default-scheduler"
-	}
-	if cr.Spec.VMStorage.SecurityContext == nil {
-		cr.Spec.VMStorage.SecurityContext = &corev1.PodSecurityContext{}
 	}
 	if cr.Spec.VMStorage.Image.PullPolicy == "" {
 		cr.Spec.VMStorage.Image.PullPolicy = corev1.PullIfNotPresent

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -3,6 +3,7 @@
 ## Next release
 
 ### Fixes
+- [vmselect](https://docs.victoriametrics.com/operator/api.html#vmcluster): fix cache directory when `cacheDataPath` not specified, before it will use `/tmp` which is protect by default strict securityContext.
 
 ### Features
 


### PR DESCRIPTION
After [enable strict securityContext](https://github.com/VictoriaMetrics/operator/blob/master/vars.MD#L119) in v0.36.0 by default, if `vmselect.cacheMountPath` not set, vmselect won't be start successfully cause default cache dir "/tmp" is protected. 
Fix this by using `/cache` dir and mount to emptyDir if `vmselect.cacheMountPath` not set.

Another fix is for vmselect and vmstorage, both podSecurityContext was set to non-nil, thus default podSecurityContext won't be applied to them.