### PR TITLE
remove deprecated autoscaling/v2beta1 HPA objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ VictoriaMetrics provides [helm charts](https://github.com/VictoriaMetrics/helm-c
 ## Kubernetes' compatibility versions
 
 operator tested at kubernetes versions
-from 1.25 to 1.28
+from 1.25 to 1.29
 
 ## Troubleshooting
 

--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -403,24 +403,6 @@ func buildProbe(container v1.Container, cr probeCRD) v1.Container {
 }
 
 func buildHPASpec(targetRef v2beta2.CrossVersionObjectReference, spec *victoriametricsv1beta1.EmbeddedHPA, or []metav1.OwnerReference, lbls map[string]string, namespace string) client.Object {
-	if k8stools.IsHPAV2BetaSupported() {
-		return &v2beta2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            targetRef.Name,
-				Namespace:       namespace,
-				Labels:          lbls,
-				OwnerReferences: or,
-			},
-			Spec: v2beta2.HorizontalPodAutoscalerSpec{
-				MaxReplicas:    spec.MaxReplicas,
-				MinReplicas:    spec.MinReplicas,
-				ScaleTargetRef: targetRef,
-				Metrics:        spec.Metrics,
-				Behavior:       spec.Behaviour,
-			},
-		}
-	}
-
 	return &v2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            targetRef.Name,

--- a/controllers/factory/k8stools/version.go
+++ b/controllers/factory/k8stools/version.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"k8s.io/api/autoscaling/v2"
-	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -59,16 +58,6 @@ func IsPDBV1APISupported() bool {
 	return false
 }
 
-// IsHPAV2BetaSupported checks if new
-// Beta deprecated since 1.26
-// https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/#horizontalpodautoscaler-v2-graduates-to-ga
-func IsHPAV2BetaSupported() bool {
-	if ServerMajorVersion == 1 && ServerMinorVersion < 26 {
-		return true
-	}
-	return false
-}
-
 // IsFSGroupChangePolicySupported checks if `fsGroupChangePolicy` is supported,
 // Supported since 1.20
 // https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recursive-permission-changes-on-mount
@@ -79,12 +68,9 @@ func IsFSGroupChangePolicySupported() bool {
 	return false
 }
 
-// NewHPAEmptyObject returns HorizontalPodAutoscaler object for given kubernetes version
+// NewHPAEmptyObject returns HorizontalPodAutoscaler object
 func NewHPAEmptyObject(opts ...func(obj client.Object)) client.Object {
-	var hpa client.Object = &v2beta2.HorizontalPodAutoscaler{}
-	if !IsHPAV2BetaSupported() {
-		hpa = &v2.HorizontalPodAutoscaler{}
-	}
+	var hpa client.Object = &v2.HorizontalPodAutoscaler{}
 	for _, opt := range opts {
 		opt(hpa)
 	}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ aliases:
 
 ## Next release
 
-- TODO
+- Remove deprecated autoscaling/v2beta1 HPA objects, previously operator still use it for k8s 1.25. See [this issue](https://github.com/VictoriaMetrics/operator/issues/864) for details.
 
 <a name="v0.41.1"></a>
 ## [v0.41.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.41.1) - 1 Feb 2024


### PR DESCRIPTION
address https://github.com/VictoriaMetrics/operator/issues/864,
since operator supports k8s version from 1.25 now, there is no need to have autoscaling/v2beta1.