### PR TITLE
controllers/prometheus-converter: fix owner reference type for VMScrapeConfig

### DIFF
--- a/controllers/converter/apis.go
+++ b/controllers/converter/apis.go
@@ -8,6 +8,7 @@ import (
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -673,8 +674,8 @@ func ConvertScrapeConfig(promscrapeConfig *monitoringv1alpha1.ScrapeConfig, conf
 	if conf.EnabledPrometheusConverterOwnerReferences {
 		cs.OwnerReferences = []metav1.OwnerReference{
 			{
-				APIVersion:         v1.SchemeGroupVersion.String(),
-				Kind:               v1.ServiceMonitorsKind,
+				APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+				Kind:               v1alpha1.ScrapeConfigsKind,
 				Name:               promscrapeConfig.Name,
 				UID:                promscrapeConfig.UID,
 				Controller:         ptr.To(true),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ aliases:
 - [vmagent](./api.md#vmagent): set `status.selector` field. It allows correctly use `VPA` with `vmagent`. See this [issue](https://github.com/VictoriaMetrics/operator/issues/693) for details.
 - [prometheus-converter](./README.md): fixes bug with prometheus-operator ScrapeConfig converter. Only copy `spec` field for it. See this [issue](https://github.com/VictoriaMetrics/operator/issues/942) for details.
 - [vmscrapeconfig](./resources/vmscrapeconfig.md): `authorization` section in sd configs works properly with empty `type` field (default value for this field is `Bearer`). 
+- [prometheus-converter](./README.md): fixes owner reference type on VMScrapeConfig objects
 
 <a name="v0.43.5"></a>
 


### PR DESCRIPTION
This patches fixes the owner reference type for VMScrapeConfig objects. Without this patch, on many clusters, newly-created VMScrapeConfig objects would immediately be deleted because the owner reference would not resolve.