### PR TITLE
fix community pr workflow job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,6 +77,6 @@ jobs:
             echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
             make publish-via-docker
           else
-            echo "there is no docker secret, just build image"
-            make build-operator-crosscompile docker-operator-crosscompile
+            echo "there is no docker secret, just build"
+            make build-operator-crosscompile
           fi


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/operator/actions/runs/7339857157/job/19984839742?pr=834,
`docker-operator-crosscompile` has been removed in https://github.com/VictoriaMetrics/operator/commit/c199848d02f45a0495fc031f546320b2bc471eae,
and since community job can't retrieve `secrets` for some reason, just skip the image build.