### PR TITLE
Fix livenessProbe scheme

### DIFF
--- a/controllers/factory/builders.go
+++ b/controllers/factory/builders.go
@@ -349,7 +349,7 @@ func buildProbe(container v1.Container, cr probeCRD) v1.Container {
 			probeHandler := v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Port:   intstr.Parse(port),
-					Scheme: "HTTP",
+					Scheme: v1.URIScheme(scheme),
 					Path:   probePath(),
 				},
 			}

--- a/controllers/factory/builders_test.go
+++ b/controllers/factory/builders_test.go
@@ -469,6 +469,35 @@ func Test_buildProbe(t *testing.T) {
 			},
 		},
 		{
+			name: "build default probe with empty ep using HTTPS",
+			args: args{
+				cr: testBuildProbeCR{
+					probePath: func() string {
+						return "/health"
+					},
+					port:            "8051",
+					needAddLiveness: true,
+					scheme:          "HTTPS",
+				},
+				container: v1.Container{},
+			},
+			validate: func(container v1.Container) error {
+				if container.LivenessProbe == nil {
+					return fmt.Errorf("want liveness to be not nil")
+				}
+				if container.ReadinessProbe == nil {
+					return fmt.Errorf("want readinessProbe to be not nil")
+				}
+				if container.LivenessProbe.HTTPGet.Scheme != "HTTPS" {
+					return fmt.Errorf("expect scheme to be HTTPS got: %s", container.LivenessProbe.HTTPGet.Scheme)
+				}
+				if container.ReadinessProbe.HTTPGet.Scheme != "HTTPS" {
+					return fmt.Errorf("expect scheme to be HTTPS got: %s", container.ReadinessProbe.HTTPGet.Scheme)
+				}
+				return nil
+			},
+		},
+		{
 			name: "build default probe with ep",
 			args: args{
 				cr: testBuildProbeCR{


### PR DESCRIPTION
Fixes #896

Don't use hardcoded `HTTP` for liveness probe.