### PR TITLE
docs: fix the issue of incorrect links to referenced documents in the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ So you can use familiar CRD objects: `ServiceMonitor`, `PodMonitor`, `Prometheus
 - `VMRule` - defines alerting or recording rules.
 - `VMProbe` - defines a probing configuration for targets with blackbox exporter.
 
-Besides, operator allows you to manage VictoriaMetrics applications inside kubernetes cluster and simplifies this process [quick-start](/docs/quick-start.MD)
-With CRD (Custom Resource Definition) you can define application configuration and apply it to your cluster [crd-objects](/docs/api.MD).
+Besides, operator allows you to manage VictoriaMetrics applications inside kubernetes cluster and simplifies this process [quick-start](/docs/quick-start.md)
+With CRD (Custom Resource Definition) you can define application configuration and apply it to your cluster [crd-objects](/docs/api.md).
 
  Operator simplifies VictoriaMetrics cluster installation, upgrading and managing.
 
- It has integration with VictoriaMetrics `vmbackupmanager` - advanced tools for making backups. Check backup [docs](/docs/backups.MD)
+ It has integration with VictoriaMetrics [vmbackupmanager](https://docs.victoriametrics.com/vmbackupmanager.html) - advanced tools for making backups. Check [Backup automation for VMSingle](./docs/resources/vmsingle.md#backup-automation) or [Backup automation for VMCluster](./docs/resources/vmcluster.md#backup-automation).
 
 ## Use cases
 
  For kubernetes-cluster administrators, it simplifies installation, configuration, management for `VictoriaMetrics` application. And the main feature of operator -  is ability to delegate applications monitoring configuration to the end-users.
 
- For applications developers, its great possibility for managing observability of applications. You can define metrics scraping and alerting configuration for your application and manage it with an application deployment process. Just define app_deployment.yaml, app_vmpodscrape.yaml and app_vmrule.yaml. That's it, you can apply it to a kubernetes cluster. Check [quick-start](/docs/quick-start.MD) for an example.
+ For applications developers, its great possibility for managing observability of applications. You can define metrics scraping and alerting configuration for your application and manage it with an application deployment process. Just define app_deployment.yaml, app_vmpodscrape.yaml and app_vmrule.yaml. That's it, you can apply it to a kubernetes cluster. Check [quick-start](/docs/quick-start.md) for an example.
 
 ## Operator vs helm-chart
 

--- a/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
@@ -207,10 +207,10 @@ spec:
     bring own resources and fully manages them.
 
      You can read more about operator at docs:
-      - quick start [doc](https://github.com/VictoriaMetrics/operator/docs/quick-start.MD)
-      - high availability [doc](https://github.com/VictoriaMetrics/operator/docs/high-availability.MD)
-      - design and description of implementation [design](https://github.com/VictoriaMetrics/operator/docs/design.MD)
-      - operator objects description [doc](https://github.com/VictoriaMetrics/operator/docs/api.MD)
+      - quick start [doc](https://github.com/VictoriaMetrics/operator/blob/master/docs/quick-start.md)
+      - high availability [doc](https://github.com/VictoriaMetrics/operator/blob/master/docs/high-availability.md)
+      - design and description of implementation [design](https://github.com/VictoriaMetrics/operator/blob/master/docs/design.md)
+      - operator objects description [doc](https://github.com/VictoriaMetrics/operator/blob/master/docs/api.md)
 
     # VictoriaMetrics
     * VictoriaMetrics can be used as long-term storage for Prometheus or for [vmagent](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmagent/README.md).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -756,7 +756,7 @@ menu:
 
 - Adds alertmanager service scrape auto generation https://github.com/VictoriaMetrics/operator/issues/385 thanks [@FRosner](https://github.com/FRosner)
 - Auto-add routing for vminsert and vmselect CRD components for `VMUser` https://github.com/VictoriaMetrics/operator/issues/379
-- Updates docs for `VMAuth`https://github.com/VictoriaMetrics/operator/blob/master/docs/auth.MD
+- Updates docs for `VMAuth`https://github.com/VictoriaMetrics/operator/blob/master/docs/auth.md
 - Allows changing default disk space usage for `VMAgent` https://github.com/VictoriaMetrics/operator/pull/381 thanks [@arctan90](https://github.com/arctan90)
 - Adds Arch labels for clusterversion template https://github.com/VictoriaMetrics/operator/commit/9e89c3b2459fb85faa8e973fa1f1558d924000f3 thanks [@yselkowitz](https://github.com/yselkowitz)
 - improves docs and fixes typos https://github.com/VictoriaMetrics/operator/commit/ae248dcb352a092d9f9caee87454b1ad25650a4c thanks [@flokli](https://github.com/flokli)
@@ -801,7 +801,7 @@ menu:
 
 ### Breaking changes
 
-- **changes default behavior for CR selectors, such serviceScrapeSelector at vmagent.spec. Now it select all targets if is missing https://github.com/VictoriaMetrics/operator/commit/519e89b457576099288af2ea135878f6da25b567 See more at docs https://github.com/VictoriaMetrics/operator/blob/master/docs/quick-start.MD#object-selectors**
+- **changes default behavior for CR selectors, such serviceScrapeSelector at vmagent.spec. Now it select all targets if is missing https://github.com/VictoriaMetrics/operator/commit/519e89b457576099288af2ea135878f6da25b567 See more at docs https://github.com/VictoriaMetrics/operator/blob/master/docs/quick-start.md#object-selectors**
 - **operator doesn't add cluster domain name for in-cluster communication, now its empty value. It should resolve issue with using operator at clusters with custom k8s domain https://github.com/VictoriaMetrics/operator/issues/354 thanks [@flokli](https://github.com/flokli)**
 
 ### Features


### PR DESCRIPTION
Fix issue: the main issue addressed was the incorrect document links referenced throughout the project.