### PR TITLE
vmauth: don't mount config in the vmauth container when using the cus…

### DIFF
--- a/controllers/factory/vmauth/vmauth.go
+++ b/controllers/factory/vmauth/vmauth.go
@@ -247,14 +247,14 @@ func makeSpecForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperator
 					},
 				},
 			})
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      vmAuthVolumeName,
+				MountPath: vmAuthConfigRawFolder,
+			})
 		}
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "config-out",
 			MountPath: vmAuthConfigFolder,
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "config",
-			MountPath: vmAuthConfigRawFolder,
 		})
 		operatorContainers[0].VolumeMounts = volumeMounts
 

--- a/controllers/factory/vmauth/vmauth_test.go
+++ b/controllers/factory/vmauth/vmauth_test.go
@@ -7,6 +7,8 @@ import (
 	victoriametricsv1beta1 "github.com/VictoriaMetrics/operator/api/v1beta1"
 	"github.com/VictoriaMetrics/operator/controllers/factory/k8stools"
 	"github.com/VictoriaMetrics/operator/internal/config"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -152,5 +154,304 @@ func TestCreateOrUpdateVMAuth(t *testing.T) {
 				t.Errorf("CreateOrUpdateVMAuth() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestMakeSpecForAuthOk(t *testing.T) {
+	f := func(t *testing.T, cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperatorConf, wantYaml string) {
+		t.Helper()
+		setDefaultForVMAuth(cr, c)
+
+		// this trick allows to omit empty fields for yaml
+		var wantSpec corev1.PodSpec
+		if err := yaml.Unmarshal([]byte(wantYaml), &wantSpec); err != nil {
+			t.Fatalf("not expected wantYaml: %q: \n%q", wantYaml, err)
+		}
+		wantYAMLForCompare, err := yaml.Marshal(wantSpec)
+		if err != nil {
+			t.Fatalf("BUG: cannot parse as yaml: %q", err)
+		}
+		got, err := makeSpecForVMAuth(cr, c)
+		if err != nil {
+			t.Fatalf("not expected error=%q", err)
+		}
+		gotYAML, err := yaml.Marshal(got.Spec)
+		if err != nil {
+			t.Fatalf("cannot parse got as yaml: %q", err)
+		}
+
+		// compare yaml output instead of structs, since structs could be modified by marshal/unmarshal callbacks
+		if !cmp.Equal(string(gotYAML), string(wantYAMLForCompare)) {
+			diff := cmp.Diff(wantSpec, got.Spec)
+			t.Fatalf("not expected output for test, diff is %s", diff)
+		}
+	}
+	testConfBuild := func(setup func(c *config.BaseOperatorConf)) *config.BaseOperatorConf {
+		c := *config.MustGetBaseConfig()
+		setup(&c)
+		return &c
+	}
+	t.Run("custom-loader", func(t *testing.T) {
+		f(t, &victoriametricsv1beta1.VMAuth{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "default"},
+			Spec:       victoriametricsv1beta1.VMAuthSpec{},
+		}, testConfBuild(func(c *config.BaseOperatorConf) {
+			c.VMAuthDefault.UseDefaultResources = false
+			c.VMAuthDefault.Image = "vm-repo"
+			c.VMAuthDefault.Version = "v1.97.1"
+			c.VMAuthDefault.Port = "8429"
+			c.UseCustomConfigReloader = true
+			c.CustomConfigReloaderImage = "vmcustom:config-reloader-v0.35.0"
+		}), `
+volumes:
+  - name: config-out
+    volumesource:
+      emptydir:
+        medium: ""
+        sizelimit: null
+initcontainers:
+  - name: config-init
+    image: vmcustom:config-reloader-v0.35.0
+    command:
+      - /usr/local/bin/config-reloader
+    args:
+      - --reload-url=http://localhost:8429/-/reload
+      - --config-envsubst-file=/opt/vmauth/config.yaml
+      - --config-secret-name=default/vmauth-config-auth
+      - --only-init-config
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config-out
+        readonly: false
+        mountpath: /opt/vmauth
+containers:
+  - name: vmauth
+    image: vm-repo:v1.97.1
+    imagepullpolicy: IfNotPresent
+    args:
+      - -auth.config=/opt/vmauth/config.yaml
+      - -httpListenAddr=:8429
+    ports:
+      - name: http
+        hostport: 0
+        containerport: 8429
+        protocol: TCP
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config-out
+        readonly: false
+        mountpath: /opt/vmauth
+    livenessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            type: 0
+            intval: 8429
+            strval: ""
+          scheme: HTTP
+      timeoutseconds: 5
+      periodseconds: 5
+      successthreshold: 1
+      failurethreshold: 10
+    readinessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            intval: 8429
+          scheme: HTTP
+      initialdelayseconds: 0
+      timeoutseconds: 5
+      periodseconds: 5
+      successthreshold: 1
+      failurethreshold: 10
+    terminationmessagepolicy: FallbackToLogsOnError
+  - name: config-reloader
+    image: vmcustom:config-reloader-v0.35.0
+    command:
+      - /usr/local/bin/config-reloader
+    args:
+      - --reload-url=http://localhost:8429/-/reload
+      - --config-envsubst-file=/opt/vmauth/config.yaml
+      - --config-secret-name=default/vmauth-config-auth
+    env:
+      - name: POD_NAME
+        valuefrom:
+          fieldref:
+            apiversion: ""
+            fieldpath: metadata.name
+    ports:
+      - name: reloader-http
+        containerport: 8435
+        protocol: TCP
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config-out
+        readonly: false
+        mountpath: /opt/vmauth
+    livenessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            type: 0
+            intval: 8435
+            strval: ""
+          scheme: HTTP
+      timeoutseconds: 0
+      periodseconds: 0
+      successthreshold: 0
+      failurethreshold: 0
+    readinessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            intval: 8435
+          scheme: HTTP
+      initialdelayseconds: 5
+      timeoutseconds: 0
+      periodseconds: 0
+      successthreshold: 0
+      failurethreshold: 0
+    terminationmessagepolicy: FallbackToLogsOnError
+serviceaccountname: vmauth-auth
+
+`)
+	})
+	t.Run("no-custom-loader", func(t *testing.T) {
+		f(t, &victoriametricsv1beta1.VMAuth{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth", Namespace: "default"},
+			Spec:       victoriametricsv1beta1.VMAuthSpec{},
+		}, testConfBuild(func(c *config.BaseOperatorConf) {
+			c.VMAuthDefault.UseDefaultResources = false
+			c.VMAuthDefault.Image = "vm-repo"
+			c.VMAuthDefault.Version = "v1.97.1"
+			c.VMAuthDefault.Port = "8429"
+			c.VMAuthDefault.ConfigReloadImage = "quay.io/prometheus-operator/prometheus-config-reloader:v1"
+			c.UseCustomConfigReloader = false
+		}), `
+volumes:
+  - name: config-out
+    volumesource:
+      emptydir:
+        medium: ""
+        sizelimit: null
+  - name: config
+    volumesource:
+      secret:
+        secretname: vmauth-config-auth
+initcontainers:
+  - name: config-init
+    image: quay.io/prometheus-operator/prometheus-config-reloader:v1
+    command:
+      - /bin/sh
+    args:
+      - -c
+      - "gunzip -c /opt/vmauth-config-gz/config.yaml.gz > /opt/vmauth/config.yaml"
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config
+        mountpath: /opt/vmauth-config-gz
+      - name: config-out
+        mountpath: /opt/vmauth
+containers:
+  - name: vmauth
+    image: vm-repo:v1.97.1
+    imagepullpolicy: IfNotPresent
+    args:
+      - -auth.config=/opt/vmauth/config.yaml
+      - -httpListenAddr=:8429
+    ports:
+      - name: http
+        hostport: 0
+        containerport: 8429
+        protocol: TCP
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config
+        mountpath: /opt/vmauth/config
+      - name: config-out
+        mountpath: /opt/vmauth
+    livenessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            type: 0
+            intval: 8429
+            strval: ""
+          scheme: HTTP
+      timeoutseconds: 5
+      periodseconds: 5
+      successthreshold: 1
+      failurethreshold: 10
+    readinessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            intval: 8429
+          scheme: HTTP
+      initialdelayseconds: 0
+      timeoutseconds: 5
+      periodseconds: 5
+      successthreshold: 1
+      failurethreshold: 10
+    terminationmessagepolicy: FallbackToLogsOnError
+  - name: config-reloader
+    image: quay.io/prometheus-operator/prometheus-config-reloader:v1
+    command:
+      - /bin/prometheus-config-reloader
+    args:
+      - --reload-url=http://localhost:8429/-/reload
+      - --config-envsubst-file=/opt/vmauth/config.yaml
+      - --config-file=/opt/vmauth-config-gz/config.yaml.gz
+    env:
+      - name: POD_NAME
+        valuefrom:
+          fieldref:
+            apiversion: ""
+            fieldpath: metadata.name
+    resources:
+      limits: {}
+      requests: {}
+    volumemounts:
+      - name: config-out
+        readonly: false
+        mountpath: /opt/vmauth
+      - name: config
+        mountpath: /opt/vmauth-config-gz
+    terminationmessagepolicy: FallbackToLogsOnError
+serviceaccountname: vmauth-auth
+
+`)
+	})
+}
+
+func setDefaultForVMAuth(cr *victoriametricsv1beta1.VMAuth, c *config.BaseOperatorConf) {
+	// inject default
+	if cr.Spec.Image.Repository == "" {
+		cr.Spec.Image.Repository = c.VMAuthDefault.Image
+	}
+	if cr.Spec.Image.Tag == "" {
+		cr.Spec.Image.Tag = c.VMAuthDefault.Version
+	}
+	if cr.Spec.Image.PullPolicy == "" {
+		cr.Spec.Image.PullPolicy = corev1.PullIfNotPresent
+	}
+	if cr.Spec.Port == "" {
+		cr.Spec.Port = c.VMAuthDefault.Port
 	}
 }


### PR DESCRIPTION
…tom reloader

When the custom reloader is in use, there is no config volume defined and the vmauth container cannot start with a config volume mount.

This patch also adds basic tests for the vmauth pod spec.