### PR TITLE
docs: fix broken links

### DIFF
--- a/api/v1beta1/additional.go
+++ b/api/v1beta1/additional.go
@@ -109,14 +109,14 @@ type EmbeddedObjectMetadata struct {
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
 	// Cannot be updated.
-	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 
 	// Labels Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="PodLabels"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:label"
@@ -126,7 +126,7 @@ type EmbeddedObjectMetadata struct {
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
 }
@@ -360,7 +360,7 @@ type EmbeddedProbes struct {
 }
 
 // EmbeddedHPA embeds HorizontalPodAutoScaler spec v2.
-// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/
+// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/
 type EmbeddedHPA struct {
 	MinReplicas *int32                                   `json:"minReplicas,omitempty"`
 	MaxReplicas int32                                    `json:"maxReplicas,omitempty"`

--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -311,8 +311,8 @@ type VMAgentSpec struct {
 
 	// ShardCount - numbers of shards of VMAgent
 	// in this case operator will use 1 deployment/sts per shard with
-	// replicas count according to spec.replicas
-	// https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets
+	// replicas count according to spec.replicas,
+	// see https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets
 	// +optional
 	ShardCount *int `json:"shardCount,omitempty"`
 

--- a/api/victoriametrics/v1beta1/additional.go
+++ b/api/victoriametrics/v1beta1/additional.go
@@ -109,14 +109,14 @@ type EmbeddedObjectMetadata struct {
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
 	// Cannot be updated.
-	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 
 	// Labels Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="PodLabels"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:label"
@@ -126,7 +126,7 @@ type EmbeddedObjectMetadata struct {
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
 }
@@ -360,7 +360,7 @@ type EmbeddedProbes struct {
 }
 
 // EmbeddedHPA embeds HorizontalPodAutoScaler spec v2.
-// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/
+// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/
 type EmbeddedHPA struct {
 	MinReplicas *int32                                   `json:"minReplicas,omitempty"`
 	MaxReplicas int32                                    `json:"maxReplicas,omitempty"`

--- a/api/victoriametrics/v1beta1/vmagent_types.go
+++ b/api/victoriametrics/v1beta1/vmagent_types.go
@@ -311,8 +311,8 @@ type VMAgentSpec struct {
 
 	// ShardCount - numbers of shards of VMAgent
 	// in this case operator will use 1 deployment/sts per shard with
-	// replicas count according to spec.replicas
-	// https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets
+	// replicas count according to spec.replicas,
+	// see https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets
 	// +optional
 	ShardCount *int `json:"shardCount,omitempty"`
 

--- a/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -1164,7 +1164,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -1172,14 +1172,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               podScrapeNamespaceSelector:
@@ -2572,7 +2572,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -2580,7 +2580,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -2588,7 +2588,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   spec:
@@ -2602,7 +2602,7 @@ spec:
               shardCount:
                 description: ShardCount - numbers of shards of VMAgent in this case
                   operator will use 1 deployment/sts per shard with replicas count
-                  according to spec.replicas https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets
+                  according to spec.replicas, see https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets
                 type: integer
               startupProbe:
                 description: StartupProbe that will be added to CRD pod
@@ -2676,7 +2676,7 @@ spec:
                               map stored with a resource that may be set by external
                               tools to store and retrieve arbitrary metadata. They
                               are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                             type: object
                           labels:
                             additionalProperties:
@@ -2684,7 +2684,7 @@ spec:
                             description: 'Labels Map of string keys and values that
                               can be used to organize and categorize (scope and select)
                               objects. May match selectors of replication controllers
-                              and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                             type: object
                           name:
                             description: 'Name must be unique within a namespace.
@@ -2692,7 +2692,7 @@ spec:
                               may allow a client to request the generation of an appropriate
                               name automatically. Name is primarily intended for creation
                               idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                             type: string
                         type: object
                       spec:

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -688,7 +688,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -696,14 +696,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               podSecurityPolicyName:
@@ -837,7 +837,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -845,7 +845,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -853,7 +853,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   spec:
@@ -928,7 +928,7 @@ spec:
                               map stored with a resource that may be set by external
                               tools to store and retrieve arbitrary metadata. They
                               are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                             type: object
                           labels:
                             additionalProperties:
@@ -936,7 +936,7 @@ spec:
                             description: 'Labels Map of string keys and values that
                               can be used to organize and categorize (scope and select)
                               objects. May match selectors of replication controllers
-                              and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                             type: object
                           name:
                             description: 'Name must be unique within a namespace.
@@ -944,7 +944,7 @@ spec:
                               may allow a client to request the generation of an appropriate
                               name automatically. Name is primarily intended for creation
                               idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                             type: string
                         type: object
                       spec:

--- a/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -1019,7 +1019,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -1027,14 +1027,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               podSecurityPolicyName:
@@ -1688,7 +1688,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -1696,7 +1696,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -1704,7 +1704,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   spec:

--- a/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -191,7 +191,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   class_name:
                     description: ClassName defines ingress class name for VMAuth
@@ -390,14 +390,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                   tlsHosts:
                     description: TlsHosts configures TLS access for ingress, tlsSecretName
@@ -526,7 +526,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -534,14 +534,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               podSecurityPolicyName:
@@ -651,7 +651,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -659,7 +659,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -667,7 +667,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   spec:

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -362,7 +362,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -370,7 +370,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -378,7 +378,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   port:
@@ -517,7 +517,7 @@ spec:
                               map stored with a resource that may be set by external
                               tools to store and retrieve arbitrary metadata. They
                               are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                             type: object
                           labels:
                             additionalProperties:
@@ -525,7 +525,7 @@ spec:
                             description: 'Labels Map of string keys and values that
                               can be used to organize and categorize (scope and select)
                               objects. May match selectors of replication controllers
-                              and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                             type: object
                           name:
                             description: 'Name must be unique within a namespace.
@@ -533,7 +533,7 @@ spec:
                               may allow a client to request the generation of an appropriate
                               name automatically. Name is primarily intended for creation
                               idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                             type: string
                         type: object
                       spec:
@@ -1228,7 +1228,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -1236,7 +1236,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -1244,7 +1244,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   port:
@@ -1351,7 +1351,7 @@ spec:
                               map stored with a resource that may be set by external
                               tools to store and retrieve arbitrary metadata. They
                               are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                             type: object
                           labels:
                             additionalProperties:
@@ -1359,7 +1359,7 @@ spec:
                             description: 'Labels Map of string keys and values that
                               can be used to organize and categorize (scope and select)
                               objects. May match selectors of replication controllers
-                              and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                             type: object
                           name:
                             description: 'Name must be unique within a namespace.
@@ -1367,7 +1367,7 @@ spec:
                               may allow a client to request the generation of an appropriate
                               name automatically. Name is primarily intended for creation
                               idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                             type: string
                         type: object
                       spec:
@@ -1444,7 +1444,7 @@ spec:
                                   map stored with a resource that may be set by external
                                   tools to store and retrieve arbitrary metadata.
                                   They are not queryable and should be preserved when
-                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                                 type: object
                               labels:
                                 additionalProperties:
@@ -1452,7 +1452,7 @@ spec:
                                 description: 'Labels Map of string keys and values
                                   that can be used to organize and categorize (scope
                                   and select) objects. May match selectors of replication
-                                  controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                                 type: object
                               name:
                                 description: 'Name must be unique within a namespace.
@@ -1460,7 +1460,7 @@ spec:
                                   resources may allow a client to request the generation
                                   of an appropriate name automatically. Name is primarily
                                   intended for creation idempotence and configuration
-                                  definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                                 type: string
                             type: object
                           spec:
@@ -2385,7 +2385,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -2393,7 +2393,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -2401,7 +2401,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   port:
@@ -2508,7 +2508,7 @@ spec:
                               map stored with a resource that may be set by external
                               tools to store and retrieve arbitrary metadata. They
                               are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                             type: object
                           labels:
                             additionalProperties:
@@ -2516,7 +2516,7 @@ spec:
                             description: 'Labels Map of string keys and values that
                               can be used to organize and categorize (scope and select)
                               objects. May match selectors of replication controllers
-                              and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                             type: object
                           name:
                             description: 'Name must be unique within a namespace.
@@ -2524,7 +2524,7 @@ spec:
                               may allow a client to request the generation of an appropriate
                               name automatically. Name is primarily intended for creation
                               idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                             type: string
                         type: object
                       spec:

--- a/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -286,7 +286,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -294,14 +294,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               podSecurityPolicyName:
@@ -418,7 +418,7 @@ spec:
                           stored with a resource that may be set by external tools
                           to store and retrieve arbitrary metadata. They are not queryable
                           and should be preserved when modifying objects. More info:
-                          http://kubernetes.io/docs/user-guide/annotations'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                         type: object
                       labels:
                         additionalProperties:
@@ -426,7 +426,7 @@ spec:
                         description: 'Labels Map of string keys and values that can
                           be used to organize and categorize (scope and select) objects.
                           May match selectors of replication controllers and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels'
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                         type: object
                       name:
                         description: 'Name must be unique within a namespace. Is required
@@ -434,7 +434,7 @@ spec:
                           a client to request the generation of an appropriate name
                           automatically. Name is primarily intended for creation idempotence
                           and configuration definition. Cannot be updated. More info:
-                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                         type: string
                     type: object
                   spec:
@@ -629,7 +629,7 @@ spec:
                     description: 'Annotations is an unstructured key value map stored
                       with a resource that may be set by external tools to store and
                       retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
                     type: object
                   labels:
                     additionalProperties:
@@ -637,14 +637,14 @@ spec:
                     description: 'Labels Map of string keys and values that can be
                       used to organize and categorize (scope and select) objects.
                       May match selectors of replication controllers and services.
-                      More info: http://kubernetes.io/docs/user-guide/labels'
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                     type: object
                   name:
                     description: 'Name must be unique within a namespace. Is required
                       when creating resources, although some resources may allow a
                       client to request the generation of an appropriate name automatically.
                       Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                     type: string
                 type: object
               streamAggrConfig:

--- a/docs/api.md
+++ b/docs/api.md
@@ -780,7 +780,7 @@ VMAgentSpec defines the desired state of VMAgent
 | extraEnvs | ExtraEnvs that will be added to VMAgent pod | [][v1.EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#envvar-v1-core) | false |
 | serviceSpec | ServiceSpec that will be added to vmagent service spec | *[ServiceSpec](#servicespec) | false |
 | serviceScrapeSpec | ServiceScrapeSpec that will be added to vmagent VMServiceScrape spec | *[VMServiceScrapeSpec](#vmservicescrapespec) | false |
-| shardCount | ShardCount - numbers of shards of VMAgent in this case operator will use 1 deployment/sts per shard with replicas count according to spec.replicas https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets | *int | false |
+| shardCount | ShardCount - numbers of shards of VMAgent in this case operator will use 1 deployment/sts per shard with replicas count according to spec.replicas, see https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets | *int | false |
 | updateStrategy | UpdateStrategy - overrides default update strategy. works only for deployments, statefulset always use OnDelete. | *[appsv1.DeploymentStrategyType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#deploymentstrategy-v1-apps) | false |
 | rollingUpdate | RollingUpdate - overrides deployment update params. | *[appsv1.RollingUpdateDeployment](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#rollingupdatedeployment-v1-apps) | false |
 | podDisruptionBudget | PodDisruptionBudget created by operator | *[EmbeddedPodDisruptionBudgetSpec](#embeddedpoddisruptionbudgetspec) | false |
@@ -866,7 +866,7 @@ DiscoverySelector can be used at CRD components discovery
 
 ## EmbeddedHPA
 
-EmbeddedHPA embeds HorizontalPodAutoScaler spec v2. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2beta2/
+EmbeddedHPA embeds HorizontalPodAutoScaler spec v2. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -883,9 +883,9 @@ EmbeddedObjectMetadata contains a subset of the fields included in k8s.io/apimac
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| name | Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names | string | false |
-| labels | Labels Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels | map[string]string | false |
-| annotations | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations | map[string]string | false |
+| name | Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names | string | false |
+| labels | Labels Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels | map[string]string | false |
+| annotations | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations | map[string]string | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -2034,9 +2034,9 @@ EmbeddedIngress describes ingress configuration options.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | class_name | ClassName defines ingress class name for VMAuth | *string | false |
-| name | Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names | string | false |
-| labels | Labels Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels | map[string]string | false |
-| annotations | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations | map[string]string | false |
+| name | Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names | string | false |
+| labels | Labels Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels | map[string]string | false |
+| annotations | Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations | map[string]string | false |
 | tlsHosts | TlsHosts configures TLS access for ingress, tlsSecretName must be defined for it. | []string | false |
 | tlsSecretName | TlsSecretName defines secretname at the VMAuth namespace with cert and key https://kubernetes.io/docs/concepts/services-networking/ingress/#tls | string | false |
 | extraRules | ExtraRules - additional rules for ingress, must be checked for correctness by user. | [][v12.IngressRule](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#ingressrule-v1-networking-k8s-io) | false |


### PR DESCRIPTION
replace `https://victoriametrics.github.io/vmagent.html#scraping-big-number-of-targets` -> `https://docs.victoriametrics.com/vmagent.html#scraping-big-number-of-targets`;
refer to https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/