### PR TITLE
controllers/k8stools: fix grow sts pvcs behavior

### DIFF
--- a/controllers/factory/k8stools/expansion_test.go
+++ b/controllers/factory/k8stools/expansion_test.go
@@ -404,7 +404,6 @@ func Test_growSTSPVC(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "expand with named class",

--- a/controllers/factory/k8stools/sts.go
+++ b/controllers/factory/k8stools/sts.go
@@ -78,8 +78,8 @@ func HandleSTSUpdate(ctx context.Context, rclient client.Client, cr STSOptions, 
 		}
 	}
 
-	// check if pvc need to resize if sts got recreated
-	if isRecreated {
+	// check if pvcs need to resize
+	if cr.HasClaim {
 		err = growSTSPVC(ctx, rclient, newSts)
 	}
 	return err


### PR DESCRIPTION
follow up https://github.com/VictoriaMetrics/operator/pull/760
1. check if pvcs need to be reize as long as there is pvc since error could happen when grow pvcs and sts was updated already
2. not return error to caller if there is no point to retry when growPVC, like sc is unexpandable
If sc is unexpandable or vm opearator is under single namespace mode, pvc must be expand with user's intervention. 
Breaking reconcile and requeue under those circumstance will have no other effects except cause more pressure on cluster[list/get request and will perform sts rolling update once again].
