### PR TITLE
Makefile: bump based alpine images to the latest v3.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CRD_PRESERVE=x-kubernetes-preserve-unknown-fields true
 # Current Operator version
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
-ALPINE_IMAGE=alpine:3.18.3
+ALPINE_IMAGE=alpine:3.19.0
 CHANNEL=beta
 DEFAULT_CHANNEL=beta
 BUNDLE_CHANNELS := --channels=$(CHANNEL)


### PR DESCRIPTION
Using the [new version of alpine Linux ](https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html) should fix vulnerabilities which are in previous alpine versions, see more https://artifacthub.io/packages/olm/community-operators/victoriametrics-operator/0.39.4?modal=security-report