### PR TITLE
controllers/factory/vmalert: do not add `notifier.*` flags if `notifier.blackhole` is set by user

### DIFF
--- a/controllers/factory/vmalert.go
+++ b/controllers/factory/vmalert.go
@@ -832,6 +832,12 @@ func BuildNotifiersArgs(cr *victoriametricsv1beta1.VMAlert, ntBasicAuth map[stri
 		return append(finalArgs, fmt.Sprintf("-notifier.config=%s/%s", notifierConfigMountPath, cr.Spec.NotifierConfigRef.Key))
 	}
 
+	if _, ok := cr.Spec.ExtraArgs["notifier.blackhole"]; ok {
+		// notifier.blackhole disables sending notifications completely, so we don't need to add any notifier args
+		// also no need to add notifier.blackhole to args as it will be added with ExtraArgs
+		return finalArgs
+	}
+
 	url := remoteFlag{flagSetting: "-notifier.url=", isNotNull: true}
 	authUser := remoteFlag{flagSetting: "-notifier.basicAuth.username="}
 	authPasswordFile := remoteFlag{flagSetting: "-notifier.basicAuth.passwordFile="}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ aliases:
 
 ## Next release
 
+- [vmalert](./api.md#vmalert): do not add `notifiers.*` flags in case `notifier.blackhole` is provided via `spec.extraArgs`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/894) for details.
+
 <a name="v0.42.2"></a>
 ## [v0.42.](https://github.com/VictoriaMetrics/operator/releases/tag/v0.42.2) - 6 Mar 2024
 


### PR DESCRIPTION

Previously, setting "notifier.blackhole" and not using any notifiers would lead to CrashLoopBackoff because vmalert would receive an empty "notifier.url" value.

Updates:
- https://github.com/VictoriaMetrics/operator/issues/894
- https://github.com/VictoriaMetrics/operator/pull/813