### PR TITLE
controllers/finalize: Remove finalizer for child objects for non zero DeletionTimestamp

### DIFF
--- a/controllers/factory/alertmanager/statefulset.go
+++ b/controllers/factory/alertmanager/statefulset.go
@@ -514,6 +514,13 @@ func createDefaultAMConfig(ctx context.Context, cr *victoriametricsv1beta1.VMAle
 		}
 		return err
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existAMSecretConfig); err != nil {
+		return err
+	}
+
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existAMSecretConfig); err != nil {
+		return err
+	}
 
 	newAMSecretConfig.Annotations = labels.Merge(existAMSecretConfig.Annotations, newAMSecretConfig.Annotations)
 	newAMSecretConfig.Finalizers = victoriametricsv1beta1.MergeFinalizers(&existAMSecretConfig, victoriametricsv1beta1.FinalizerName)

--- a/controllers/factory/alertmanager/statefulset.go
+++ b/controllers/factory/alertmanager/statefulset.go
@@ -518,10 +518,6 @@ func createDefaultAMConfig(ctx context.Context, cr *victoriametricsv1beta1.VMAle
 		return err
 	}
 
-	if err := finalize.FreeIfNeeded(ctx, rclient, &existAMSecretConfig); err != nil {
-		return err
-	}
-
 	newAMSecretConfig.Annotations = labels.Merge(existAMSecretConfig.Annotations, newAMSecretConfig.Annotations)
 	newAMSecretConfig.Finalizers = victoriametricsv1beta1.MergeFinalizers(&existAMSecretConfig, victoriametricsv1beta1.FinalizerName)
 	return rclient.Update(ctx, newAMSecretConfig)

--- a/controllers/factory/reconcile/deploy.go
+++ b/controllers/factory/reconcile/deploy.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,9 @@ func Deployment(ctx context.Context, rclient client.Client, newDeploy *appsv1.De
 				return waitDeploymentReady(ctx, rclient, newDeploy, waitDeadline)
 			}
 			return fmt.Errorf("cannot get deployment for app: %s err: %w", newDeploy.Name, err)
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, &currentDeploy); err != nil {
+			return err
 		}
 		if hasHPA {
 			newDeploy.Spec.Replicas = currentDeploy.Spec.Replicas

--- a/controllers/factory/reconcile/hpa.go
+++ b/controllers/factory/reconcile/hpa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
@@ -23,6 +24,9 @@ func HPA(ctx context.Context, rclient client.Client, targetHPA client.Object) er
 				return rclient.Create(ctx, targetHPA)
 			}
 			return fmt.Errorf("cannot get exist hpa object: %w", err)
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, existHPA); err != nil {
+			return err
 		}
 		targetHPA.SetResourceVersion(existHPA.GetResourceVersion())
 		victoriametricsv1beta1.MergeFinalizers(targetHPA, victoriametricsv1beta1.FinalizerName)

--- a/controllers/factory/reconcile/pdb.go
+++ b/controllers/factory/reconcile/pdb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/controllers/factory/logger"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +26,9 @@ func PDB(ctx context.Context, rclient client.Client, pdb *policyv1.PodDisruption
 				return rclient.Create(ctx, pdb)
 			}
 			return fmt.Errorf("cannot get existing pdb: %s, err: %w", pdb.Name, err)
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, currentPdb); err != nil {
+			return err
 		}
 		pdb.Annotations = labels.Merge(currentPdb.Annotations, pdb.Annotations)
 		if currentPdb.ResourceVersion != "" {

--- a/controllers/factory/reconcile/service.go
+++ b/controllers/factory/reconcile/service.go
@@ -48,6 +48,9 @@ func reconcileService(ctx context.Context, rclient client.Client, newService *v1
 		}
 		return fmt.Errorf("cannot get service for existing service: %w", err)
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, existingService); err != nil {
+		return err
+	}
 	// lets save annotations and labels even after recreation.
 	if newService.Spec.Type != existingService.Spec.Type {
 		// type mismatch.

--- a/controllers/factory/reconcile/service_account.go
+++ b/controllers/factory/reconcile/service_account.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -22,6 +23,9 @@ func ServiceAccount(ctx context.Context, rclient client.Client, sa *v1.ServiceAc
 				return rclient.Create(ctx, sa)
 			}
 			return fmt.Errorf("cannot get ServiceAccount for given CRD Object=%q, err=%w", sa.Name, err)
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, &existSA); err != nil {
+			return err
 		}
 
 		existSA.OwnerReferences = sa.OwnerReferences

