### PR TITLE
reconcile: fixes statefulset endless reconcile loop

### DIFF
--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -726,13 +726,6 @@ func (cr *VMAgent) AsURL() string {
 	return fmt.Sprintf("%s://%s.%s.svc:%s", protoFromFlags(cr.Spec.ExtraArgs), cr.PrefixedName(), cr.Namespace, port)
 }
 
-func (cr VMAgent) STSUpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
-	if cr.Spec.StatefulRollingUpdateStrategy == "" {
-		return appsv1.OnDeleteStatefulSetStrategyType
-	}
-	return cr.Spec.StatefulRollingUpdateStrategy
-}
-
 // AsCRDOwner implements interface
 func (cr *VMAgent) AsCRDOwner() []metav1.OwnerReference {
 	return GetCRDAsOwner(Agent)

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -473,13 +473,6 @@ func (cr *VMAlertmanager) AsNotifiers() []VMAlertNotifierSpec {
 	return r
 }
 
-func (cr VMAlertmanager) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
-	if cr.Spec.RollingUpdateStrategy == "" {
-		return appsv1.OnDeleteStatefulSetStrategyType
-	}
-	return cr.Spec.RollingUpdateStrategy
-}
-
 func (cr *VMAlertmanager) GetVolumeName() string {
 	if cr.Spec.Storage != nil && cr.Spec.Storage.VolumeClaimTemplate.Name != "" {
 		return cr.Spec.Storage.VolumeClaimTemplate.Name

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -830,20 +830,6 @@ func (s VMSelect) GetCacheMountVolumeName() string {
 	return PrefixedName("cachedir", "vmselect")
 }
 
-func (s VMStorage) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
-	if s.RollingUpdateStrategy == "" {
-		return appsv1.OnDeleteStatefulSetStrategyType
-	}
-	return s.RollingUpdateStrategy
-}
-
-func (s VMSelect) UpdateStrategy() appsv1.StatefulSetUpdateStrategyType {
-	if s.RollingUpdateStrategy == "" {
-		return appsv1.OnDeleteStatefulSetStrategyType
-	}
-	return s.RollingUpdateStrategy
-}
-
 // Image defines docker image settings
 type Image struct {
 	// Repository contains name of docker image + it's repository if needed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,13 @@ aliases:
   - /operator/changelog/index.html
 ---
 
+
+- [operator](https://docs.victoriametrics.com/operator/): fixes statefulset `rollingUpdate` strategyType readiness check.
+- [operator](https://docs.victoriametrics.com/operator/): fixes statefulset reconcile endless loop bug introduced at v0.47.1 version with [commit](https://github.com/VictoriaMetrics/operator/commit/57b65771b29ffd8b5d577e160aacddf0481295ee).
+
 ## [v0.47.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.47.1) - 23 Aug 2024
+
+**It is recommended upgrading to [operator v0.47.2](https://docs.victoriametrics.com/operator/changelog/#v0471---23-aug-2024) because v0.47.1 contains a bug, which can lead to endless statefulset reconcile loop.**
 
 - [operator](https://docs.victoriametrics.com/operator/): properly update statefulset on `revisionHistoryLimitCount` change. See this [issue](https://github.com/VictoriaMetrics/operator/issues/1070) for details.
 - [vmalertmanagerconfig](https://docs.victoriametrics.com/operator/resources/vmalertmanagerconfig): properly construct `tls_config` for `emails` notifications. See this [issue](https://github.com/VictoriaMetrics/operator/issues/1080) for details.

--- a/internal/controller/operator/factory/alertmanager/alertmanager.go
+++ b/internal/controller/operator/factory/alertmanager/alertmanager.go
@@ -67,7 +67,6 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *vmv1beta1.VMAlertmanage
 		HasClaim:       len(newSts.Spec.VolumeClaimTemplates) > 0,
 		VolumeName:     cr.GetVolumeName,
 		SelectorLabels: cr.SelectorLabels,
-		UpdateStrategy: cr.UpdateStrategy,
 	}
 	return reconcile.HandleSTSUpdate(ctx, rclient, stsOpts, newSts, c)
 }

--- a/internal/controller/operator/factory/alertmanager/alertmanager_test.go
+++ b/internal/controller/operator/factory/alertmanager/alertmanager_test.go
@@ -226,6 +226,8 @@ func TestCreateOrUpdateAlertManager(t *testing.T) {
 							continue
 						}
 						got.Status.ReadyReplicas = *tt.args.cr.Spec.ReplicaCount
+						got.Status.UpdatedReplicas = *tt.args.cr.Spec.ReplicaCount
+
 						if err := fclient.Status().Update(ctx, &got); err != nil {
 							t.Errorf("cannot update status statefulset for alertmanager: %s", err)
 						}

--- a/internal/controller/operator/factory/build/statefulset.go
+++ b/internal/controller/operator/factory/build/statefulset.go
@@ -1,0 +1,29 @@
+package build
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+)
+
+// AddDefaultsToSTS sets default values to statefulset spec
+func AddDefaultsToSTS(sts *appsv1.StatefulSetSpec) {
+	if sts.UpdateStrategy.Type == "" {
+		sts.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+	}
+	if sts.PodManagementPolicy == "" {
+		sts.PodManagementPolicy = appsv1.ParallelPodManagement
+		if sts.MinReadySeconds > 0 || sts.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType {
+			sts.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+		}
+	}
+	if sts.RevisionHistoryLimit == nil {
+		sts.RevisionHistoryLimit = ptr.To[int32](10)
+	}
+
+	if sts.PersistentVolumeClaimRetentionPolicy == nil {
+		sts.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		}
+	}
+}

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -126,8 +127,8 @@ func recreateSTSIfNeed(ctx context.Context, rclient client.Client, newSTS, exist
 	if newSTS.Spec.MinReadySeconds != existingSTS.Spec.MinReadySeconds ||
 		newSTS.Spec.PodManagementPolicy != existingSTS.Spec.PodManagementPolicy ||
 		newSTS.Spec.UpdateStrategy != existingSTS.Spec.UpdateStrategy ||
-		newSTS.Spec.RevisionHistoryLimit != existingSTS.Spec.RevisionHistoryLimit ||
-		newSTS.Spec.PersistentVolumeClaimRetentionPolicy != existingSTS.Spec.PersistentVolumeClaimRetentionPolicy {
+		!ptr.Equal(newSTS.Spec.RevisionHistoryLimit, existingSTS.Spec.RevisionHistoryLimit) ||
+		!ptr.Equal(newSTS.Spec.PersistentVolumeClaimRetentionPolicy, existingSTS.Spec.PersistentVolumeClaimRetentionPolicy) {
 		return true, false, handleRemove()
 	}
 	if newSTS.Spec.ServiceName != existingSTS.Spec.ServiceName {

--- a/internal/controller/operator/factory/vmcluster/vmcluster_test.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster_test.go
@@ -339,6 +339,7 @@ func TestCreateOrUpdateVMCluster(t *testing.T) {
 						return err
 					}
 					vmselect.Status.ReadyReplicas = *tt.args.cr.Spec.VMSelect.ReplicaCount
+					vmselect.Status.UpdatedReplicas = *tt.args.cr.Spec.VMSelect.ReplicaCount
 					if err := fclient.Status().Update(ctx, &vmselect); err != nil {
 						return err
 					}
@@ -352,6 +353,7 @@ func TestCreateOrUpdateVMCluster(t *testing.T) {
 						return err
 					}
 					vmstorage.Status.ReadyReplicas = *tt.args.cr.Spec.VMStorage.ReplicaCount
+					vmstorage.Status.UpdatedReplicas = *tt.args.cr.Spec.VMStorage.ReplicaCount
 					if err := fclient.Status().Update(ctx, &vmstorage); err != nil {
 						return err
 					}


### PR DESCRIPTION
* Previous commit made incorrect equal check to revisionHistoryLimit, since kubernetes automatically sets default value for revisionHistory and some other fields. It fails operator check and re-creates statefulset on each reconcile loop.

* with this change operator will set default values to generated statefulset. It must fix this issue and prevent possible future misconfiguration.

related issues
https://github.com/VictoriaMetrics/helm-charts/issues/1319 https://github.com/VictoriaMetrics/operator/issues/1070