### PR TITLE
vmuser: add support of tls_insecure_skip_verify parameter

### DIFF
--- a/api/v1beta1/vmuser_types.go
+++ b/api/v1beta1/vmuser_types.go
@@ -74,6 +74,10 @@ type VMUserSpec struct {
 
 	// DisableSecretCreation skips related secret creation for vmuser
 	DisableSecretCreation bool `json:"disable_secret_creation,omitempty"`
+
+	// TLSInsecureSkipVerify allows to skip tls verification for targetRefs
+	// +optional
+	TLSInsecureSkipVerify bool `json:"tls_insecure_skip_verify"`
 }
 
 // TargetRef describes target for user traffic forwarding.

--- a/config/crd/bases/operator.victoriametrics.com_vmusers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmusers.yaml
@@ -192,6 +192,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              tls_insecure_skip_verify:
+                description: TLSInsecureSkipVerify allows to skip tls verification
+                  for targetRefs
+                type: boolean
               tokenRef:
                 description: TokenRef allows fetching token from user-created secrets
                   by its name and key.

--- a/controllers/factory/vmuser.go
+++ b/controllers/factory/vmuser.go
@@ -637,6 +637,12 @@ func genUserCfg(user *victoriametricsv1beta1.VMUser, crdUrlCache map[string]stri
 	if len(user.Spec.ResponseHeaders) > 0 {
 		r = append(r, yaml.MapItem{Key: "response_headers", Value: user.Spec.ResponseHeaders})
 	}
+	if user.Spec.TLSInsecureSkipVerify {
+		r = append(r, yaml.MapItem{
+			Key:   "tls_insecure_skip_verify",
+			Value: user.Spec.TLSInsecureSkipVerify,
+		})
+	}
 	// fast path.
 	if token != "" {
 		r = append(r, yaml.MapItem{

--- a/controllers/factory/vmuser_test.go
+++ b/controllers/factory/vmuser_test.go
@@ -59,6 +59,41 @@ password: pass
 `,
 		},
 		{
+			name: "skip TLS verification",
+			args: args{
+				user: &v1beta1.VMUser{
+					Spec: v1beta1.VMUserSpec{
+						Name:                  pointer.StringPtr("user1"),
+						UserName:              pointer.StringPtr("basic"),
+						Password:              pointer.StringPtr("pass"),
+						TLSInsecureSkipVerify: true,
+						TargetRefs: []v1beta1.TargetRef{
+							{
+								Static: &v1beta1.StaticRef{
+									URL: "https://vmselect",
+								},
+								Paths: []string{
+									"/select/0/prometheus",
+									"/select/0/graphite",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `url_map:
+- url_prefix:
+  - https://vmselect
+  src_paths:
+  - /select/0/prometheus
+  - /select/0/graphite
+name: user1
+tls_insecure_skip_verify: true
+username: basic
+password: pass
+`,
+		},
+		{
 			name: "with crd",
 			args: args{
 				user: &v1beta1.VMUser{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,10 @@ menu:
 
 ## Next release
 
-- TODO
+### Features
+
+- [vmuser](./api.md#vmuser): adds `tls_insecure_skip_verify` setting which allows to disable TLS verification for connection to backend. It's supported since `v1.95.0` release of [vmauth](https://docs.victoriametrics.com/vmauth.html)
+
 
 <a name="v0.38.0"></a>
 ## [v0.39.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.39.0) - 4 Oct 2023


### PR DESCRIPTION
Allow to skip TLS verification on per-user basis by using tls_insecure_skip_verify parameter.

Marking as draft until https://github.com/VictoriaMetrics/VictoriaMetrics/pull/5256  is merged and released.