### PR TITLE
vmnodescrape: remove duplicated `series_limit` and `sample_limit` fie…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,10 +23,11 @@ aliases:
 
 - [operator](./README.md): kubebuilder v2 -> v4 upgrade
 - [operator](./README.md): upgraded certificates.cert-manager.io/v1alpha2 to certificates.cert-manager.io/v1
-- [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 - [operator](./README.md): code-generator v0.27.11 -> v0.30.0 upgrade
-
 - [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): adds missing `handleReconcileErr` callback to the reconcile loop. It must properly handle errors and deregister objects.
+
+- [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
+- - [vmnodescrape](./api.md#vmnodescrape): remove duplicated `series_limit` and `sample_limit` fields in generated scrape_config. See [this issue](https://github.com/VictoriaMetrics/operator/issues/986).
 
 <a name="v0.45.0"></a>
 

--- a/internal/controller/operator/factory/vmagent/nodescrape.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape.go
@@ -209,13 +209,6 @@ func generateNodeScrapeConfig(
 	relabelings = enforceNamespaceLabel(relabelings, cr.Namespace, enforcedNamespaceLabel)
 	cfg = append(cfg, yaml.MapItem{Key: "relabel_configs", Value: relabelings})
 
-	if cr.Spec.SampleLimit > 0 {
-		cfg = append(cfg, yaml.MapItem{Key: "sample_limit", Value: cr.Spec.SampleLimit})
-	}
-	if cr.Spec.SeriesLimit > 0 {
-		cfg = append(cfg, yaml.MapItem{Key: "series_limit", Value: cr.Spec.SeriesLimit})
-	}
-
 	if nodeSpec.MetricRelabelConfigs != nil {
 		var metricRelabelings []yaml.MapSlice
 		for _, c := range nodeSpec.MetricRelabelConfigs {

--- a/internal/controller/operator/factory/vmagent/nodescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape_test.go
@@ -93,6 +93,7 @@ relabel_configs:
 						HonorLabels:     true,
 						ProxyURL:        pointer.String("https://some-url"),
 						SampleLimit:     50,
+						SeriesLimit:     1000,
 						FollowRedirects: pointer.Bool(true),
 						ScrapeTimeout:   "10s",
 						ScrapeInterval:  "5s",
@@ -138,6 +139,7 @@ scrape_timeout: 10s
 metrics_path: /metrics
 proxy_url: https://some-url
 sample_limit: 50
+series_limit: 1000
 params:
   module:
   - client
@@ -183,7 +185,6 @@ relabel_configs:
   target_label: __address__
   regex: ^(.*):(.*)
   replacement: ${1}:9100
-sample_limit: 50
 metric_relabel_configs: []
 stream_parse: true
 proxy_tls_config:


### PR DESCRIPTION
…lds in generated scrape_config
address https://github.com/VictoriaMetrics/operator/issues/986