### PR TITLE
config: removes unused patch

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -20,6 +20,3 @@ patches:
 - path: service_account_patch.yaml
   target:
     name: vm-operator-manager-rolebinding
-- path: service_account_patch.yaml
-  target:
-    name: vm-operator-psp-rolebinding


### PR DESCRIPTION
https://github.com/VictoriaMetrics/operator/commit/aec40dba892f2d0a23537ab5cf80d732e6c4b31d removed the kustomize files related to the psp, but the patch remained. Remove this.