### PR TITLE
operator/converter: add `operator_prometheus_converter_watch_events_t…

### DIFF
--- a/controllers/factory/k8stools/client_utils.go
+++ b/controllers/factory/k8stools/client_utils.go
@@ -188,6 +188,7 @@ func NewObjectWatcherForNamespaces[T any, PT interface {
 						close(ownss.result)
 						return
 					}
+					watchEventsTotalByType.WithLabelValues(string(ev.Type), "ALL_NAMESPACES", crdTypeName).Inc()
 					select {
 					case ownss.result <- ev:
 					case <-ctx.Done():


### PR DESCRIPTION
…otal` for ALL_NAMESPACES.

`operator_prometheus_converter_watch_events_total` is missing now when watching all namespaces.
