### PR TITLE
controllers: properly check annotations at sts claim template

### DIFF
--- a/config/examples/vmcluster_storage_class_unexpandable.yaml
+++ b/config/examples/vmcluster_storage_class_unexpandable.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMCluster
+metadata:
+  name: example-vmcluster-persistent
+spec:
+  retentionPeriod: "4"
+  replicationFactor: 2
+  vmstorage:
+    replicaCount: 2
+    storageDataPath: "/vm-data"
+    storage:
+      volumeClaimTemplate:
+        metadata:
+         annotations:
+          operator.victoriametrics.com/pvc-allow-volume-expansion: "false"
+        spec:
+          storageClassName: sc-immutable
+          resources:
+            requests:
+              storage: 10Gi
+  vmselect:
+    replicaCount: 2
+    cacheMountPath: "/select-cache"
+    storage:
+      volumeClaimTemplate:
+        metadata:
+         annotations:
+          operator.victoriametrics.com/pvc-allow-volume-expansion: "false"
+        spec:
+          storageClassName: sc-mutable
+          resources:
+            requests:
+              storage: 2Gi
+  vminsert:
+    replicaCount: 2
+


### PR DESCRIPTION
previously each pvc created by sts must be annotated with operator.victoriametrics.com/pvc-allow-volume-expansion now, it's no longer needed, operator performs a check on sts claim definition itself it allows to use it for PVC autoscaler or simmilar tool https://github.com/VictoriaMetrics/operator/issues/867