### PR TITLE
controller/factory/k8stools: optimize `HandleSTSUpdate`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,9 @@ menu:
 
 ## Next release
 
-- TODO
+### Features
+
+- [vmoperator](./README.md): optimize statefulset update logic, that should reduce some unneeded operations. See [this PR](https://github.com/VictoriaMetrics/operator/pull/801) for details.
 
 <a name="v0.39.1"></a>
 ## [v0.39.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.39.1) - 1 Nov 2023


### PR DESCRIPTION
1. even if statefulset needs recreate because VolumeClaimTemplates changed, sometimes pod doesn't need to be recreated. Since pod's volume only cares VolumeClaimTemplate's name, so other attributes like size or storageClassName won't effect that.
```
    volumes:
    - name: vmstorage-db
      persistentVolumeClaim:
        claimName: vmstorage-db-vmstorage-test-insight-victoria-metrics-k8s-stack-0
```
2. remove hack code from https://github.com/VictoriaMetrics/operator/issues/344, this should be resolved by https://github.com/kubernetes/kubernetes/pull/109694 and other fixes. Statefulset's currentRevision&updateRevision should be updated by statefulset controller now.

ps. also add some comments on why updating sts.Status.CurrentRevision to UpdateRevision by hand, please check if that's right @f41gh7 