### PR TITLE
Fix(vmagent, vmauth): use proper flag for custom configmap reloader init container

### DIFF
--- a/controllers/factory/vmauth.go
+++ b/controllers/factory/vmauth.go
@@ -519,7 +519,7 @@ func buildInitConfigContainer(baseImage string, c *config.BaseOperatorConf, conf
 			Command: []string{
 				"/usr/local/bin/config-reloader",
 			},
-			Args: append(configReloaderArgs, "--mode=one-shot"),
+			Args: append(configReloaderArgs, "--only-init-config"),
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "config-out",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type BaseOperatorConf struct {
 	UseCustomConfigReloader bool `default:"false"`
 	// container registry name prefix, e.g. docker.io
 	ContainerRegistry         string `default:""`
-	CustomConfigReloaderImage string `default:"victoriametrics/operator:config-reloader-v0.32.0"`
+	CustomConfigReloaderImage string `default:"victoriametrics/operator:config-reloader-v0.38.0"`
 	PSPAutoCreateEnabled      bool   `default:"false"`
 	VMAlertDefault            struct {
 		Image               string `default:"victoriametrics/vmalert"`


### PR DESCRIPTION
- Use the `--only-init-config` flag for custom configmap reloader init container in vmauth and vmagent deployments. 
- Update the default custom config reloader image to v0.38.0.

Fixes #770 .
