### PR TITLE
update operator-hub part in release doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 for developing you need:
 - golang 1.15+
-- operator-sdk v1.0.0
+- operator-sdk v1.33.0
 - docker
 - minikube or kind for e2e tests
 - golangci-lint
@@ -50,39 +50,23 @@ This will scaffold api and controller. Then you have to edit code at `api` and `
 
 Choose version (release tag at github) and generate or update corresponding csv file
 ```bash
-TAG=v0.2.1 make packagemanifest
-TAG=v0.2.1 make bundle
+TAG=v0.36.0 make bundle
 ```
 
-it will generate files at directories: `packagemanifest/0.2.1/` and `bundle/`
+it will generate files at directories: `bundle/`
 
+### publish to operator-hub
 
-commit changes
-
-publish olm package to quay.io with (you have to define AUTH_TOKEN for quay firsh)
-
-```bash
-export AUTH_TOKEN="basic ..."
-TAG=v0.2.1 make packagemanifest-publish
-TAG=v0.2.1 make bundle-publish
+checkout to the latest release:
+1) `git checkout tags/v0.36.0`
+2) build package manifest: `TAG=v0.36.0 make bundle`
+3) add replacement for a previous version to generated cluster csv:
+`vi bundle/manifests/victoriametrics-operator.clusterserviceversion`
+```yaml
+spec:
+  replaces: victoriametrics-operator.v0.35.0
 ```
+Now you have to fork two repos and create pull requests to them with new version `/bundle`:
+1) https://github.com/k8s-operatorhub/community-operators for OperatorHub.io
+2) https://github.com/redhat-openshift-ecosystem/community-operators-prod for Embedded OperatorHub in OpenShift and OKD.
 
-### integration with operator-hub
-
- Clone repo locally: git clone https://github.com/operator-framework/community-operators.git
-
- copy content to operator-hub repo and run tests
- you can specify version (OP_VER) and channel OP_CHANNEL
- ```bash
-cp -R packagemanifests/* $PATH_TO_OPERATOR_REPO/upstream-community-operators/victoriametrics/
-cd $PATH_TO_OPERATOR_REPO
-#run tests
-make operator.verify OP_PATH=upstream-community-operators/victoria-metrics-operator VERBOSE=1
-make operator.test OP_PATH=upstream-community-operators/victoria-metrics-operator/ VERBOSE=1
-
-```
-
- Now you can submit merge request with changes to operator-hub repo
-
-
-troubleshooting: [url](https://github.com/operator-framework/community-operators/blob/master/docs/using-scripts.md#troubleshooting)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ VictoriaMetrics provides [helm charts](https://github.com/VictoriaMetrics/helm-c
 ## Kubernetes' compatibility versions
 
 operator tested at kubernetes versions
-from 1.16 to 1.25
+from 1.25 to 1.28
 
 ## Troubleshooting
 

--- a/Release.md
+++ b/Release.md
@@ -15,37 +15,14 @@
 ### Operator Hub release
 
 checkout to the latest release:
-1) `git checkout tags/v0.7.2`
-2) build package manifest: `TAG=v0.7.2 make packagemanifests`
+1) `git checkout tags/v0.36.0`
+2) build package manifest: `TAG=v0.36.0 make bundle`
 3) add replacement for a previous version to generated cluster csv:
-`vi packagemanifests/0.7.2/victoriametrics-operator.0.7.2.clusterserviceversion.yaml`
+`vi bundle/manifests/victoriametrics-operator.clusterserviceversion`
 ```yaml
 spec:
-  replaces: victoriametrics-operator.v0.6.1
+  replaces: victoriametrics-operator.v0.35.0
 ```
-4) publish changes to the quay, login first with your login, password:
-`bash hack/get_quay_token.sh`, copy token content to var `export AUTH_TOKEN="basic afsASF"`, 
-   then push change to quay: `TAG=v0.7.2 make packagemanifests-push`
-   
-5) now you have to copy content of packagemanifests to the community-operators repo,
-  first for upstream, next for community, sign-off commits and create PRs.
-   ```bash
-   cp -R packagemanifests/* ~/community-operators/upstream-community-operators/victoriametrics-operator
-   cd ~/community-operators
-   git add upstream-community-operators/victoriametrics-operator/0.7.2/
-   git add upstream-community-operators/victoriametrics-operator/victoriametrics-operator.package.yaml
-   git commit -m "updates victoriametrics operator version 0.7.2
-   Signed-off-by: Nikolay Khramchikhin <nik@victoriametrics.com>" --signoff
-   ```
-   checkout to the new branch and create separate commit for openshift operator-hub
-   ```bash
-   cp -R packagemanifests/* ~/community-operators/community-operators/victoriametrics-operator
-   cd ~/community-operators
-   git add community-operators/victoriametrics-operator/0.7.2/
-   git add community-operators/victoriametrics-operator/victoriametrics-operator.package.yaml
-   git commit -m "updates victoriametrics operator version 0.7.2
-   Signed-off-by: Nikolay Khramchikhin <nik@victoriametrics.com>" --signoff
-   ```
-   
-6) create pull requests at community-operator repo:
-   https://github.com/operator-framework/community-operators
+Now you have to fork two repos and create pull requests to them with new version `/bundle`:
+1) https://github.com/k8s-operatorhub/community-operators for OperatorHub.io
+2) https://github.com/redhat-openshift-ecosystem/community-operators-prod for Embedded OperatorHub in OpenShift and OKD.


### PR DESCRIPTION
1. deprecate packagemanifests;
2. some old contents are already invalid, like local test [script](https://github.com/operator-framework/community-operators/blob/master/docs/operator-test-suite.md) provided by previous repo, now we do validate when making bundle
https://github.com/VictoriaMetrics/operator/blob/2fa4c6043e52044f547c6c8f3913d41d4647977c/Makefile#L328
And there are some extra [tests](https://github.com/k8s-operatorhub/community-operators/blob/main/.github/workflows/operator_test.yaml) when creating pull requests to `https://github.com/k8s-operatorhub/community-operators` and `https://github.com/redhat-openshift-ecosystem/community-operators-prod`.
