### PR TITLE
vmscrapeconfig: support max_scrape_size option

### DIFF
--- a/api/operator/v1beta1/vmscrapeconfig_types.go
+++ b/api/operator/v1beta1/vmscrapeconfig_types.go
@@ -66,6 +66,9 @@ type VMScrapeConfigSpec struct {
 	// ScrapeTimeout is the number of seconds to wait until a scrape request times out.
 	// +optional
 	ScrapeTimeout string `json:"scrapeTimeout,omitempty"`
+	// MaxScrapeSize defines a maximum size of scraped data for a job
+        // +optional
+        MaxScrapeSize string `json:"max_scrape_size,omitempty"`
 	// HonorTimestamps controls whether to respect the timestamps present in scraped data.
 	// +optional
 	HonorTimestamps *bool `json:"honorTimestamps,omitempty"`

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -22563,6 +22563,10 @@ spec:
                   - role
                   type: object
                 type: array
+              max_scrape_size:
+                description: MaxScrapeSize defines a maximum size of scraped data
+                  for a job
+                type: string
               metricRelabelConfigs:
                 description: MetricRelabelConfigs to apply to samples before ingestion.
                 items:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,8 @@ aliases:
 - [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 - [vmnodescrape](./api.md#vmnodescrape): remove duplicated `series_limit` and `sample_limit` fields in generated scrape_config. See [this issue](https://github.com/VictoriaMetrics/operator/issues/986).
 
+- [vmscrapeconfig](./api.md#vmscrapeconfig) - added `max_scrape_size` parameter for scrape protocols configuration
+
 <a name="v0.45.0"></a>
 
 ## [v0.45.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.45.0) - 10 Jun 2024

--- a/internal/controller/operator/factory/vmagent/scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/scrapeconfig.go
@@ -83,6 +83,9 @@ func generateScrapeConfig(
 	if sc.Spec.SeriesLimit > 0 {
 		cfg = append(cfg, yaml.MapItem{Key: "series_limit", Value: sc.Spec.SeriesLimit})
 	}
+	if sc.Spec.MaxScrapeSize != "" {
+		cfg = append(cfg, yaml.MapItem{Key: "max_scrape_size", Value: sc.Spec.MaxScrapeSize})
+	}
 
 	var relabelings []yaml.MapSlice
 	for _, c := range sc.Spec.RelabelConfigs {

--- a/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
@@ -40,6 +40,7 @@ func TestGenerateScrapeConfig(t *testing.T) {
 						Namespace: "default",
 					},
 					Spec: vmv1beta1.VMScrapeConfigSpec{
+						MaxScrapeSize:  "60KB",
 						ScrapeInterval: "10s",
 						StaticConfigs: []vmv1beta1.StaticConfig{
 							{
@@ -68,6 +69,7 @@ scrape_interval: 30s
 basic_auth:
   username: admin
   password: dangerous
+max_scrape_size: 60KB
 relabel_configs: []
 static_configs:
 - targets:


### PR DESCRIPTION
Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/6434