### PR TITLE
add missing status route in vmauth example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -423,6 +423,7 @@ spec:
           - "/prometheus/api/v1/query"
           - "/prometheus/api/v1/query_range"
           - "/prometheus/api/v1/series"
+          - "/prometheus/api/v1/status/.*"
           - "/prometheus/api/v1/label/"
           - "/prometheus/api/v1/label/[^/]+/values"
 ```
@@ -642,6 +643,7 @@ spec:
         - "/prometheus/api/v1/query"
         - "/prometheus/api/v1/query_range"
         - "/prometheus/api/v1/series"
+        - "/prometheus/api/v1/status/.*"
         - "/prometheus/api/v1/label/"
         - "/prometheus/api/v1/label/[^/]+/values"
     # vmalert


### PR DESCRIPTION
`/prometheus/api/v1/status` is needed for top/active queries in vmui.
related thread https://victoriametrics.slack.com/archives/CGZF1H6L9/p1702542069333989?thread_ts=1702387812.406289&cid=CGZF1H6L9