### PR TITLE
upgrade default config-reloader image to latest

### DIFF
--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -2,6 +2,8 @@
 
 ## Next release
 
+### Features
+- [vmoperator](https://docs.victoriametrics.com/operator/): upgrade vmagent/vmauth's default config-reloader image.
 ### Fixes
 
 - [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmcluster): remove redundant annotation `operator.victoriametrics/last-applied-spec` from created workloads like vmstorage statefulset.

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -3,7 +3,9 @@
 ## Next release
 
 ### Features
+
 - [vmoperator](https://docs.victoriametrics.com/operator/): upgrade vmagent/vmauth's default config-reloader image.
+
 ### Fixes
 
 - [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmcluster): remove redundant annotation `operator.victoriametrics/last-applied-spec` from created workloads like vmstorage statefulset.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,7 @@ type BaseOperatorConf struct {
 	VMAgentDefault struct {
 		Image               string `default:"victoriametrics/vmagent"`
 		Version             string `default:"v1.93.4"`
-		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.58.0"`
+		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {
@@ -203,7 +203,7 @@ type BaseOperatorConf struct {
 	VMAuthDefault struct {
 		Image               string `default:"victoriametrics/vmauth"`
 		Version             string `default:"v1.93.4"`
-		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.48.1"`
+		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8427"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {

--- a/vars.MD
+++ b/vars.MD
@@ -10,7 +10,7 @@ aliases:
 - /operator/vars.html
 ---
 # Auto Generated vars for package config 
- updated at Mon Sep 11 07:21:27 UTC 2023 
+ updated at Wed Sep 13 03:51:48 UTC 2023 
 
 
 | varible name | variable default value | variable required | variable description |
@@ -32,7 +32,7 @@ aliases:
 | VM_VMALERTDEFAULT_CONFIGRELOADIMAGE | jimmidyson/configmap-reload:v0.3.0 | false | - |
 | VM_VMAGENTDEFAULT_IMAGE | victoriametrics/vmagent | false | - |
 | VM_VMAGENTDEFAULT_VERSION | v1.93.4 | false | - |
-| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.58.0 | false | - |
+| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0 | false | - |
 | VM_VMAGENTDEFAULT_PORT | 8429 | false | - |
 | VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES | true | false | - |
 | VM_VMAGENTDEFAULT_RESOURCE_LIMIT_MEM | 500Mi | false | - |
@@ -98,7 +98,7 @@ aliases:
 | VM_VMBACKUP_LOGLEVEL | INFO | false | - |
 | VM_VMAUTHDEFAULT_IMAGE | victoriametrics/vmauth | false | - |
 | VM_VMAUTHDEFAULT_VERSION | v1.93.4 | false | - |
-| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.48.1 | false | - |
+| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0 | false | - |
 | VM_VMAUTHDEFAULT_PORT | 8427 | false | - |
 | VM_VMAUTHDEFAULT_USEDEFAULTRESOURCES | true | false | - |
 | VM_VMAUTHDEFAULT_RESOURCE_LIMIT_MEM | 300Mi | false | - |


### PR DESCRIPTION
address https://github.com/VictoriaMetrics/operator/issues/755
upgrade default config-reloader image to [latest](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.68.0) `prometheus-config-reloader:v0.68.0`, will also introduce several good features for reloader:
1. [Set web server's ReadTimeout and ReadHeaderTimeout to 30s](https://github.com/prometheus-operator/prometheus-operator/pull/5340)
2. [add the reload-timeout argument](https://github.com/prometheus-operator/prometheus-operator/pull/5349)
3. [add SIGTERM handler](https://github.com/prometheus-operator/prometheus-operator/pull/5617)