--- a/controllers/factory/reconcile/statefulset.go
+++ b/controllers/factory/reconcile/statefulset.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/controllers/factory/logger"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,6 +69,9 @@ func HandleSTSUpdate(ctx context.Context, rclient client.Client, cr STSOptions, 
 				return waitForStatefulSetReady(ctx, rclient, newSts, c)
 			}
 			return fmt.Errorf("cannot get sts %s under namespace %s: %w", newSts.Name, newSts.Namespace, err)
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, &currentSts); err != nil {
+			return err
 		}
 		// will update the original cr replicaCount to propagate right num,
 		// for now, it's only used in vmselect

--- a/controllers/factory/reconcile/vmservicescrape.go
+++ b/controllers/factory/reconcile/vmservicescrape.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,6 +21,9 @@ func VMServiceScrapeForCRD(ctx context.Context, rclient client.Client, vss *vict
 			if errors.IsNotFound(err) {
 				return rclient.Create(ctx, vss)
 			}
+			return err
+		}
+		if err := finalize.FreeIfNeeded(ctx, rclient, &existVSS); err != nil {
 			return err
 		}
 		updateIsNeeded := !equality.Semantic.DeepEqual(vss.Spec, existVSS.Spec) || !equality.Semantic.DeepEqual(vss.Labels, existVSS.Labels) || !equality.Semantic.DeepEqual(vss.Annotations, existVSS.Annotations)

--- a/controllers/factory/vmagent/rbac.go
+++ b/controllers/factory/vmagent/rbac.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	v1beta12 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	rbacV1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +144,9 @@ func ensureVMAgentCRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cli
 		}
 		return fmt.Errorf("cannot get exist cluster role for vmagent: %w", err)
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existsClusterRole); err != nil {
+		return err
+	}
 
 	existsClusterRole.OwnerReferences = clusterRole.OwnerReferences
 	existsClusterRole.Labels = clusterRole.Labels
@@ -161,6 +165,9 @@ func ensureVMAgentCRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cl
 			return rclient.Create(ctx, clusterRoleBinding)
 		}
 		return fmt.Errorf("cannot get clusterRoleBinding for vmagent: %w", err)
+	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existsClusterRoleBinding); err != nil {
+		return err
 	}
 
 	existsClusterRoleBinding.OwnerReferences = clusterRoleBinding.OwnerReferences
@@ -221,6 +228,9 @@ func ensureVMAgentRExist(ctx context.Context, cr *v1beta12.VMAgent, rclient clie
 		}
 		return fmt.Errorf("cannot get exist cluster role for vmagent: %w", err)
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existsClusterRole); err != nil {
+		return err
+	}
 
 	existsClusterRole.OwnerReferences = nr.OwnerReferences
 	existsClusterRole.Labels = nr.Labels
@@ -239,6 +249,9 @@ func ensureVMAgentRBExist(ctx context.Context, cr *v1beta12.VMAgent, rclient cli
 			return rclient.Create(ctx, rb)
 		}
 		return fmt.Errorf("cannot get rb for vmagent: %w", err)
+	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existsRB); err != nil {
+		return err
 	}
 
 	existsRB.OwnerReferences = rb.OwnerReferences

--- a/controllers/factory/vmagent/vmagent.go
+++ b/controllers/factory/vmagent/vmagent.go
@@ -791,6 +791,9 @@ func createOrUpdateTLSAssets(ctx context.Context, cr *victoriametricsv1beta1.VMA
 		}
 		return fmt.Errorf("cannot get existing tls secret: %s, for vmagent: %s, err: %w", tlsAssetsSecret.Name, cr.Name, err)
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, currentAssetSecret); err != nil {
+		return err
+	}
 	tlsAssetsSecret.Annotations = labels.Merge(currentAssetSecret.Annotations, tlsAssetsSecret.Annotations)
 	victoriametricsv1beta1.MergeFinalizers(tlsAssetsSecret, victoriametricsv1beta1.FinalizerName)
 	return rclient.Update(ctx, tlsAssetsSecret)

--- a/controllers/factory/vmagent/vmagent_scrapeconfig.go
+++ b/controllers/factory/vmagent/vmagent_scrapeconfig.go
@@ -15,6 +15,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/utils"
 	"github.com/VictoriaMetrics/metricsql"
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
 	"github.com/VictoriaMetrics/operator/controllers/factory/logger"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -152,6 +153,10 @@ func createOrUpdateConfigurationSecret(ctx context.Context, cr *victoriametricsv
 			return ssCache, rclient.Create(ctx, s)
 		}
 		return nil, fmt.Errorf("cannot get secret for vmagent: %q : %w", cr.Name, err)
+	}
+
+	if err := finalize.FreeIfNeeded(ctx, rclient, curSecret); err != nil {
+		return nil, err
 	}
 
 	s.Annotations = labels.Merge(curSecret.Annotations, s.Annotations)

