### PR TITLE
follow up https://github.com/VictoriaMetrics/operator/commit/991536d

### DIFF
--- a/api/v1beta1/vmagent_types.go
+++ b/api/v1beta1/vmagent_types.go
@@ -58,8 +58,8 @@ type VMAgentSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	// +optional
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
 	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`

--- a/api/v1beta1/vmalert_types.go
+++ b/api/v1beta1/vmalert_types.go
@@ -64,8 +64,8 @@ type VMAlertSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
 	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`

--- a/api/v1beta1/vmalertmanager_types.go
+++ b/api/v1beta1/vmalertmanager_types.go
@@ -100,6 +100,11 @@ type VMAlertmanagerSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Retention Time duration VMAlertmanager shall retain data for. Default is '120h',
 	// and must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).
 	// +kubebuilder:validation:Pattern:="[0-9]+(ms|s|m|h)"

--- a/api/v1beta1/vmauth_types.go
+++ b/api/v1beta1/vmauth_types.go
@@ -47,8 +47,8 @@ type VMAuthSpec struct {
 	// ReplicaCount is the expected size of the VMAuth
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
 	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -179,6 +179,11 @@ type VMSelect struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.
@@ -378,8 +383,8 @@ type VMInsert struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
 	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
@@ -563,6 +568,11 @@ type VMStorage struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.

--- a/api/v1beta1/vmsingle_types.go
+++ b/api/v1beta1/vmsingle_types.go
@@ -64,8 +64,8 @@ type VMSingleSpec struct {
 	// if you need more - use vm cluster
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
 	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -3225,6 +3225,11 @@ func (in *VMAlertmanagerSpec) DeepCopyInto(out *VMAlertmanagerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(StorageSpec)
@@ -4807,6 +4812,11 @@ func (in *VMSelect) DeepCopyInto(out *VMSelect) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -5451,6 +5461,11 @@ func (in *VMStorage) DeepCopyInto(out *VMStorage) {
 	}
 	if in.ReplicaCount != nil {
 		in, out := &in.ReplicaCount, &out.ReplicaCount
+		*out = new(int32)
+		**out = **in
+	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
 		*out = new(int32)
 		**out = **in
 	}

--- a/api/victoriametrics/v1beta1/vmagent_types.go
+++ b/api/victoriametrics/v1beta1/vmagent_types.go
@@ -58,11 +58,11 @@ type VMAgentSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	// +optional
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output deploy definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.

--- a/api/victoriametrics/v1beta1/vmalert_types.go
+++ b/api/victoriametrics/v1beta1/vmalert_types.go
@@ -64,11 +64,11 @@ type VMAlertSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.

--- a/api/victoriametrics/v1beta1/vmalertmanager_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanager_types.go
@@ -100,6 +100,11 @@ type VMAlertmanagerSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Retention Time duration VMAlertmanager shall retain data for. Default is '120h',
 	// and must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).
 	// +kubebuilder:validation:Pattern:="[0-9]+(ms|s|m|h)"

--- a/api/victoriametrics/v1beta1/vmauth_types.go
+++ b/api/victoriametrics/v1beta1/vmauth_types.go
@@ -47,6 +47,11 @@ type VMAuthSpec struct {
 	// ReplicaCount is the expected size of the VMAuth
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 
 	// Volumes allows configuration of additional volumes on the output deploy definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of

--- a/api/victoriametrics/v1beta1/vmcluster_types.go
+++ b/api/victoriametrics/v1beta1/vmcluster_types.go
@@ -179,6 +179,11 @@ type VMSelect struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.
@@ -378,11 +383,11 @@ type VMInsert struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
-	// The number of old ReplicaSets to retain to allow rollback.
-	// This is a pointer to distinguish between explicit zero and not specified.
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
 	// Defaults to 10.
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.
@@ -563,6 +568,11 @@ type VMStorage struct {
 	// size.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 	// Volumes allows configuration of additional volumes on the output Deployment definition.
 	// Volumes specified will be appended to other volumes that are generated as a result of
 	// StorageSpec objects.

--- a/api/victoriametrics/v1beta1/vmsingle_types.go
+++ b/api/victoriametrics/v1beta1/vmsingle_types.go
@@ -64,6 +64,11 @@ type VMSingleSpec struct {
 	// if you need more - use vm cluster
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of pods",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom"
 	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	// The number of old ReplicaSets to retain to allow rollback in deployment or
+	// maximum number of revisions that will be maintained in the StatefulSet's revision history.
+	// Defaults to 10.
+	// +optional
+	RevisionHistoryLimitCount *int32 `json:"revisionHistoryLimitCount,omitempty"`
 
 	// StorageDataPath disables spec.storage option and overrides arg for victoria-metrics binary --storageDataPath,
 	// its users responsibility to mount proper device into given path.

--- a/api/victoriametrics/v1beta1/zz_generated.deepcopy.go
+++ b/api/victoriametrics/v1beta1/zz_generated.deepcopy.go
@@ -2251,6 +2251,11 @@ func (in *VMAgentSpec) DeepCopyInto(out *VMAgentSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -2785,6 +2790,11 @@ func (in *VMAlertSpec) DeepCopyInto(out *VMAlertSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -3215,6 +3225,11 @@ func (in *VMAlertmanagerSpec) DeepCopyInto(out *VMAlertmanagerSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(StorageSpec)
@@ -3473,6 +3488,11 @@ func (in *VMAuthSpec) DeepCopyInto(out *VMAuthSpec) {
 	}
 	if in.ReplicaCount != nil {
 		in, out := &in.ReplicaCount, &out.ReplicaCount
+		*out = new(int32)
+		**out = **in
+	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
 		*out = new(int32)
 		**out = **in
 	}
@@ -3915,6 +3935,11 @@ func (in *VMInsert) DeepCopyInto(out *VMInsert) {
 	}
 	if in.ReplicaCount != nil {
 		in, out := &in.ReplicaCount, &out.ReplicaCount
+		*out = new(int32)
+		**out = **in
+	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
 		*out = new(int32)
 		**out = **in
 	}
@@ -4787,6 +4812,11 @@ func (in *VMSelect) DeepCopyInto(out *VMSelect) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))
@@ -5131,6 +5161,11 @@ func (in *VMSingleSpec) DeepCopyInto(out *VMSingleSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(v1.PersistentVolumeClaimSpec)
@@ -5426,6 +5461,11 @@ func (in *VMStorage) DeepCopyInto(out *VMStorage) {
 	}
 	if in.ReplicaCount != nil {
 		in, out := &in.ReplicaCount, &out.ReplicaCount
+		*out = new(int32)
+		**out = **in
+	}
+	if in.RevisionHistoryLimitCount != nil {
+		in, out := &in.RevisionHistoryLimitCount, &out.RevisionHistoryLimitCount
 		*out = new(int32)
 		**out = **in
 	}

--- a/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmagents.yaml
@@ -2307,9 +2307,9 @@ spec:
                     type: object
                 type: object
               revisionHistoryLimitCount:
-                description: The number of old ReplicaSets to retain to allow rollback.
-                  This is a pointer to distinguish between explicit zero and not specified.
-                  Defaults to 10.
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
                 format: int32
                 type: integer
               rollingUpdate:

--- a/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalertmanagers.yaml
@@ -773,6 +773,12 @@ spec:
                   (milliseconds seconds minutes hours).
                 pattern: '[0-9]+(ms|s|m|h)'
                 type: string
+              revisionHistoryLimitCount:
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
+                format: int32
+                type: integer
               rollingUpdateStrategy:
                 description: RollingUpdateStrategy defines strategy for application
                   updates Default is OnDelete, in this case operator handles update

--- a/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmalerts.yaml
@@ -1500,9 +1500,9 @@ spec:
                     type: object
                 type: object
               revisionHistoryLimitCount:
-                description: The number of old ReplicaSets to retain to allow rollback.
-                  This is a pointer to distinguish between explicit zero and not specified.
-                  Defaults to 10.
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
                 format: int32
                 type: integer
               rollingUpdate:

--- a/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmauths.yaml
@@ -603,9 +603,9 @@ spec:
                     type: object
                 type: object
               revisionHistoryLimitCount:
-                description: The number of old ReplicaSets to retain to allow rollback.
-                  This is a pointer to distinguish between explicit zero and not specified.
-                  Defaults to 10.
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
                 format: int32
                 type: integer
               runtimeClassName:

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -440,8 +440,9 @@ spec:
                     type: object
                   revisionHistoryLimitCount:
                     description: The number of old ReplicaSets to retain to allow
-                      rollback. This is a pointer to distinguish between explicit
-                      zero and not specified. Defaults to 10.
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
                     format: int32
                     type: integer
                   rollingUpdate:
@@ -1310,6 +1311,13 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  revisionHistoryLimitCount:
+                    description: The number of old ReplicaSets to retain to allow
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
+                    format: int32
+                    type: integer
                   rollingUpdateStrategy:
                     description: RollingUpdateStrategy defines strategy for application
                       updates Default is OnDelete, in this case operator handles update
@@ -2467,6 +2475,13 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  revisionHistoryLimitCount:
+                    description: The number of old ReplicaSets to retain to allow
+                      rollback in deployment or maximum number of revisions that will
+                      be maintained in the StatefulSet's revision history. Defaults
+                      to 10.
+                    format: int32
+                    type: integer
                   rollingUpdateStrategy:
                     description: RollingUpdateStrategy defines strategy for application
                       updates Default is OnDelete, in this case operator handles update

--- a/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -376,9 +376,9 @@ spec:
                   https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#retention
                 type: string
               revisionHistoryLimitCount:
-                description: The number of old ReplicaSets to retain to allow rollback.
-                  This is a pointer to distinguish between explicit zero and not specified.
-                  Defaults to 10.
+                description: The number of old ReplicaSets to retain to allow rollback
+                  in deployment or maximum number of revisions that will be maintained
+                  in the StatefulSet's revision history. Defaults to 10.
                 format: int32
                 type: integer
               runtimeClassName:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -184,23 +184,3 @@ webhooks:
     resources:
     - vmusers
   sideEffects: None
-- admissionReviewVersions:
-    - v1
-  clientConfig:
-    service:
-      name: vm-operator
-      namespace: victoriametrics-system
-      path: /validate-operator-victoriametrics-com-v1beta1-vmrule
-  failurePolicy: Fail
-  name: vvmrule.kb.io
-  rules:
-    - apiGroups:
-        - operator.victoriametrics.com
-      apiVersions:
-        - v1beta1
-      operations:
-        - CREATE
-        - UPDATE
-      resources:
-        - vmrules
-  sideEffects: None

--- a/controllers/factory/alertmanager.go
+++ b/controllers/factory/alertmanager.go
@@ -477,9 +477,10 @@ func makeStatefulSetSpec(cr *victoriametricsv1beta1.VMAlertmanager, c *config.Ba
 	}
 
 	return &appsv1.StatefulSetSpec{
-		ServiceName:         cr.PrefixedName(),
-		Replicas:            cr.Spec.ReplicaCount,
-		PodManagementPolicy: appsv1.ParallelPodManagement,
+		ServiceName:          cr.PrefixedName(),
+		Replicas:             cr.Spec.ReplicaCount,
+		RevisionHistoryLimit: cr.Spec.RevisionHistoryLimitCount,
+		PodManagementPolicy:  appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: cr.UpdateStrategy(),
 		},

--- a/controllers/factory/vmagent.go
+++ b/controllers/factory/vmagent.go
@@ -235,7 +235,8 @@ func newDeployForVMAgent(cr *victoriametricsv1beta1.VMAgent, c *config.BaseOpera
 				Finalizers:      []string{victoriametricsv1beta1.FinalizerName},
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: cr.Spec.ReplicaCount,
+				Replicas:             cr.Spec.ReplicaCount,
+				RevisionHistoryLimit: cr.Spec.RevisionHistoryLimitCount,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: cr.SelectorLabels(),
 				},

--- a/controllers/factory/vmcluster.go
+++ b/controllers/factory/vmcluster.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -370,7 +369,7 @@ func genVMSelectSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv1
 			},
 			Template:             *podSpec,
 			ServiceName:          cr.Spec.VMSelect.GetNameWithPrefix(cr.Name),
-			RevisionHistoryLimit: pointer.Int32Ptr(10),
+			RevisionHistoryLimit: cr.Spec.VMSelect.RevisionHistoryLimitCount,
 		},
 	}
 	if cr.Spec.VMSelect.CacheMountPath != "" {
@@ -1027,7 +1026,7 @@ func GenVMStorageSpec(cr *v1beta1.VMCluster, c *config.BaseOperatorConf) (*appsv
 			},
 			Template:             *podSpec,
 			ServiceName:          cr.Spec.VMStorage.GetNameWithPrefix(cr.Name),
-			RevisionHistoryLimit: pointer.Int32Ptr(10),
+			RevisionHistoryLimit: cr.Spec.VMStorage.RevisionHistoryLimitCount,
 		},
 	}
 	storageSpec := cr.Spec.VMStorage.Storage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ aliases:
 
 - [vmalertmanager](./api.html#vmalertmanagerconfig): fix `VMAlertmanagerConfig` discovery according to [the docs](https://docs.victoriametrics.com/operator/resources/vmalertmanager.html#using-vmalertmanagerconfig).
 - [vmoperator](./README.md): add alerting rules for operator itself. See [this issue](https://github.com/VictoriaMetrics/operator/issues/526) for details.
-- [vmoperator](./README.md): add `revisionHistoryLimitCount` as spec for victoria metrics resources which creates Deployment. See [this issue](https://github.com/VictoriaMetrics/operator/pull/834) for details.
+- [vmoperator](./README.md): add `revisionHistoryLimitCount` field for victoriametrics workload CRDs. See [this issue](https://github.com/VictoriaMetrics/operator/pull/834) for details. Thanks [@gidesh](https://github.com/gidesh)
 
 <a name="v0.39.4"></a>
 ## [v0.39.4](https://github.com/VictoriaMetrics/operator/releases/tag/v0.39.4) - 13 Dec 2023

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,6 +186,7 @@ VMAlertmanagerSpec is a specification of the desired behavior of the VMAlertmana
 | logLevel | Log level for VMAlertmanager to be configured with. | string | false |
 | logFormat | LogFormat for VMAlertmanager to be configured with. | string | false |
 | replicaCount | ReplicaCount Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected | *int32 | false |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | retention | Retention Time duration VMAlertmanager shall retain data for. Default is &#39;120h&#39;, and must match the regular expression `[0-9]+(ms\|s\|m\|h)` (milliseconds seconds minutes hours). | string | false |
 | storage | Storage is the definition of how storage will be used by the VMAlertmanager instances. | *[StorageSpec](#storagespec) | false |
 | volumes | Volumes allows configuration of additional volumes on the output StatefulSet definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
@@ -740,6 +741,7 @@ VMAgentSpec defines the desired state of VMAgent
 | logLevel | LogLevel for VMAgent to be configured with. INFO, WARN, ERROR, FATAL, PANIC | string | false |
 | logFormat | LogFormat for VMAgent to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMAgent cluster. The controller will eventually make the size of the running cluster equal to the expected size. NOTE enable VMSingle deduplication for replica usage | *int32 | false |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output deploy definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output deploy definition. VolumeMounts specified will be appended to other VolumeMounts in the vmagent container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ if not specified - default setting will be used | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |
@@ -1134,6 +1136,7 @@ VMAlertSpec defines the desired state of VMAlert
 | logFormat | LogFormat for VMAlert to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMAlert to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMAlert cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | false |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output Deployment definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition. VolumeMounts specified will be appended to other VolumeMounts in the VMAlert container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |
@@ -1233,6 +1236,7 @@ VMSingleSpec defines the desired state of VMSingle
 | logLevel | LogLevel for victoria metrics single to be configured with. | string | false |
 | logFormat | LogFormat for VMSingle to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMSingle it can be 0 or 1 if you need more - use vm cluster | *int32 | false |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | storageDataPath | StorageDataPath disables spec.storage option and overrides arg for victoria-metrics binary --storageDataPath, its users responsibility to mount proper device into given path. | string | false |
 | storage | Storage is the definition of how storage will be used by the VMSingle by default it`s empty dir | *[v1.PersistentVolumeClaimSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#persistentvolumeclaimspec-v1-core) | false |
 | storageMetadata | StorageMeta defines annotations and labels attached to PVC for given vmsingle CR | [EmbeddedObjectMetadata](#embeddedobjectmetadata) | false |
@@ -1784,6 +1788,7 @@ VMClusterStatus defines the observed state of VMCluster
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMInsert cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output Deployment definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition. VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |
@@ -1853,6 +1858,7 @@ VMClusterStatus defines the observed state of VMCluster
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output Deployment definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition. VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |
@@ -1904,6 +1910,7 @@ VMClusterStatus defines the observed state of VMCluster
 | logFormat | LogFormat for VMSelect to be configured with. default or json | string | false |
 | logLevel | LogLevel for VMSelect to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMStorage cluster. The controller will eventually make the size of the running cluster equal to the expected size. | *int32 | true |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output Deployment definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition. VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |
@@ -2151,6 +2158,7 @@ VMAuthSpec defines the desired state of VMAuth
 | logLevel | LogLevel for victoria metrics single to be configured with. | string | false |
 | logFormat | LogFormat for VMAuth to be configured with. | string | false |
 | replicaCount | ReplicaCount is the expected size of the VMAuth | *int32 | false |
+| revisionHistoryLimitCount | The number of old ReplicaSets to retain to allow rollback in deployment or maximum number of revisions that will be maintained in the StatefulSet&#39;s revision history. Defaults to 10. | *int32 | false |
 | volumes | Volumes allows configuration of additional volumes on the output deploy definition. Volumes specified will be appended to other volumes that are generated as a result of StorageSpec objects. | [][v1.Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core) | false |
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition. VolumeMounts specified will be appended to other VolumeMounts in the VMAuth container, that are generated as a result of StorageSpec objects. | [][v1.VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volumemount-v1-core) | false |
 | resources | Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ if not defined default resources from operator config will be used | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#resourcerequirements-v1-core) | false |


### PR DESCRIPTION
follow-up https://github.com/VictoriaMetrics/operator/commit/991536d212ab9dc2d81f82260d89aae877f6ba28
add `revisionHistoryLimitCount` for all the workload CRD resources, previously only for deployments.
remove dup config in validating webhook, update docs.