### PR TITLE
controllers/vmuser: fixes ip_filters indent

### DIFF
--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -557,8 +557,9 @@ func genUrlMaps(userName string, refs []victoriametricsv1beta1.TargetRef, result
 				Value: ref.Headers,
 			})
 		}
+		urlMap = addIPFiltersToYaml(urlMap, ref.IPFilters)
 		urlMaps = append(urlMaps, urlMap)
-		result = addIPFiltersToYaml(result, ref.IPFilters)
+
 	}
 	result = append(result, yaml.MapItem{Key: "url_map", Value: urlMaps})
 	return result, nil

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- TODO
+* [vmuser](https://docs.victoriametrics.com/operator/api.html#vmuser): [Enterprise] fixes ip_filters indent for url_prefix. Previously it wasn't possible to use ip_filters with multiple target refs
 
 ### Features
 


### PR DESCRIPTION
previously config was incorrectly rendered if multiple targetRef was defined