### PR TITLE
internal/finalize: fixes typo at PDB delete function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 ---
 # CHANGELOG
 
+- [operator](./README.md): properly release `PodDisruptionBudget` object finalizer. Previously it could be kept due to typo. See this [issue](https://github.com/VictoriaMetrics/operator/issues/1036) for details.
+
 ## [v0.46.4](https://github.com/VictoriaMetrics/operator/releases/tag/v0.46.4) - 9 Jul 2024
 
 ### Breaking changes
@@ -1769,4 +1771,3 @@ it contains basic api objects support:
 [v0.0.6]: https://github.com/VictoriaMetrics/operator/compare/v0.0.2...v0.0.6
 [v0.0.2]: https://github.com/VictoriaMetrics/operator/compare/v0.0.1...v0.0.2
 [v0.0.1]: https://github.com/VictoriaMetrics/operator/tree/v0.0.1
-

--- a/internal/controller/operator/factory/finalize/common.go
+++ b/internal/controller/operator/factory/finalize/common.go
@@ -98,7 +98,7 @@ func finalizePBD(ctx context.Context, rclient client.Client, crd crdObject) erro
 	return removeFinalizeObjByName(ctx, rclient, &policyv1.PodDisruptionBudget{}, crd.PrefixedName(), crd.GetNSName())
 }
 
-func finalizePBDWithName(ctx context.Context, rclient client.Client, ns, name string) error {
+func finalizePBDWithName(ctx context.Context, rclient client.Client, name, ns string) error {
 	return removeFinalizeObjByName(ctx, rclient, &policyv1.PodDisruptionBudget{}, name, ns)
 }
 


### PR DESCRIPTION
Previously name and namespace args were misplaced at removeFinalize function call. It prevented from proper object deletion. And caused various errors during objects deletion.

https://github.com/VictoriaMetrics/operator/issues/1036