### PR TITLE
passing `-replicationFactor` to vmselect

### DIFF
--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -399,16 +399,21 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		args = append(args, fmt.Sprintf("-loggerFormat=%s", cr.Spec.VMSelect.LogFormat))
 	}
 	if cr.Spec.ReplicationFactor != nil && *cr.Spec.ReplicationFactor > 1 {
-		args = append(args, fmt.Sprintf("-replicationFactor=%d", *cr.Spec.ReplicationFactor))
-
+		var replicationFactorIsSet bool
 		var dedupIsSet bool
 		for arg := range cr.Spec.VMSelect.ExtraArgs {
 			if strings.Contains(arg, "dedup.minScrapeInterval") {
 				dedupIsSet = true
 			}
+			if strings.Contains(arg, "replicationFactor") {
+				replicationFactorIsSet = true
+			}
 		}
 		if !dedupIsSet {
 			args = append(args, "-dedup.minScrapeInterval=1ms")
+		}
+		if !replicationFactorIsSet {
+			args = append(args, fmt.Sprintf("-replicationFactor=%d", *cr.Spec.ReplicationFactor))
 		}
 	}
 

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -399,6 +399,8 @@ func makePodSpecForVMSelect(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (
 		args = append(args, fmt.Sprintf("-loggerFormat=%s", cr.Spec.VMSelect.LogFormat))
 	}
 	if cr.Spec.ReplicationFactor != nil && *cr.Spec.ReplicationFactor > 1 {
+		args = append(args, fmt.Sprintf("-replicationFactor=%d", *cr.Spec.ReplicationFactor))
+
 		var dedupIsSet bool
 		for arg := range cr.Spec.VMSelect.ExtraArgs {
 			if strings.Contains(arg, "dedup.minScrapeInterval") {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ menu:
 
 ## Next release
 
-- TODO
+- [vmcluster](./api.md#vmcluster): from now on operator passes `-replicationFactor` (if it set in `vmcluster`) for `vmselect`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/778).
 
 <a name="v0.38.0"></a>
 ## [v0.39.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.39.0) - 4 Oct 2023


### PR DESCRIPTION
from now on operator passes `-replicationFactor` (if it set in `vmcluster`) for `vmselect` 

issue: #778 