### PR TITLE
controllers/reconcile: adds waitReady function for statefulset

### DIFF
--- a/controllers/factory/reconcile/deploy.go
+++ b/controllers/factory/reconcile/deploy.go
@@ -7,6 +7,7 @@ import (
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,7 +17,7 @@ import (
 )
 
 // Deployment performs an update or create operator for deployment and waits until it's replicas is ready
-func Deployment(ctx context.Context, rclient client.Client, newDeploy *appsv1.Deployment, waitDeadline time.Duration) error {
+func Deployment(ctx context.Context, rclient client.Client, newDeploy *appsv1.Deployment, waitDeadline time.Duration, hasHPA bool) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var currentDeploy appsv1.Deployment
 		err := rclient.Get(ctx, types.NamespacedName{Name: newDeploy.Name, Namespace: newDeploy.Namespace}, &currentDeploy)
@@ -28,6 +29,9 @@ func Deployment(ctx context.Context, rclient client.Client, newDeploy *appsv1.De
 				return waitDeploymentReady(ctx, rclient, newDeploy, waitDeadline)
 			}
 			return fmt.Errorf("cannot get deployment for app: %s err: %w", newDeploy.Name, err)
+		}
+		if hasHPA {
+			newDeploy.Spec.Replicas = currentDeploy.Spec.Replicas
 		}
 		newDeploy.Spec.Template.Annotations = labels.Merge(currentDeploy.Spec.Template.Annotations, newDeploy.Spec.Template.Annotations)
 		newDeploy.Finalizers = victoriametricsv1beta1.MergeFinalizers(&currentDeploy, victoriametricsv1beta1.FinalizerName)
@@ -44,8 +48,7 @@ func Deployment(ctx context.Context, rclient client.Client, newDeploy *appsv1.De
 
 // waitDeploymentReady waits until deployment's replicaSet rollouts and all new pods is ready
 func waitDeploymentReady(ctx context.Context, rclient client.Client, dep *appsv1.Deployment, deadline time.Duration) error {
-	time.Sleep(time.Second * 2)
-	return wait.PollImmediateWithContext(ctx, time.Second*5, deadline, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollWithContext(ctx, time.Second*5, deadline, func(ctx context.Context) (done bool, err error) {
 		var actualDeploy appsv1.Deployment
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: dep.Namespace, Name: dep.Name}, &actualDeploy); err != nil {
 			return false, fmt.Errorf("cannot fetch actual deployment state: %w", err)
@@ -62,4 +65,26 @@ func waitDeploymentReady(ctx context.Context, rclient client.Client, dep *appsv1
 		}
 		return false, nil
 	})
+	if err != nil {
+		return reportFirstNotReadyPodOnError(ctx, rclient, fmt.Errorf("cannot wait for deployment to become ready: %w", err), dep.Namespace, labels.SelectorFromSet(dep.Spec.Selector.MatchLabels), dep.Spec.MinReadySeconds)
+	}
+	return nil
+}
+
+func reportFirstNotReadyPodOnError(ctx context.Context, rclient client.Client, origin error, ns string, selector labels.Selector, minReadySeconds int32) error {
+	// list pods and join statuses
+	var podList v1.PodList
+	if err := rclient.List(ctx, &podList, &client.ListOptions{
+		LabelSelector: selector,
+		Namespace:     ns,
+	}); err != nil {
+		return fmt.Errorf("cannot list pods for selector=%q: %w", selector.String(), err)
+	}
+	for _, dp := range podList.Items {
+		if PodIsReady(&dp, minReadySeconds) {
+			continue
+		}
+		return podStatusesToError(origin, &dp)
+	}
+	return fmt.Errorf("cannot find any pod for selector=%q, check kubernetes events, origin err: %w", selector.String(), origin)
 }

--- a/controllers/factory/reconcile/statefulset_pvc_expand.go
+++ b/controllers/factory/reconcile/statefulset_pvc_expand.go
@@ -66,7 +66,7 @@ func recreateSTSIfNeed(ctx context.Context, rclient client.Client, newSTS, exist
 			}
 			return false, fmt.Errorf("unexpected error for polling, want notFound, got: %w", err)
 		}); err != nil {
-			return err
+			return fmt.Errorf("cannot wait for sts to be deleted: %w", err)
 		}
 
 		if err := rclient.Create(ctx, newSTS); err != nil {

--- a/controllers/factory/reconcile/statefulset_test.go
+++ b/controllers/factory/reconcile/statefulset_test.go
@@ -95,7 +95,7 @@ func Test_waitForPodReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fclient := k8stools.GetTestClientWithObjects(tt.predefinedObjects)
 
-			if err := waitForPodReady(context.Background(), fclient, tt.args.ns, tt.args.podName, tt.args.c, 0, nil); (err != nil) != tt.wantErr {
+			if err := waitForPodReady(context.Background(), fclient, tt.args.ns, tt.args.podName, tt.args.c, 0); (err != nil) != tt.wantErr {
 				t.Errorf("waitForPodReady() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -207,7 +207,7 @@ func Test_podIsReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := PodIsReady(tt.args.pod, tt.args.minReadySeconds); got != tt.want {
+			if got := PodIsReady(&tt.args.pod, tt.args.minReadySeconds); got != tt.want {
 				t.Errorf("PodIsReady() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -238,7 +238,6 @@ func ensureVMAgentRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cli
 		if errors.IsNotFound(err) {
 			return rclient.Create(ctx, rb)
 		}
-		fmt.Println("HERE")
 		return fmt.Errorf("cannot get rb for vmagent: %w", err)
 	}
 

--- a/controllers/factory/vmagent/vmagent.go
+++ b/controllers/factory/vmagent/vmagent.go
@@ -141,7 +141,7 @@ func CreateOrUpdateVMAgent(ctx context.Context, cr *victoriametricsv1beta1.VMAge
 				if err != nil {
 					return fmt.Errorf("cannot fill placeholders for deployment sharded vmagent: %w", err)
 				}
-				if err := reconcile.Deployment(ctx, rclient, shardedDeploy, c.PodWaitReadyTimeout); err != nil {
+				if err := reconcile.Deployment(ctx, rclient, shardedDeploy, c.PodWaitReadyTimeout, false); err != nil {
 					return err
 				}
 				deploymentNames[shardedDeploy.Name] = struct{}{}
@@ -175,7 +175,7 @@ func CreateOrUpdateVMAgent(ctx context.Context, cr *victoriametricsv1beta1.VMAge
 			if err != nil {
 				return fmt.Errorf("cannot fill placeholders for deployment in vmagent: %w", err)
 			}
-			if err := reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout); err != nil {
+			if err := reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout, false); err != nil {
 				return err
 			}
 			deploymentNames[newDeploy.Name] = struct{}{}

--- a/controllers/factory/vmalert/vmalert.go
+++ b/controllers/factory/vmalert/vmalert.go
@@ -213,7 +213,7 @@ func CreateOrUpdateVMAlert(ctx context.Context, cr *victoriametricsv1beta1.VMAle
 		return fmt.Errorf("cannot generate new deploy for vmalert: %w", err)
 	}
 
-	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout)
+	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout, false)
 }
 
 // newDeployForCR returns a busybox pod with the same name/namespace as the cr

--- a/controllers/factory/vmauth/vmauth.go
+++ b/controllers/factory/vmauth/vmauth.go
@@ -99,7 +99,7 @@ func CreateOrUpdateVMAuth(ctx context.Context, cr *victoriametricsv1beta1.VMAuth
 		return fmt.Errorf("cannot build new deploy for vmauth: %w", err)
 	}
 
-	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout)
+	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout, false)
 }
 
 func newDeployForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperatorConf) (*appsv1.Deployment, error) {

--- a/controllers/factory/vmsingle/vmsingle.go
+++ b/controllers/factory/vmsingle/vmsingle.go
@@ -117,7 +117,7 @@ func CreateOrUpdateVMSingle(ctx context.Context, cr *victoriametricsv1beta1.VMSi
 		return fmt.Errorf("cannot generate new deploy for vmsingle: %w", err)
 	}
 
-	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout)
+	return reconcile.Deployment(ctx, rclient, newDeploy, c.PodWaitReadyTimeout, false)
 }
 
 func newDeployForVMSingle(ctx context.Context, cr *victoriametricsv1beta1.VMSingle, c *config.BaseOperatorConf) (*appsv1.Deployment, error) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ aliases:
 
 ## Next release
 
