### PR TITLE
Update vmalertmanager.md to fix typo in doc

### DIFF
--- a/docs/resources/vmalertmanager.md
+++ b/docs/resources/vmalertmanager.md
@@ -99,7 +99,7 @@ spec:
     - name: 'default'
 ```
 
-If both `configSecret` and `configRawYaml` are defined, only configuration from `configRawYaml` will be used. Values from `configRawYaml` will be ignored.
+If both `configSecret` and `configRawYaml` are defined, only configuration from `configRawYaml` will be used. Values from `configSecret` will be ignored.
 
 ### Using VMAlertmanagerConfig
 


### PR DESCRIPTION
Fixing typo in what would be honored for configuration if secret and raw values, both are provided.