### PR TITLE
vmrule: sync group attributes `eval_offset`, `eval_delay` and `eval_a…

### DIFF
--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -31,6 +31,18 @@ type RuleGroup struct {
 	// rule can produce
 	// +optional
 	Limit int `json:"limit,omitempty"`
+	// Optional
+	// Group will be evaluated at the exact offset in the range of [0...interval].
+	EvalOffset string `json:"eval_offset,omitempty" yaml:"eval_offset,omitempty"`
+	// Optional
+	// Adjust the `time` parameter of group evaluation requests to compensate intentional query delay from the datasource.
+	EvalDelay string `json:"eval_delay,omitempty" yaml:"eval_delay,omitempty"`
+	// Optional
+	// The evaluation timestamp will be aligned with group's interval,
+	// instead of using the actual timestamp that evaluation happens at.
+	// It is enabled by default to get more predictable results
+	// and to visually align with graphs plotted via Grafana or vmui.
+	EvalAlignment *bool `json:"eval_alignment,omitempty" yaml:"eval_alignment,omitempty"`
 	// Concurrency defines how many rules execute at once.
 	// +optional
 	Concurrency int `json:"concurrency,omitempty" yaml:"concurrency,omitempty"`

--- a/api/operator/v1beta1/zz_generated.deepcopy.go
+++ b/api/operator/v1beta1/zz_generated.deepcopy.go
@@ -2082,6 +2082,11 @@ func (in *RuleGroup) DeepCopyInto(out *RuleGroup) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EvalAlignment != nil {
+		in, out := &in.EvalAlignment, &out.EvalAlignment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/config/crd/crd.yaml
+++ b/config/crd/crd.yaml
@@ -17535,6 +17535,24 @@ spec:
                     concurrency:
                       description: Concurrency defines how many rules execute at once.
                       type: integer
+                    eval_alignment:
+                      description: |-
+                        Optional
+                        The evaluation timestamp will be aligned with group's interval,
+                        instead of using the actual timestamp that evaluation happens at.
+                        It is enabled by default to get more predictable results
+                        and to visually align with graphs plotted via Grafana or vmui.
+                      type: boolean
+                    eval_delay:
+                      description: |-
+                        Optional
+                        Adjust the `time` parameter of group evaluation requests to compensate intentional query delay from the datasource.
+                      type: string
+                    eval_offset:
+                      description: |-
+                        Optional
+                        Group will be evaluated at the exact offset in the range of [0...interval].
+                      type: string
                     extra_filter_labels:
                       additionalProperties:
                         type: string

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,14 +19,13 @@ aliases:
 **Update note 1: the `--metrics-addr` command-line flag at `operator` was deprecated. Use `--metrics-bind-address` instead.**
 **Update note 2: the `--enable-leader-election` command-line flag at `operator` was deprecated. Use `--leader-elect` instead.**
 
-### Features
-
 - [operator](./README.md): kubebuilder v2 -> v4 upgrade
 - [operator](./README.md): upgraded certificates.cert-manager.io/v1alpha2 to certificates.cert-manager.io/v1
-- [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 - [operator](./README.md): code-generator v0.27.11 -> v0.30.0 upgrade
-
 - [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): adds missing `handleReconcileErr` callback to the reconcile loop. It must properly handle errors and deregister objects.
+- [vmrule](./api.md#vmrule): sync group attributes `eval_offset`, `eval_delay` and `eval_alignment` from [upstream](https://docs.victoriametrics.com/vmalert/#groups).
+
+- [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 
 <a name="v0.45.0"></a>
 


### PR DESCRIPTION
…lignment` from upstream
address https://github.com/VictoriaMetrics/operator/issues/982