### PR TITLE
chore: minor fixes

### DIFF
--- a/api/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/v1beta1/vmalertmanagerconfig_types.go
@@ -256,7 +256,7 @@ type Receiver struct {
 	VictorOpsConfigs []VictorOpsConfig `json:"victorops_configs,omitempty"`
 	// WeChatConfigs defines wechat notification configurations.
 	// +optional
-	WeChatConfigs   []WeChatConfig   `json:"wechat_configs,omitempty"`
+	WeChatConfigs []WeChatConfig `json:"wechat_configs,omitempty"`
 	// +optional
 	TelegramConfigs []TelegramConfig `json:"telegram_configs,omitempty"`
 	// +optional
@@ -266,7 +266,8 @@ type Receiver struct {
 	// +optional
 	SNSConfigs []SnsConfig `json:"sns_configs,omitempty"`
 	// +optional
-	WebexConfigs []WebexConfig `json:"webex_configs,omitempty"`}
+	WebexConfigs []WebexConfig `json:"webex_configs,omitempty"`
+}
 
 type TelegramConfig struct {
 	// SendResolved controls notify about resolved alerts.
@@ -879,13 +880,13 @@ type Sigv4Config struct {
 	// AWS region, if blank the region from the default credentials chain is used
 	// +optional
 	Region string `json:"region,omitempty"`
-    // The AWS API keys. Both access_key and secret_key must be supplied or both must be blank.
-    // If blank the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are used.
+	// The AWS API keys. Both access_key and secret_key must be supplied or both must be blank.
+	// If blank the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are used.
 	// +optional
-	AccessKey string `json:"access_key",omitempty"`
+	AccessKey string `json:"access_key,omitempty"`
 	// secret key selector to get the keys from a Kubernetes Secret
 	// +optional
-	AccessKeySelector *v1.SecretKeySelector `json:"access_key_selector",omitempty"`
+	AccessKeySelector *v1.SecretKeySelector `json:"access_key_selector,omitempty"`
 	// secret key selector to get the keys from a Kubernetes Secret
 	// +optional
 	SecretKey *v1.SecretKeySelector `json:"secret_key_selector,omitempty"`
@@ -910,7 +911,7 @@ type WebexConfig struct {
 	// The message body template
 	// +optional
 	Message string `json:"message,omitempty"`
-	// HTTP client configuration. You must use this configuration to supply the bot token as part of the HTTP `Authorization` header. 
+	// HTTP client configuration. You must use this configuration to supply the bot token as part of the HTTP `Authorization` header.
 	// +optional
 	HTTPConfig *HTTPConfig `json:"http_config,omitempty"`
 }

--- a/api/v1beta1/vmcluster_types.go
+++ b/api/v1beta1/vmcluster_types.go
@@ -141,9 +141,6 @@ func init() {
 }
 
 type VMSelect struct {
-	// Name is deprecated and will be removed at 0.22.0 release
-	// +deprecated
-	Name string `json:"name,omitempty"`
 	// PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// Image - docker image settings for VMSelect
@@ -313,10 +310,7 @@ type VMSelect struct {
 }
 
 func (s VMSelect) GetNameWithPrefix(clusterName string) string {
-	if s.Name == "" {
-		return PrefixedName(clusterName, "vmselect")
-	}
-	return PrefixedName(s.Name, "vmselect")
+	return PrefixedName(clusterName, "vmselect")
 }
 
 func (s VMSelect) BuildPodName(baseName string, podIndex int32, namespace, portName, domain string) string {
@@ -347,33 +341,28 @@ type InsertPorts struct {
 }
 
 type VMInsert struct {
-	// Name is deprecated and will be removed at 0.22.0 release
-	// +deprecated
-	// +optional
-	Name string `json:"name,omitempty"`
-
-	// PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods.
+	// PodMetadata configures Labels and Annotations which are propagated to the VMInsert pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 
 	// Image - docker image settings for VMInsert
 	// +optional
 	Image Image `json:"image,omitempty"`
-	// Secrets is a list of Secrets in the same namespace as the VMSelect
-	// object, which shall be mounted into the VMSelect Pods.
+	// Secrets is a list of Secrets in the same namespace as the VMInsert
+	// object, which shall be mounted into the VMInsert Pods.
 	// The Secrets are mounted into /etc/vm/secrets/<secret-name>.
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
-	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
-	// object, which shall be mounted into the VMSelect Pods.
+	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMInsert
+	// object, which shall be mounted into the VMInsert Pods.
 	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
-	// LogFormat for VMSelect to be configured with.
+	// LogFormat for VMInsert to be configured with.
 	// default or json
 	// +optional
 	// +kubebuilder:validation:Enum=default;json
 	LogFormat string `json:"logFormat,omitempty"`
-	// LogLevel for VMSelect to be configured with.
+	// LogLevel for VMInsert to be configured with.
 	// +optional
 	// +kubebuilder:validation:Enum=INFO;WARN;ERROR;FATAL;PANIC
 	LogLevel string `json:"logLevel,omitempty"`
@@ -398,7 +387,7 @@ type VMInsert struct {
 	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.
-	// VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container,
+	// VolumeMounts specified will be appended to other VolumeMounts in the VMInsert container,
 	// that are generated as a result of StorageSpec objects.
 	// +optional
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
@@ -421,7 +410,7 @@ type VMInsert struct {
 	// +optional
 	Containers []v1.Container `json:"containers,omitempty"`
 	// InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-	// fetch secrets for injection into the VMSelect configuration from external sources. Any
+	// fetch secrets for injection into the VMInsert configuration from external sources. Any
 	// errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	// Using initContainers for any use case other then secret fetching is entirely outside the scope
 	// of what the maintainers will support and by doing so, you accept that this behaviour may break
@@ -474,7 +463,7 @@ type VMInsert struct {
 	// +optional
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 
-	// ExtraEnvs that will be added to VMSelect pod
+	// ExtraEnvs that will be added to VMInsert pod
 	// +optional
 	ExtraEnvs []v1.EnvVar `json:"extraEnvs,omitempty"`
 
@@ -529,45 +518,37 @@ func (cr *VMInsert) ProbeNeedLiveness() bool {
 }
 
 func (i VMInsert) GetNameWithPrefix(clusterName string) string {
-	if i.Name == "" {
-		return PrefixedName(clusterName, "vminsert")
-	}
-	return PrefixedName(i.Name, "vminsert")
+	return PrefixedName(clusterName, "vminsert")
 }
 
 type VMStorage struct {
-	// Name is deprecated and will be removed at 0.22.0 release
-	// +deprecated
-	// +optional
-	Name string `json:"name,omitempty"`
-
 	// MinReadySeconds defines a minim number os seconds to wait before starting update next pod
 	// if previous in healthy state
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
-	// PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods.
+	// PodMetadata configures Labels and Annotations which are propagated to the VMStorage pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 
 	// Image - docker image settings for VMStorage
 	// +optional
 	Image Image `json:"image,omitempty"`
 
-	// Secrets is a list of Secrets in the same namespace as the VMSelect
-	// object, which shall be mounted into the VMSelect Pods.
+	// Secrets is a list of Secrets in the same namespace as the VMStorage
+	// object, which shall be mounted into the VMStorage Pods.
 	// The Secrets are mounted into /etc/vm/secrets/<secret-name>.
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
-	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
-	// object, which shall be mounted into the VMSelect Pods.
+	// ConfigMaps is a list of ConfigMaps in the same namespace as the VMStorage
+	// object, which shall be mounted into the VMStorage Pods.
 	// The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
 	// +optional
 	ConfigMaps []string `json:"configMaps,omitempty"`
-	// LogFormat for VMSelect to be configured with.
+	// LogFormat for VMStorage to be configured with.
 	// default or json
 	// +optional
 	// +kubebuilder:validation:Enum=default;json
 	LogFormat string `json:"logFormat,omitempty"`
-	// LogLevel for VMSelect to be configured with.
+	// LogLevel for VMStorage to be configured with.
 	// +optional
 	// +kubebuilder:validation:Enum=INFO;WARN;ERROR;FATAL;PANIC
 	LogLevel string `json:"logLevel,omitempty"`
@@ -587,7 +568,7 @@ type VMStorage struct {
 	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 	// VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.
-	// VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container,
+	// VolumeMounts specified will be appended to other VolumeMounts in the VMStorage container,
 	// that are generated as a result of StorageSpec objects.
 	// +optional
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
@@ -610,7 +591,7 @@ type VMStorage struct {
 	// +optional
 	Containers []v1.Container `json:"containers,omitempty"`
 	// InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-	// fetch secrets for injection into the VMSelect configuration from external sources. Any
+	// fetch secrets for injection into the VMStorage configuration from external sources. Any
 	// errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	// Using initContainers for any use case other then secret fetching is entirely outside the scope
 	// of what the maintainers will support and by doing so, you accept that this behaviour may break
@@ -676,7 +657,7 @@ type VMStorage struct {
 
 	// +optional
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
-	// ExtraEnvs that will be added to VMSelect pod
+	// ExtraEnvs that will be added to VMStorage pod
 	// +optional
 	ExtraEnvs []v1.EnvVar `json:"extraEnvs,omitempty"`
 	// ServiceSpec that will be create additional service for vmstorage
@@ -759,12 +740,12 @@ type VMBackup struct {
 	Image Image `json:"image,omitempty"`
 	// Port for health check connections
 	Port string `json:"port,omitempty"`
-	// LogFormat for VMSelect to be configured with.
+	// LogFormat for VMBackup to be configured with.
 	// default or json
 	// +optional
 	// +kubebuilder:validation:Enum=default;json
 	LogFormat *string `json:"logFormat,omitempty"`
-	// LogLevel for VMSelect to be configured with.
+	// LogLevel for VMBackup to be configured with.
 	// +optional
 	// +kubebuilder:validation:Enum=INFO;WARN;ERROR;FATAL;PANIC
 	LogLevel *string `json:"logLevel,omitempty"`
@@ -823,10 +804,7 @@ func (s VMStorage) BuildPodName(baseName string, podIndex int32, namespace strin
 }
 
 func (s VMStorage) GetNameWithPrefix(clusterName string) string {
-	if s.Name == "" {
-		return PrefixedName(clusterName, "vmstorage")
-	}
-	return PrefixedName(s.Name, "vmstorage")
+	return PrefixedName(clusterName, "vmstorage")
 }
 
 func (s VMStorage) GetStorageVolumeName() string {

--- a/api/victoriametrics/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/victoriametrics/v1beta1/vmalertmanagerconfig_types.go
@@ -256,7 +256,7 @@ type Receiver struct {
 	VictorOpsConfigs []VictorOpsConfig `json:"victorops_configs,omitempty"`
 	// WeChatConfigs defines wechat notification configurations.
 	// +optional
-	WeChatConfigs   []WeChatConfig   `json:"wechat_configs,omitempty"`
+	WeChatConfigs []WeChatConfig `json:"wechat_configs,omitempty"`
 	// +optional
 	TelegramConfigs []TelegramConfig `json:"telegram_configs,omitempty"`
 	// +optional
@@ -266,7 +266,8 @@ type Receiver struct {
 	// +optional
 	SNSConfigs []SnsConfig `json:"sns_configs,omitempty"`
 	// +optional
-	WebexConfigs []WebexConfig `json:"webex_configs,omitempty"`}
+	WebexConfigs []WebexConfig `json:"webex_configs,omitempty"`
+}
 
 type TelegramConfig struct {
 	// SendResolved controls notify about resolved alerts.
@@ -879,13 +880,13 @@ type Sigv4Config struct {
 	// AWS region, if blank the region from the default credentials chain is used
 	// +optional
 	Region string `json:"region,omitempty"`
-    // The AWS API keys. Both access_key and secret_key must be supplied or both must be blank.
-    // If blank the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are used.
+	// The AWS API keys. Both access_key and secret_key must be supplied or both must be blank.
+	// If blank the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are used.
 	// +optional
-	AccessKey string `json:"access_key",omitempty"`
+	AccessKey string `json:"access_key,omitempty"`
 	// secret key selector to get the keys from a Kubernetes Secret
 	// +optional
-	AccessKeySelector *v1.SecretKeySelector `json:"access_key_selector",omitempty"`
+	AccessKeySelector *v1.SecretKeySelector `json:"access_key_selector,omitempty"`
 	// secret key selector to get the keys from a Kubernetes Secret
 	// +optional
 	SecretKey *v1.SecretKeySelector `json:"secret_key_selector,omitempty"`
@@ -910,7 +911,7 @@ type WebexConfig struct {
 	// The message body template
 	// +optional
 	Message string `json:"message,omitempty"`
-	// HTTP client configuration. You must use this configuration to supply the bot token as part of the HTTP `Authorization` header. 
+	// HTTP client configuration. You must use this configuration to supply the bot token as part of the HTTP `Authorization` header.
 	// +optional
 	HTTPConfig *HTTPConfig `json:"http_config,omitempty"`
 }

--- a/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmclusters.yaml
@@ -168,8 +168,8 @@ spec:
                     type: string
                   configMaps:
                     description: |-
-                      ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
-                      object, which shall be mounted into the VMSelect Pods.
+                      ConfigMaps is a list of ConfigMaps in the same namespace as the VMInsert
+                      object, which shall be mounted into the VMInsert Pods.
                       The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
                     items:
                       type: string
@@ -236,7 +236,7 @@ spec:
                       type: string
                     type: object
                   extraEnvs:
-                    description: ExtraEnvs that will be added to VMSelect pod
+                    description: ExtraEnvs that will be added to VMInsert pod
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -288,7 +288,7 @@ spec:
                   initContainers:
                     description: |-
                       InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-                      fetch secrets for injection into the VMSelect configuration from external sources. Any
+                      fetch secrets for injection into the VMInsert configuration from external sources. Any
                       errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                       Using initContainers for any use case other then secret fetching is entirely outside the scope
                       of what the maintainers will support and by doing so, you accept that this behaviour may break
@@ -323,14 +323,14 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   logFormat:
                     description: |-
-                      LogFormat for VMSelect to be configured with.
+                      LogFormat for VMInsert to be configured with.
                       default or json
                     enum:
                     - default
                     - json
                     type: string
                   logLevel:
-                    description: LogLevel for VMSelect to be configured with.
+                    description: LogLevel for VMInsert to be configured with.
                     enum:
                     - INFO
                     - WARN
@@ -344,10 +344,6 @@ spec:
                       if previous in healthy state
                     format: int32
                     type: integer
-                  name:
-                    description: Name is deprecated and will be removed at 0.22.0
-                      release
-                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -387,7 +383,7 @@ spec:
                     type: object
                   podMetadata:
                     description: PodMetadata configures Labels and Annotations which
-                      are propagated to the VMSelect pods.
+                      are propagated to the VMInsert pods.
                     properties:
                       annotations:
                         additionalProperties:
@@ -558,8 +554,8 @@ spec:
                     type: string
                   secrets:
                     description: |-
-                      Secrets is a list of Secrets in the same namespace as the VMSelect
-                      object, which shall be mounted into the VMSelect Pods.
+                      Secrets is a list of Secrets in the same namespace as the VMInsert
+                      object, which shall be mounted into the VMInsert Pods.
                       The Secrets are mounted into /etc/vm/secrets/<secret-name>.
                     items:
                       type: string
@@ -695,7 +691,7 @@ spec:
                   volumeMounts:
                     description: |-
                       VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.
-                      VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container,
+                      VolumeMounts specified will be appended to other VolumeMounts in the VMInsert container,
                       that are generated as a result of StorageSpec objects.
                     items:
                       description: VolumeMount describes a mounting of a Volume within
@@ -1266,10 +1262,6 @@ spec:
                       if previous in healthy state
                     format: int32
                     type: integer
-                  name:
-                    description: Name is deprecated and will be removed at 0.22.0
-                      release
-                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -2416,8 +2408,8 @@ spec:
                     type: array
                   configMaps:
                     description: |-
-                      ConfigMaps is a list of ConfigMaps in the same namespace as the VMSelect
-                      object, which shall be mounted into the VMSelect Pods.
+                      ConfigMaps is a list of ConfigMaps in the same namespace as the VMStorage
+                      object, which shall be mounted into the VMStorage Pods.
                       The ConfigMaps are mounted into /etc/vm/configs/<configmap-name>.
                     items:
                       type: string
@@ -2484,7 +2476,7 @@ spec:
                       type: string
                     type: object
                   extraEnvs:
-                    description: ExtraEnvs that will be added to VMSelect pod
+                    description: ExtraEnvs that will be added to VMStorage pod
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -2531,7 +2523,7 @@ spec:
                   initContainers:
                     description: |-
                       InitContainers allows adding initContainers to the pod definition. Those can be used to e.g.
-                      fetch secrets for injection into the VMSelect configuration from external sources. Any
+                      fetch secrets for injection into the VMStorage configuration from external sources. Any
                       errors during the execution of an initContainer will lead to a restart of the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                       Using initContainers for any use case other then secret fetching is entirely outside the scope
                       of what the maintainers will support and by doing so, you accept that this behaviour may break
@@ -2550,14 +2542,14 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   logFormat:
                     description: |-
-                      LogFormat for VMSelect to be configured with.
+                      LogFormat for VMStorage to be configured with.
                       default or json
                     enum:
                     - default
                     - json
                     type: string
                   logLevel:
-                    description: LogLevel for VMSelect to be configured with.
+                    description: LogLevel for VMStorage to be configured with.
                     enum:
                     - INFO
                     - WARN
@@ -2588,10 +2580,6 @@ spec:
                       if previous in healthy state
                     format: int32
                     type: integer
-                  name:
-                    description: Name is deprecated and will be removed at 0.22.0
-                      release
-                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -2631,7 +2619,7 @@ spec:
                     type: object
                   podMetadata:
                     description: PodMetadata configures Labels and Annotations which
-                      are propagated to the VMSelect pods.
+                      are propagated to the VMStorage pods.
                     properties:
                       annotations:
                         additionalProperties:
@@ -2771,8 +2759,8 @@ spec:
                     type: string
                   secrets:
                     description: |-
-                      Secrets is a list of Secrets in the same namespace as the VMSelect
-                      object, which shall be mounted into the VMSelect Pods.
+                      Secrets is a list of Secrets in the same namespace as the VMStorage
+                      object, which shall be mounted into the VMStorage Pods.
                       The Secrets are mounted into /etc/vm/secrets/<secret-name>.
                     items:
                       type: string
@@ -3140,14 +3128,14 @@ spec:
                         type: object
                       logFormat:
                         description: |-
-                          LogFormat for VMSelect to be configured with.
+                          LogFormat for VMBackup to be configured with.
                           default or json
                         enum:
                         - default
                         - json
                         type: string
                       logLevel:
-                        description: LogLevel for VMSelect to be configured with.
+                        description: LogLevel for VMBackup to be configured with.
                         enum:
                         - INFO
                         - WARN
@@ -3293,7 +3281,7 @@ spec:
                   volumeMounts:
                     description: |-
                       VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.
-                      VolumeMounts specified will be appended to other VolumeMounts in the VMSelect container,
+                      VolumeMounts specified will be appended to other VolumeMounts in the VMStorage container,
                       that are generated as a result of StorageSpec objects.
                     items:
                       description: VolumeMount describes a mounting of a Volume within

--- a/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
+++ b/config/crd/bases/operator.victoriametrics.com_vmsingles.yaml
@@ -1291,14 +1291,14 @@ spec:
                     type: object
                   logFormat:
                     description: |-
-                      LogFormat for VMSelect to be configured with.
+                      LogFormat for VMBackup to be configured with.
                       default or json
                     enum:
                     - default
                     - json
                     type: string
                   logLevel:
-                    description: LogLevel for VMSelect to be configured with.
+                    description: LogLevel for VMBackup to be configured with.
                     enum:
                     - INFO
                     - WARN

--- a/config/examples/operator_rbac_for_single_namespace.yaml
+++ b/config/examples/operator_rbac_for_single_namespace.yaml
@@ -35,6 +35,7 @@ rules:
       - ""
     resources:
       - endpoints
+      - pods
     verbs:
       - 'list'
       - 'watch'
@@ -42,7 +43,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
       - configmaps
       - configmaps/finalizers
       - persistentvolumeclaims

--- a/config/examples/operator_rbac_for_single_namespace.yaml
+++ b/config/examples/operator_rbac_for_single_namespace.yaml
@@ -35,7 +35,6 @@ rules:
       - ""
     resources:
       - endpoints
-      - pods
     verbs:
       - 'list'
       - 'watch'
@@ -43,6 +42,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
       - configmaps
       - configmaps/finalizers
       - persistentvolumeclaims

--- a/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
@@ -17,39 +17,75 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
-  name: victoriametrics-operator.vX.Y.Z
+  name: victoriametrics-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: VMAlert  executes a list of given alerting or recording rules against configured address.
-      displayName: VMAlert
-      kind: VMAlert
-      name: vmalerts.operator.victoriametrics.com
+    - description: VMAgent - is a tiny but brave agent, which helps you collect metrics
+        from various sources and stores them in VictoriaMetrics or any other Prometheus-compatible
+        storage system that supports the remote_write protocol.
+      displayName: VMAgent
+      kind: VMAgent
+      name: vmagents.operator.victoriametrics.com
       specDescriptors:
-      - description: ReplicaCount is the expected size of the VMAlert cluster. The controller will eventually make the size of the running cluster equal to the expected size.
+      - description: RelabelConfig ConfigMap with global relabel config -remoteWrite.relabelConfig
+          This relabeling is applied to all the collected metrics before sending them
+          to remote storage.
+        displayName: Key at Configmap with relabelConfig name
+        path: relabelConfig
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector
+      - description: ConfigMap with relabeling config which is applied to metrics
+          before sending them to the corresponding -remoteWrite.url
+        displayName: Key at Configmap with relabelConfig for remoteWrite
+        path: remoteWrite[0].urlRelabelConfig
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector
+      - description: ReplicaCount is the expected size of the VMAgent cluster. The
+          controller will eventually make the size of the running cluster equal to
+          the expected size. NOTE enable VMSingle deduplication for replica usage
         displayName: Number of pods
         path: replicaCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
       - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          if not specified - default setting will be used
         displayName: Resources
         path: resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: ServiceAccountName is the name of the ServiceAccount to use to
+          run the VMAgent Pods.
+        displayName: ServiceAccount name
+        path: serviceAccountName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ServiceAccount
+      version: v1beta1
+    - description: VMAlertmanagerConfig is the Schema for the vmalertmanagerconfigs
+        API
+      displayName: VMAlertmanager Config
+      kind: VMAlertmanagerConfig
+      name: vmalertmanagerconfigs.operator.victoriametrics.com
       version: v1beta1
     - description: VMAlertmanager represents Victoria-Metrics deployment for Alertmanager.
       displayName: VMAlertmanager
       kind: VMAlertmanager
       name: vmalertmanagers.operator.victoriametrics.com
       specDescriptors:
-      - description: 'ConfigSecret is the name of a Kubernetes Secret in the same namespace as the VMAlertmanager object, which contains configuration for this VMAlertmanager, configuration must be inside secret key: alertmanager.yaml. It must be created by user. instance. Defaults to ''vmalertmanager-<alertmanager-name>'' The secret is mounted into /etc/alertmanager/config.'
+      - description: 'ConfigSecret is the name of a Kubernetes Secret in the same
+          namespace as the VMAlertmanager object, which contains configuration for
+          this VMAlertmanager, configuration must be inside secret key: alertmanager.yaml.
+          It must be created by user. instance. Defaults to ''vmalertmanager-<alertmanager-name>''
+          The secret is mounted into /etc/alertmanager/config.'
         displayName: Secret with alertmanager config
         path: configSecret
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: ReplicaCount Size is the expected size of the alertmanager cluster. The controller will eventually make the size of the running cluster equal to the expected
+      - description: ReplicaCount Size is the expected size of the alertmanager cluster.
+          The controller will eventually make the size of the running cluster equal
+          to the expected
         displayName: Number of pods
         path: replicaCount
         x-descriptors:
@@ -65,118 +101,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:ServiceAccount
       version: v1beta1
-    - description: VMPodScrape is scrape configuration for pods, it generates vmagent's config for scraping pod targets based on selectors.
-      displayName: VMPod Scrape
-      kind: VMPodScrape
-      name: vmpodscrapes.operator.victoriametrics.com
-      version: v1beta1
-    - description: VMRule defines rule records for vmalert application
-      displayName: VMRule
-      kind: VMRule
-      name: vmrules.operator.victoriametrics.com
-      version: v1beta1
-    - description: VMSingle  is fast, cost-effective and scalable time-series database.
-      displayName: VMSingle
-      kind: VMSingle
-      name: vmsingles.operator.victoriametrics.com
+    - description: VMAlert  executes a list of given alerting or recording rules against
+        configured address.
+      displayName: VMAlert
+      kind: VMAlert
+      name: vmalerts.operator.victoriametrics.com
       specDescriptors:
-      - description: ReplicaCount is the expected size of the VMSingle it can be 0 or 1 if you need more - use vm cluster
+      - description: ReplicaCount is the expected size of the VMAlert cluster. The
+          controller will eventually make the size of the running cluster equal to
+          the expected size.
         displayName: Number of pods
         path: replicaCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ if not defined default resources from operator config will be used
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         displayName: Resources
         path: resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      version: v1beta1
-    - description: ' VMProbe defines a probe for targets, that will be executed with prober,  like blackbox exporter. It helps to monitor reachability of target with various checks.'
-      displayName: VMProbe
-      kind: VMProbe
-      name: vmprobes.operator.victoriametrics.com
-      version: v1beta1
-    - description: VMAgent - is a tiny but brave agent, which helps you collect metrics from various sources and stores them in VictoriaMetrics or any other Prometheus-compatible storage system that supports the remote_write protocol.
-      displayName: VMAgent
-      kind: VMAgent
-      name: vmagents.operator.victoriametrics.com
-      specDescriptors:
-      - description: RelabelConfig ConfigMap with global relabel config -remoteWrite.relabelConfig This relabeling is applied to all the collected metrics before sending them to remote storage.
-        displayName: Key at Configmap with relabelConfig name
-        path: relabelConfig
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector
-      - description: ConfigMap with relabeling config which is applied to metrics before sending them to the corresponding -remoteWrite.url
-        displayName: Key at Configmap with relabelConfig for remoteWrite
-        path: remoteWrite[0].urlRelabelConfig
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector
-      - description: ReplicaCount is the expected size of the VMAgent cluster. The controller will eventually make the size of the running cluster equal to the expected size. NOTE enable VMSingle deduplication for replica usage
-        displayName: Number of pods
-        path: replicaCount
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ if not specified - default setting will be used
-        displayName: Resources
-        path: resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: ServiceAccountName is the name of the ServiceAccount to use to run the VMAgent Pods.
-        displayName: ServiceAccount name
-        path: serviceAccountName
-        x-descriptors:
-        - urn:alm:descriptor:io.kubernetes:ServiceAccount
-      version: v1beta1
-    - description: VMServiceScrape is scrape configuration for endpoints associated with kubernetes service, it generates scrape configuration for vmagent based on selectors. result config will scrape service endpoints
-      displayName: VMService Scrape
-      kind: VMServiceScrape
-      name: vmservicescrapes.operator.victoriametrics.com
-      version: v1beta1
-    - description: VMCluster is fast, cost-effective and scalable time-series database. Cluster version with
-      displayName: VMCluster
-      kind: VMCluster
-      name: vmclusters.operator.victoriametrics.com
-      specDescriptors:
-      - description: ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size.
-        displayName: Number of pods
-        path: vminsert.replicaCount
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        displayName: Resources
-        path: vminsert.resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size.
-        displayName: Number of pods
-        path: vmselect.replicaCount
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        displayName: Resources
-        path: vmselect.resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      - description: ReplicaCount is the expected size of the VMSelect cluster. The controller will eventually make the size of the running cluster equal to the expected size.
-        displayName: Number of pods
-        path: vmstorage.replicaCount
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        displayName: Resources
-        path: vmstorage.resources
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
-      version: v1beta1
-    - description: VMNodeScrape defines discovery for targets placed on kubernetes nodes, usually its node-exporters and other host services. InternalIP is used as __address__ for scraping.
-      displayName: VMNode Scrape
-      kind: VMNodeScrape
-      name: vmnodescrapes.operator.victoriametrics.com
-      version: v1beta1
-    - description: VMStaticScrape  defines static targets configuration for scraping.
-      displayName: VMStatic Scrape
-      kind: VMStaticScrape
-      name: vmstaticscrapes.operator.victoriametrics.com
       version: v1beta1
     - description: VMAuth is the Schema for the vmauths API
       displayName: VMAuth
@@ -188,11 +130,110 @@ spec:
         path: replicaCount
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
-      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ if not defined default resources from operator config will be used
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          if not defined default resources from operator config will be used
         displayName: Resources
         path: resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      version: v1beta1
+    - description: VMCluster is fast, cost-effective and scalable time-series database.
+        Cluster version with
+      displayName: VMCluster
+      kind: VMCluster
+      name: vmclusters.operator.victoriametrics.com
+      specDescriptors:
+      - description: ReplicaCount is the expected size of the VMInsert cluster. The
+          controller will eventually make the size of the running cluster equal to
+          the expected size.
+        displayName: Number of pods
+        path: vminsert.replicaCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        displayName: Resources
+        path: vminsert.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: ReplicaCount is the expected size of the VMSelect cluster. The
+          controller will eventually make the size of the running cluster equal to
+          the expected size.
+        displayName: Number of pods
+        path: vmselect.replicaCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        displayName: Resources
+        path: vmselect.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: ReplicaCount is the expected size of the VMStorage cluster. The
+          controller will eventually make the size of the running cluster equal to
+          the expected size.
+        displayName: Number of pods
+        path: vmstorage.replicaCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        displayName: Resources
+        path: vmstorage.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      version: v1beta1
+    - description: VMNodeScrape defines discovery for targets placed on kubernetes
+        nodes, usually its node-exporters and other host services. InternalIP is used
+        as __address__ for scraping.
+      displayName: VMNode Scrape
+      kind: VMNodeScrape
+      name: vmnodescrapes.operator.victoriametrics.com
+      version: v1beta1
+    - description: VMPodScrape is scrape configuration for pods, it generates vmagent's
+        config for scraping pod targets based on selectors.
+      displayName: VMPod Scrape
+      kind: VMPodScrape
+      name: vmpodscrapes.operator.victoriametrics.com
+      version: v1beta1
+    - description: VMProbe defines a probe for targets, that will be executed with
+        prober, like blackbox exporter. It helps to monitor reachability of target
+        with various checks.
+      displayName: VMProbe
+      kind: VMProbe
+      name: vmprobes.operator.victoriametrics.com
+      version: v1beta1
+    - description: VMRule defines rule records for vmalert application
+      displayName: VMRule
+      kind: VMRule
+      name: vmrules.operator.victoriametrics.com
+      version: v1beta1
+    - description: VMServiceScrape is scrape configuration for endpoints associated
+        with kubernetes service, it generates scrape configuration for vmagent based
+        on selectors. result config will scrape service endpoints
+      displayName: VMService Scrape
+      kind: VMServiceScrape
+      name: vmservicescrapes.operator.victoriametrics.com
+      version: v1beta1
+    - description: VMSingle  is fast, cost-effective and scalable time-series database.
+      displayName: VMSingle
+      kind: VMSingle
+      name: vmsingles.operator.victoriametrics.com
+      specDescriptors:
+      - description: ReplicaCount is the expected size of the VMSingle it can be 0
+          or 1 if you need more - use vm cluster
+        displayName: Number of pods
+        path: replicaCount
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount,urn:alm:descriptor:io.kubernetes:custom
+      - description: Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          if not defined default resources from operator config will be used
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      version: v1beta1
+    - description: VMStaticScrape  defines static targets configuration for scraping.
+      displayName: VMStatic Scrape
+      kind: VMStaticScrape
+      name: vmstaticscrapes.operator.victoriametrics.com
       version: v1beta1
     - description: VMUser is the Schema for the vmusers API
       displayName: VMUser
@@ -298,7 +339,9 @@ spec:
           resources:
           - pods
           verbs:
-          - '*'
+          - list
+          - watch
+          - get
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,12 +40,6 @@ rules:
 - apiGroups:
     - ""
   resources:
-    - pods
-  verbs:
-    - '*'
-- apiGroups:
-    - ""
-  resources:
     - secrets
     - secrets/finalizers
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,12 @@ rules:
 - apiGroups:
     - ""
   resources:
+    - pods
+  verbs:
+    - '*'
+- apiGroups:
+    - ""
+  resources:
     - secrets
     - secrets/finalizers
   verbs:
@@ -287,7 +293,6 @@ rules:
     - nodes/metrics
     - services
     - endpoints
-    - pods
     - configmaps
   verbs:
     - get

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 ## Next release
 
 - [vmservicescrape&vmpodscrape](./api.md#vmservicescrape): add `attach_metadata` option under VMServiceScrapeSpec&VMPodScrapeSpec, the same way like prometheus serviceMonitor&podMonitor do. See [this issue](https://github.com/VictoriaMetrics/operator/issues/893) for details.
+- [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): fix struct field tags under `Sigv4Config`.
 
 <a name="v0.42.3"></a>
 ## [v0.43.](https://github.com/VictoriaMetrics/operator/releases/tag/v0.42.3) - 12 Mar 2024

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ aliases:
 
 ## Next release
 
+**Update note: [vmcluster](./api.md#vmcluster): remove fields `VMClusterSpec.VMInsert.Name`, `VMClusterSpec.VMStorage.Name`, `VMClusterSpec.VMSelect.Name`, they're marked as deprecated since v0.21.0. See [this pull request](https://github.com/VictoriaMetrics/operator/pull/907).**
+
 - [vmservicescrape&vmpodscrape](./api.md#vmservicescrape): add `attach_metadata` option under VMServiceScrapeSpec&VMPodScrapeSpec, the same way like prometheus serviceMonitor&podMonitor do. See [this issue](https://github.com/VictoriaMetrics/operator/issues/893) for details.
 - [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): fix struct field tags under `Sigv4Config`.
 


### PR DESCRIPTION
1. follow up https://github.com/VictoriaMetrics/operator/commit/a54efbc647b0e099a583885afa263aa9fc2f9853, fix type struct field tags
2. remove unnecessary pod permission for operator, see https://github.com/VictoriaMetrics/operator/issues/902
3. remove fields `VMClusterSpec.VMInsert.Name`, `VMClusterSpec.VMStorage.Name`, `VMClusterSpec.VMSelect.Name`, they're marked as deprecated since v0.21.0 in https://github.com/VictoriaMetrics/operator/commit/141c82370da6f27fd32502dc14709e844978778a.