### PR TITLE
controllers/vmalertmanagerconfig: adds missing err handle callback

### DIFF
--- a/controllers/vmalertmanagerconfig_controller.go
+++ b/controllers/vmalertmanagerconfig_controller.go
@@ -50,11 +50,15 @@ func (r *VMAlertmanagerConfigReconciler) Scheme() *runtime.Scheme {
 // Reconcile implements interface
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagerconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagerconfigs/status,verbs=get;update;patch
-func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
 	l := r.Log.WithValues("vmalertmanagerconfig", req.NamespacedName, "name", req.Name)
+	defer func() {
+		result, resultErr = handleReconcileErr(ctx, r.Client, nil, result, resultErr)
+	}()
 
 	var instance victoriametricsv1beta1.VMAlertmanagerConfig
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return result, &getError{err, "vmalertmanagerconfig", req}
 	}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ aliases:
 
 ## Next release
 
+- [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): adds missing `handleReconcileErr` callback to the reconcile loop. It must properly handle errors and deregister objects.
+
 <a name="v0.45.0"></a>
 
 ## [v0.45.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.45.0) - 10 Jun 2024


### PR DESCRIPTION
Fixes missing err handkle func after bc09a9b