### PR TITLE
fixed replaced version extraction

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -51,7 +51,7 @@ jobs:
           VERSION=$(ls bundle | head -1)
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           export MANIFEST_PATH=bundle/${VERSION}/manifests/victoriametrics-operator.clusterserviceversion.yaml
-          export REPLACE_VERSION=$(find __k8s-operatorhub-repo/operators/victoriametrics-operator/* -type d -exec basename {} \; | sort -V -r | head -1)
+          export REPLACE_VERSION=$(find __k8s-operatorhub-repo/operators/victoriametrics-operator/* -maxdepth 0 -type d -exec basename {} \; | sort -V -r | head -1)
           yq -i '.spec.replaces = "victoriametrics-operator.v" + strenv(REPLACE_VERSION)' $MANIFEST_PATH
           mkdir -p __k8s-operatorhub-repo/operators/victoriametrics-operator
           mv bundle/* __k8s-operatorhub-repo/operators/victoriametrics-operator/

--- a/Makefile
+++ b/Makefile
@@ -182,10 +182,10 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx rm vm-builder
 	rm Dockerfile.cross
 
-publish: ROOT=./cmd
-publish: docker-buildx
-publish: TAG=config-reloader-$(TAG)
+publish: TAG:=config-reloader-$(TAG)
 publish: ROOT=./cmd/config-reloader
+publish: docker-buildx
+publish: ROOT=./cmd
 publish: docker-buildx
 
 .PHONY: build-installer

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,8 @@ olm: operator-sdk opm yq docs
 	cp config/manifests/ci.yaml bundle/
 	$(YQ) -i '.metadata.annotations.containerImage = "$(REGISTRY)/$(ORG)/$(REPO):v$(VERSION)"' \
 		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
+	$(YQ) -i '.annotations."com.redhat.openshift.versions" = "v4.12-v4.16"' \
+		bundle/$(VERSION)/metadata/annotations.yaml
 	$(if $(findstring localhost,$(REGISTRY)), \
 		$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(REGISTRY)/$(ORG)/$(REPO)-bundle:v$(VERSION) .; \
 		$(CONTAINER_TOOL) push $(REGISTRY)/$(ORG)/$(REPO)-bundle:v$(VERSION); \

--- a/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/victoriametrics-operator.clusterserviceversion.yaml
@@ -6,7 +6,6 @@ metadata:
     capabilities: Deep Insights
     categories: Monitoring
     certified: "false"
-    com.redhat.openshift.versions: v4.12-v4.16
     containerImage: docker.io/victoriametrics/operator:0.0.0
     createdAt: "2020-05-01 12:00:00"
     description: Provides monitoring capabilites for kubernetes clusters and applications

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - ../examples
 - ../default
+- scorecard.yaml
 patches:
 - patch: |-
     $patch: delete

--- a/config/manifests/scorecard.yaml
+++ b/config/manifests/scorecard.yaml
@@ -1,0 +1,60 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.35.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -123,7 +123,7 @@ func RunManager(ctx context.Context) error {
 	var watchNsCacheByName map[string]cache.Config
 	watchNss := config.MustGetWatchNamespaces()
 	if len(watchNss) > 0 {
-		setupLog.Info("operator configured with watching for subset of namespaces=%q, cluster wide access is disabled", strings.Join(watchNss, ","))
+		setupLog.Info("operator configured with watching for subset of namespaces cluster wide access is disabled", "namespaces", strings.Join(watchNss, ","))
 		watchNsCacheByName = make(map[string]cache.Config)
 		for _, ns := range watchNss {
 			watchNsCacheByName[ns] = cache.Config{}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -123,7 +123,7 @@ func RunManager(ctx context.Context) error {
 	var watchNsCacheByName map[string]cache.Config
 	watchNss := config.MustGetWatchNamespaces()
 	if len(watchNss) > 0 {
-		setupLog.Info("operator configured with watching for subset of namespaces cluster wide access is disabled", "namespaces", strings.Join(watchNss, ","))
+		setupLog.Info("operator configured with watching for subset of namespaces, cluster wide access is disabled", "namespaces", strings.Join(watchNss, ","))
 		watchNsCacheByName = make(map[string]cache.Config)
 		for _, ns := range watchNss {
 			watchNsCacheByName[ns] = cache.Config{}


### PR DESCRIPTION
- set maxdepth in find to 0 to exclude child dirs
- fixed openshift version boundaries
- exclude docs and config folders from image tag hash calculation
- properly override makefile dependency targets variables
- fixed typo in operator logging
- added scorecards for olm bundle