### PR TITLE
vmagent: use `-enableMultitenantHandlers` command-line flag for vmage…

### DIFF
--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -472,8 +472,8 @@ type VMAgentRemoteWriteSettings struct {
 	// Labels in the form 'name=value' to add to all the metrics before sending them. This overrides the label if it already exists.
 	// +optional
 	Labels map[string]string `json:"label,omitempty"`
-	// Configures vmagent in multi-tenant mode with direct cluster support
-	// docs https://docs.victoriametrics.com/vmagent.html#multitenancy
+	// Configures vmagent accepting data via the same multitenant endpoints as vminsert at VictoriaMetrics cluster does,
+	// see https://docs.victoriametrics.com/vmagent.html#multitenancy.
 	// it's global setting and affects all remote storage configurations
 	// +optional
 	UseMultiTenantMode bool `json:"useMultiTenantMode,omitempty"`

--- a/config/crd/crd.yaml
+++ b/config/crd/crd.yaml
@@ -2485,8 +2485,8 @@ spec:
                     type: string
                   useMultiTenantMode:
                     description: |-
-                      Configures vmagent in multi-tenant mode with direct cluster support
-                      docs https://docs.victoriametrics.com/vmagent.html#multitenancy
+                      Configures vmagent accepting data via the same multitenant endpoints as vminsert at VictoriaMetrics cluster does,
+                      see https://docs.victoriametrics.com/vmagent.html#multitenancy.
                       it's global setting and affects all remote storage configurations
                     type: boolean
                 type: object

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,13 +18,13 @@ aliases:
 
 **Update note 1: the `--metrics-addr` command-line flag at `operator` was deprecated. Use `--metrics-bind-address` instead.**
 **Update note 2: the `--enable-leader-election` command-line flag at `operator` was deprecated. Use `--leader-elect` instead.**
+**Update note 3: multitenant endpoints suffix `/insert/multitenant/<suffix>` needs to be added in `remoteWrite.url` if storage supports multitenancy when using `remoteWriteSettings.useMultiTenantMode`, as upstream [vmagent](https://docs.victoriametrics.com/vmagent/) has deprecated `-remoteWrite.multitenantURL` command-line flag since v1.102.0.**
 
 - [operator](./README.md): kubebuilder v2 -> v4 upgrade
 - [operator](./README.md): upgraded certificates.cert-manager.io/v1alpha2 to certificates.cert-manager.io/v1
 - [operator](./README.md): code-generator v0.27.11 -> v0.30.0 upgrade
 - [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): adds missing `handleReconcileErr` callback to the reconcile loop. It must properly handle errors and deregister objects.
 - [vmrule](./api.md#vmrule): sync group attributes `eval_offset`, `eval_delay` and `eval_alignment` from [upstream](https://docs.victoriametrics.com/vmalert/#groups).
-- [vmagent](./api.md#vmagent): use `-enableMultitenantHandlers` command-line flag for vmagent remote write multiTenant mode, previous flag `-remoteWrite.multitenantURL` is already deprecated.
 
 - [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 - - [vmnodescrape](./api.md#vmnodescrape): remove duplicated `series_limit` and `sample_limit` fields in generated scrape_config. See [this issue](https://github.com/VictoriaMetrics/operator/issues/986).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,8 +24,7 @@ aliases:
 - [operator](./README.md): code-generator v0.27.11 -> v0.30.0 upgrade
 - [vmalertmanagerconfig](./api.md#vmalertmanagerconfig): adds missing `handleReconcileErr` callback to the reconcile loop. It must properly handle errors and deregister objects.
 - [vmrule](./api.md#vmrule): sync group attributes `eval_offset`, `eval_delay` and `eval_alignment` from [upstream](https://docs.victoriametrics.com/vmalert/#groups).
-
-- [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
+- [vmagent](./api.md#vmagent): use `-enableMultitenantHandlers` command-line flag for vmagent remote write multiTenant mode, previous flag `-remoteWrite.multitenantURL` is already deprecated.
 
 - [operator](./README.md): fix VM CRs' `xxNamespaceSelector` and `xxSelector` options, previously they are inverted. See this [issue](https://github.com/VictoriaMetrics/operator/issues/980) for details.
 - - [vmnodescrape](./api.md#vmnodescrape): remove duplicated `series_limit` and `sample_limit` fields in generated scrape_config. See [this issue](https://github.com/VictoriaMetrics/operator/issues/986).

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -1082,6 +1082,9 @@ func buildRemoteWriteSettings(cr *vmv1beta1.VMAgent) []string {
 		}
 
 	}
+	if rws.UseMultiTenantMode {
+		args = append(args, "-enableMultitenantHandlers=true")
+	}
 	return args
 }
 
@@ -1106,11 +1109,6 @@ func buildRemoteWrites(cr *vmv1beta1.VMAgent, ssCache *scrapesSecretsCache) []st
 	remoteTargets := cr.Spec.RemoteWrite
 
 	url := remoteFlag{flagSetting: "-remoteWrite.url=", isNotNull: true}
-	var multiTenantModeSuffix string
-	if cr.Spec.RemoteWriteSettings != nil && cr.Spec.RemoteWriteSettings.UseMultiTenantMode {
-		multiTenantModeSuffix = "/insert/multitenant/prometheus/api/v1/write"
-		remoteArgs = append(remoteArgs, remoteFlag{flagSetting: "-enableMultitenantHandlers=true", isNotNull: true})
-	}
 
 	authUser := remoteFlag{flagSetting: "-remoteWrite.basicAuth.username="}
 	authPasswordFile := remoteFlag{flagSetting: "-remoteWrite.basicAuth.passwordFile="}
@@ -1136,9 +1134,7 @@ func buildRemoteWrites(cr *vmv1beta1.VMAgent, ssCache *scrapesSecretsCache) []st
 
 	for i := range remoteTargets {
 		rws := remoteTargets[i]
-
-		// add multi tenant suffix to remote write url
-		url.flagSetting += fmt.Sprintf("%s%s,", strings.TrimSuffix(rws.URL, "/"), multiTenantModeSuffix)
+		url.flagSetting += fmt.Sprintf("%s,", rws.URL)
 
 		var caPath, certPath, keyPath, ServerName string
 		var insecure bool

--- a/internal/controller/operator/factory/vmagent/vmagent_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_test.go
@@ -753,12 +753,12 @@ func TestBuildRemoteWrites(t *testing.T) {
 					Spec: vmv1beta1.VMAgentSpec{
 						RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
 							{
-								URL: "http://vminsert-cluster-1:8480/",
+								URL: "http://vminsert-cluster-1:8480/insert/multitenant/prometheus/api/v1/write",
 
 								SendTimeout: ptr.To("10s"),
 							},
 							{
-								URL:         "https://vminsert-cluster-2:8480",
+								URL:         "http://vmagent-aggregation:8429",
 								SendTimeout: ptr.To("15s"),
 							},
 						},
@@ -768,7 +768,7 @@ func TestBuildRemoteWrites(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"-enableMultitenantHandlers=true", "-remoteWrite.url=http://vminsert-cluster-1:8480/insert/multitenant/prometheus/api/v1/write,https://vminsert-cluster-2:8480/insert/multitenant/prometheus/api/v1/write", "-remoteWrite.sendTimeout=10s,15s"},
+			want: []string{"-remoteWrite.url=http://vminsert-cluster-1:8480/insert/multitenant/prometheus/api/v1/write,http://vmagent-aggregation:8429", "-remoteWrite.sendTimeout=10s,15s"},
 		},
 		{
 			name: "test oauth2",
@@ -1621,11 +1621,12 @@ func TestBuildRemoteWriteSettings(t *testing.T) {
 							ShowURL:            ptr.To(true),
 							TmpDataPath:        ptr.To("/tmp/my-path"),
 							MaxDiskUsagePerURL: ptr.To(int64(1000)),
+							UseMultiTenantMode: true,
 						},
 					},
 				},
 			},
-			want: []string{"-remoteWrite.maxDiskUsagePerURL=1000", "-remoteWrite.tmpDataPath=/tmp/my-path", "-remoteWrite.showURL=true"},
+			want: []string{"-remoteWrite.maxDiskUsagePerURL=1000", "-remoteWrite.tmpDataPath=/tmp/my-path", "-remoteWrite.showURL=true", "-enableMultitenantHandlers=true"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/controller/operator/factory/vmagent/vmagent_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_test.go
@@ -753,12 +753,12 @@ func TestBuildRemoteWrites(t *testing.T) {
 					Spec: vmv1beta1.VMAgentSpec{
 						RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
 							{
-								URL: "vminsert-cluster-1:8480",
+								URL: "http://vminsert-cluster-1:8480/",
 
 								SendTimeout: ptr.To("10s"),
 							},
 							{
-								URL:         "vminsert-cluster-2:8480",
+								URL:         "https://vminsert-cluster-2:8480",
 								SendTimeout: ptr.To("15s"),
 							},
 						},
@@ -768,7 +768,7 @@ func TestBuildRemoteWrites(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"-remoteWrite.multitenantURL=vminsert-cluster-1:8480,vminsert-cluster-2:8480", "-remoteWrite.sendTimeout=10s,15s"},
+			want: []string{"-enableMultitenantHandlers=true", "-remoteWrite.url=http://vminsert-cluster-1:8480/insert/multitenant/prometheus/api/v1/write,https://vminsert-cluster-2:8480/insert/multitenant/prometheus/api/v1/write", "-remoteWrite.sendTimeout=10s,15s"},
 		},
 		{
 			name: "test oauth2",


### PR DESCRIPTION
…nt remote write multiTenant mode, previous flag `remoteWrite.multitenantURL` is already deprecated.
