### PR TITLE
fix: add `custom-dashboards` path to VMUser's VMSelect pre-defined path

### DIFF
--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -791,6 +791,7 @@ func addVMSelectPaths(src []string) []string {
 		"/vmui/vmui",
 		"/graph",
 		"/prometheus/graph",
+		"/prometheus/vmui.*",
 		"/prometheus/api/v1/label.*",
 		"/graphite.*",
 		"/prometheus/api/v1/query.*",


### PR DESCRIPTION
### Context

When using VMUser's `vmuser.spec.targetRefs.crd` with a `VMCluster/vmselect` reference, the list of predefined path does not include `/prometheus/vmui/custom-dashboards` which causes a 400 when accessing VMUI behind VMAuth.