### PR TITLE
vmscrapeconfig: `authorization` section in sd configs works properly …

### DIFF
--- a/controllers/factory/vmagent/vmagent_scrapeconfig.go
+++ b/controllers/factory/vmagent/vmagent_scrapeconfig.go
@@ -1427,7 +1427,7 @@ func buildVMScrapeParams(namespace, cacheKey string, cfg *victoriametricsv1beta1
 }
 
 func addAuthorizationConfig(dst yaml.MapSlice, cacheKey string, cfg *victoriametricsv1beta1.Authorization, authorizationCache map[string]string) yaml.MapSlice {
-	if cfg == nil || len(cfg.Type) == 0 {
+	if cfg == nil {
 		// fast path
 		return dst
 	}
@@ -1436,7 +1436,11 @@ func addAuthorizationConfig(dst yaml.MapSlice, cacheKey string, cfg *victoriamet
 		return dst
 	}
 	var r yaml.MapSlice
-	r = append(r, yaml.MapItem{Key: "type", Value: cfg.Type})
+	authType := cfg.Type
+	if len(authType) == 0 {
+		authType = "Bearer"
+	}
+	r = append(r, yaml.MapItem{Key: "type", Value: authType})
 	if len(secretValue) > 0 {
 		r = append(r, yaml.MapItem{Key: "credentials", Value: secretValue})
 	} else {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ aliases:
 - [operator](./README.md): adds `spec.pause` field to `VMAgent`, `VMAlert`, `VMAuth`, `VMCluster`, `VMAlertmanager` and `VMSingle`. It allows to suspend object reconcile by operator. See this [issue](https://github.com/VictoriaMetrics/operator/issues/943) for details. Thanks @just1900
 - [vmagent](./api.md#vmagent): set `status.selector` field. It allows correctly use `VPA` with `vmagent`. See this [issue](https://github.com/VictoriaMetrics/operator/issues/693) for details.
 - [prometheus-converter](./README.md): fixes bug with prometheus-operator ScrapeConfig converter. Only copy `spec` field for it. See this [issue](https://github.com/VictoriaMetrics/operator/issues/942) for details.
+- [vmscrapeconfig](./resources/vmscrapeconfig.md): `authorization` section in sd configs works properly with empty `type` field (default value for this field is `Bearer`). 
 
 <a name="v0.43.5"></a>
 


### PR DESCRIPTION
…with empty `type` field (default value for this field is `Bearer`)

related links:
- Thread in slack: https://victoriametrics.slack.com/archives/CGZF1H6L9/p1714925950145659
- Description in our API docs: https://docs.victoriametrics.com/operator/api/#authorization
- Description in prometheus operator API docs: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.Authorization

The default value for this field should work like "Bearer".