### PR TITLE
Bump alpine base image to latest v3.18.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CRD_PRESERVE=x-kubernetes-preserve-unknown-fields true
 # Current Operator version
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
-ALPINE_IMAGE=alpine:3.17.3
+ALPINE_IMAGE=alpine:3.18.3
 CHANNEL=beta
 DEFAULT_CHANNEL=beta
 BUNDLE_CHANNELS := --channels=$(CHANNEL)


### PR DESCRIPTION
### To remove some vulnerabilities:
| Library   | Vulnerability | Severity | Status | Installed Version | Fixed Version | Title                                                                                                      |
|-----------|---------------|----------|--------|-------------------|---------------|------------------------------------------------------------------------------------------------------------|
| libcrypto3| CVE-2023-1255 | MEDIUM   | fixed  | 3.0.8-r3          | 3.0.8-r4      | Input buffer over-read in AES-XTS implementation on 64 bit ARM [Details](https://avd.aquasec.com/nvd/cve-2023-1255)       |
|           | CVE-2023-2650 | -        | -      | -                 | 3.0.9-r0      | Possible DoS translating ASN.1 object identifiers [Details](https://avd.aquasec.com/nvd/cve-2023-2650)                  |
|           | CVE-2023-2975 | -        | -      | -                 | 3.0.9-r2      | AES-SIV cipher implementation contains a bug that causes it to ignore empty... [Details](https://avd.aquasec.com/nvd/cve-2023-2975)  |
|           | CVE-2023-3446 | -        | -      | -                 | 3.0.9-r3      | Excessive time spent checking DH keys and parameters [Details](https://avd.aquasec.com/nvd/cve-2023-3446)           |
|           | CVE-2023-3817 | -        | -      | -                 | 3.0.10-r0     | Excessive time spent checking DH q parameter value [Details](https://avd.aquasec.com/nvd/cve-2023-3817)               |
| libssl3   | CVE-2023-1255 | -        | -      | -                 | 3.0.8-r4      | Input buffer over-read in AES-XTS implementation on 64 bit ARM [Details](https://avd.aquasec.com/nvd/cve-2023-1255)       |
|           | CVE-2023-2650 | -        | -      | -                 | 3.0.9-r0      | Possible DoS translating ASN.1 object identifiers [Details](https://avd.aquasec.com/nvd/cve-2023-2650)                  |
|           | CVE-2023-2975 | -        | -      | -                 | 3.0.9-r2      | AES-SIV cipher implementation contains a bug that causes it to ignore empty... [Details](https://avd.aquasec.com/nvd/cve-2023-2975)  |
|           | CVE-2023-3446 | -        | -      | -                 | 3.0.9-r3      | Excessive time spent checking DH keys and parameters [Details](https://avd.aquasec.com/nvd/cve-2023-3446)           |
|           | CVE-2023-3817 | -        | -      | -                 | 3.0.10-r0     | Excessive time spent checking DH q parameter value [Details](https://avd.aquasec.com/nvd/cve-2023-3817)               |