--- a/controllers/factory/vmalert/vmalert.go
+++ b/controllers/factory/vmalert/vmalert.go
@@ -128,6 +128,9 @@ func createOrUpdateVMAlertSecret(ctx context.Context, rclient client.Client, cr 
 		}
 		return nil
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, curSecret); err != nil {
+		return err
+	}
 	s.Annotations = labels.Merge(curSecret.Annotations, s.Annotations)
 	return rclient.Update(ctx, s)
 }
@@ -738,6 +741,9 @@ func createOrUpdateTLSAssetsForVMAlert(ctx context.Context, cr *victoriametricsv
 			return rclient.Create(ctx, tlsAssetsSecret)
 		}
 		return fmt.Errorf("cannot get existing tls secret: %s, for vmalert: %s, err: %w", tlsAssetsSecret.Name, cr.Name, err)
+	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, currentAssetSecret); err != nil {
+		return err
 	}
 	for annotation, value := range currentAssetSecret.Annotations {
 		tlsAssetsSecret.Annotations[annotation] = value

--- a/controllers/factory/vmauth/rbac.go
+++ b/controllers/factory/vmauth/rbac.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	v1beta12 "github.com/VictoriaMetrics/operator/api/v1beta1"
+	"github.com/VictoriaMetrics/operator/controllers/factory/finalize"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,9 @@ func ensureVMAuthRoleExist(ctx context.Context, cr *v1beta12.VMAuth, rclient cli
 		}
 		return fmt.Errorf("cannot get role for vmauth: %w", err)
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existRole); err != nil {
+		return err
+	}
 
 	existRole.OwnerReferences = role.OwnerReferences
 	existRole.Labels = role.Labels
@@ -50,6 +54,9 @@ func ensureVMAgentRBExist(ctx context.Context, cr *v1beta12.VMAuth, rclient clie
 			return rclient.Create(ctx, roleBinding)
 		}
 		return fmt.Errorf("cannot get rolebinding for vmauth: %w", err)
+	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existRoleBinding); err != nil {
+		return err
 	}
 
 	existRoleBinding.OwnerReferences = roleBinding.OwnerReferences

--- a/controllers/factory/vmauth/vmauth.go
+++ b/controllers/factory/vmauth/vmauth.go
@@ -357,6 +357,9 @@ func CreateOrUpdateVMAuthConfig(ctx context.Context, rclient client.Client, cr *
 		}
 		return err
 	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &curSecret); err != nil {
+		return err
+	}
 	var (
 		generatedConf             = s.Data[vmAuthConfigNameGz]
 		curConfig, curConfigFound = curSecret.Data[vmAuthConfigNameGz]
@@ -412,6 +415,9 @@ func CreateOrUpdateVMAuthIngress(ctx context.Context, rclient client.Client, cr 
 		if errors.IsNotFound(err) {
 			return rclient.Create(ctx, newIngress)
 		}
+		return err
+	}
+	if err := finalize.FreeIfNeeded(ctx, rclient, &existIngress); err != nil {
 		return err
 	}
 	newIngress.Annotations = labels.Merge(existIngress.Annotations, newIngress.Annotations)

--- a/controllers/factory/vmsingle/vmsingle.go
+++ b/controllers/factory/vmsingle/vmsingle.go
@@ -449,6 +449,7 @@ func CreateOrUpdateVMSingleStreamAggrConfig(ctx context.Context, cr *victoriamet
 		if errors.IsNotFound(err) {
 			return rclient.Create(ctx, streamAggrCM)
 		}
+		return fmt.Errorf("cannot fetch exist configmap for vmsingle streamAggr: %w", err)
 	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &existCM); err != nil {
 		return err

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 ## Next release
 
 - [vmalertmanager](./api.md#vmalertmanager): ignores content of `cr.spec.configSecret` if it's name clashes with secret used by operator for storing alertmanager config. See this [issue](https://github.com/VictoriaMetrics/operator/issues/954) for details.
+- [operator](./README.md): remove finalizer for child objects with non-empty `DeletetionTimestamp`.  See this [issue](https://github.com/VictoriaMetrics/operator/issues/953) for details.
 
 ## [v0.44.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.44.0) - 9 May 2024
 


### PR DESCRIPTION


Kubernetes performs soft delete and waits for object hard delete until finalizers == 0. During that period any actions for soft deleted objects aren't performend. It caues weird behavior for service accounts, deployments and etc. When kubernetes-controller manager ignores actions that must be performend with it. For instance, pod creation for soft deleted deployment.

 Operator now detects soft delete and free objects. An object ll be recreate at the next reconcile loop and error message ll be logged.

https://github.com/VictoriaMetrics/operator/issues/953