### PR TITLE
vmcluster: remove redundant annotation from created workloads

### DIFF
--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -41,7 +41,7 @@ var SchemeGroupVersion = schema.GroupVersion{Group: "operator.victoriametrics.co
 var (
 	labelFilterPrefixes []string
 	// default ignored annotations
-	annotationFilterPrefixes = []string{"kubectl.kubernetes.io/", "operator.victoriametrics.com/"}
+	annotationFilterPrefixes = []string{"kubectl.kubernetes.io/", "operator.victoriametrics.com/", "operator.victoriametrics/last-applied-spec"}
 )
 
 // SetLabelAndAnnotationPrefixes configures global filtering for child labels and annotations

--- a/api/victoriametrics/v1beta1/additional.go
+++ b/api/victoriametrics/v1beta1/additional.go
@@ -41,7 +41,7 @@ var SchemeGroupVersion = schema.GroupVersion{Group: "operator.victoriametrics.co
 var (
 	labelFilterPrefixes []string
 	// default ignored annotations
-	annotationFilterPrefixes = []string{"kubectl.kubernetes.io/", "operator.victoriametrics.com/"}
+	annotationFilterPrefixes = []string{"kubectl.kubernetes.io/", "operator.victoriametrics.com/", "operator.victoriametrics/last-applied-spec"}
 )
 
 // SetLabelAndAnnotationPrefixes configures global filtering for child labels and annotations

--- a/controllers/factory/k8stools/sts.go
+++ b/controllers/factory/k8stools/sts.go
@@ -37,11 +37,11 @@ func HandleSTSUpdate(ctx context.Context, rclient client.Client, cr STSOptions, 
 	if err := rclient.Get(ctx, types.NamespacedName{Name: newSts.Name, Namespace: newSts.Namespace}, &currentSts); err != nil {
 		if errors.IsNotFound(err) {
 			if err = rclient.Create(ctx, newSts); err != nil {
-				return fmt.Errorf("cannot create new alertmanager sts: %w", err)
+				return fmt.Errorf("cannot create new sts %s under namespace %s: %w", newSts.Name, newSts.Namespace, err)
 			}
 			return nil
 		}
-		return fmt.Errorf("cannot get alertmanager sts: %w", err)
+		return fmt.Errorf("cannot get sts %s under namespace %s: %w", newSts.Name, newSts.Namespace, err)
 	}
 	if cr.UpdateReplicaCount != nil {
 		cr.UpdateReplicaCount(currentSts.Spec.Replicas)

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -2,7 +2,9 @@
 
 ## Next release
 
-- TODO
+### Fixes
+
+- [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmcluster): remove redundant annotation `operator.victoriametrics/last-applied-spec` from created workloads like vmstorage statefulset.
 
 <a name="v0.38.0"></a>
 ## [v0.38.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.38.0) - 11 Sep 2023


### PR DESCRIPTION
address https://github.com/VictoriaMetrics/operator/issues/753
remove redundant annotation `operator.victoriametrics/last-applied-spec` from created workloads like vmstorage statefulset.