+- [operator](./README.md): properly set status to `expanding` for `VMCluster` during initial creation. Previously, it was always `operational`.
+- [operator](./README.md): adds more context to `Deployment` and `Statefulset` watch ready functions. Now, it reports state of unhealthy pod. It allows to find issue with it faster.
+
 <a name="v0.43.3"></a>
 
 ## [v0.43.3](https://github.com/VictoriaMetrics/operator/releases/tag/v0.43.2) - 23 Apr 2024

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -22,7 +22,7 @@ func expectPodCount(rclient client.Client, count int, ns string, lbs map[string]
 		return fmt.Sprintf("pod count mismatch, expect: %d, got: %d", count, len(podList.Items))
 	}
 	for _, pod := range podList.Items {
-		if !reconcile.PodIsReady(pod, 0) {
+		if !reconcile.PodIsReady(&pod, 0) {
 			return fmt.Sprintf("pod isnt ready: %s,\n status: %s", pod.Name, pod.Status.String())
 		}
 	}


### PR DESCRIPTION
it ensures, that all pods for statefulset is ready to serve requests. It must fix an issue when newly created cluster has operational status, when in fact pod is still not at ready state.

Adds more context to the wait timeout error. Reason of pod not to be ready. It must help to debug possible issues with pod configuration.

Deletes few typos.