### PR TITLE
corrected endpointslices apigroup

### DIFF
--- a/config/examples/operator_rbac_for_single_namespace.yaml
+++ b/config/examples/operator_rbac_for_single_namespace.yaml
@@ -24,10 +24,17 @@ metadata:
   namespace: default
 rules:
   - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - 'list'
+      - 'watch'
+      - 'get'
+  - apiGroups:
       - ""
     resources:
       - endpoints
-      - endpointslices
     verbs:
       - 'list'
       - 'watch'

--- a/config/examples/vmagent_rbac.yaml
+++ b/config/examples/vmagent_rbac.yaml
@@ -9,7 +9,7 @@ kind: ClusterRole
 metadata:
   name: vmagent
 rules:
-  - apiGroups: ["","networking.k8s.io","extensions"]
+  - apiGroups: ["","networking.k8s.io","extensions","discovery.k8s.io"]
     resources:
       - nodes
       - nodes/metrics

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -278,6 +278,14 @@ rules:
     - patch
     - update
 - apiGroups:
+    - "discovery.k8s.io"
+  resources:
+    - endpointslices
+  verbs:
+    - 'list'
+    - 'watch'
+    - 'get'
+- apiGroups:
     - ""
   resources:
     - nodes
@@ -286,7 +294,6 @@ rules:
     - services
     - endpoints
     - pods
-    - endpointslices
     - configmaps
   verbs:
     - get

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -16,6 +16,17 @@ import (
 var (
 	singleNSPolicyRules = []rbacV1.PolicyRule{
 		{
+			APIGroups: []string{"discovery.k8s.io"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"endpointslices",
+			},
+		},
+		{
 			APIGroups: []string{""},
 			Verbs: []string{
 				"get",
@@ -26,7 +37,6 @@ var (
 				"services",
 				"endpoints",
 				"pods",
-				"endpointslices",
 				"secrets",
 				"configmaps",
 			},
@@ -45,6 +55,17 @@ var (
 	}
 	clusterWidePolicyRules = []rbacV1.PolicyRule{
 		{
+			APIGroups: []string{"discovery.k8s.io"},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+			Resources: []string{
+				"endpointslices",
+			},
+		},
+		{
 			APIGroups: []string{""},
 			Verbs: []string{
 				"get",
@@ -58,7 +79,6 @@ var (
 				"services",
 				"endpoints",
 				"pods",
-				"endpointslices",
 				"configmaps",
 				"namespaces",
 				"secrets",

--- a/docs/CHANGELOG.MD
+++ b/docs/CHANGELOG.MD
@@ -10,6 +10,7 @@
 
 - [vmcluster](https://docs.victoriametrics.com/operator/api.html#vmcluster): remove redundant annotation `operator.victoriametrics/last-applied-spec` from created workloads like vmstorage statefulset.
 - [vmoperator](https://docs.victoriametrics.com/operator/): properly resize statefulset's multiple pvc when needed and allowable, before they could be updated with wrong size.
+- [vmoperator](https://docs.victoriametrics.com/operator/): fix wrong api group of endpointsices, before vmagent won't able to access endpointsices resources with default rbac rule.
 
 <a name="v0.38.0"></a>
 ## [v0.38.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.38.0) - 11 Sep 2023

--- a/hack/bundle_csv_vmagent.yaml
+++ b/hack/bundle_csv_vmagent.yaml
@@ -3,7 +3,7 @@ spec:
     spec:
       clusterPermissions:
         - rules:
-            - apiGroups: [ "","networking.k8s.io","extensions" ]
+            - apiGroups: [ "","networking.k8s.io","extensions","discovery.k8s.io" ]
               resources:
                 - nodes
                 - nodes/metrics


### PR DESCRIPTION
Hello VictoriaMetrics team,

please correct the apiGroup for endpointsices.

tested on a local k8s cluster with single mode vm


```
cat <<EOF | k apply -f -
apiVersion: operator.victoriametrics.com/v1beta1
kind: VMSingle
metadata:
  name: example-vmsingle-notpersisted
spec:
  retentionPeriod: "1"
EOF
```



```
cat <<EOF | k apply -f -
apiVersion: operator.victoriametrics.com/v1beta1
kind: VMAgent
metadata:
  name: example-vmagent
spec:
  selectAllByDefault: true
  replicaCount: 1
  remoteWrite:
    - url: "http://vmsingle-example-vmsingle-notpersisted.default.svc:8429/api/v1/write"
EOF
```

before the fix:

```
kubectl auth can-i get endpointslices --as=system:serviceaccount:default:vmagent-example-vmagent -n default
no
```

after the fix
```
kubectl auth can-i get endpointslices --as=system:serviceaccount:default:vmagent-example-vmagent -n default
yes
```

its correct here for vmagent in charts repository https://github.com/VictoriaMetrics/helm-charts/blob/8d35f1f224861327e40e91e0bdd151ac467d1ab7/charts/victoria-metrics-agent/templates/clusterrole.yaml#L21

was fixed quite a while ago by this commit https://github.com/VictoriaMetrics/helm-charts/commit/acf5d8aadeb1a7c4c92296f8456d9ab4786686fd
