### PR TITLE
internal/config: bump vm version to 1.103.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ aliases:
   - /operator/changelog/index.html
 ---
 
+- [operator](https://docs.victoriametrics.com/operator/): updates default vm apps version to v1.103.0
+
 ## [v0.47.3](https://github.com/VictoriaMetrics/operator/releases/tag/v0.47.3) - 28 Aug 2024
 
 - [operator](https://docs.victoriametrics.com/operator/): fixes statefulset reconcile endless loop bug introduced at v0.47.0 version with [commit](https://github.com/VictoriaMetrics/operator/commit/57b65771b29ffd8b5d577e160aacddf0481295ee).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,7 @@ type BaseOperatorConf struct {
 
 	VMAlertDefault struct {
 		Image               string `default:"victoriametrics/vmalert"`
-		Version             string `default:"v1.102.1"`
+		Version             string `default:"v1.103.0"`
 		Port                string `default:"8080"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {
@@ -93,7 +93,7 @@ type BaseOperatorConf struct {
 
 	VMAgentDefault struct {
 		Image               string `default:"victoriametrics/vmagent"`
-		Version             string `default:"v1.102.1"`
+		Version             string `default:"v1.103.0"`
 		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true"`
@@ -113,7 +113,7 @@ type BaseOperatorConf struct {
 
 	VMSingleDefault struct {
 		Image               string `default:"victoriametrics/victoria-metrics"`
-		Version             string `default:"v1.102.1"`
+		Version             string `default:"v1.103.0"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {
@@ -134,7 +134,7 @@ type BaseOperatorConf struct {
 		UseDefaultResources bool `default:"true"`
 		VMSelectDefault     struct {
 			Image    string `default:"victoriametrics/vmselect"`
-			Version  string `default:"v1.102.1-cluster"`
+			Version  string `default:"v1.103.0-cluster"`
 			Port     string `default:"8481"`
 			Resource struct {
 				Limit struct {
@@ -149,7 +149,7 @@ type BaseOperatorConf struct {
 		}
 		VMStorageDefault struct {
 			Image        string `default:"victoriametrics/vmstorage"`
-			Version      string `default:"v1.102.1-cluster"`
+			Version      string `default:"v1.103.0-cluster"`
 			VMInsertPort string `default:"8400"`
 			VMSelectPort string `default:"8401"`
 			Port         string `default:"8482"`
@@ -166,7 +166,7 @@ type BaseOperatorConf struct {
 		}
 		VMInsertDefault struct {
 			Image    string `default:"victoriametrics/vminsert"`
-			Version  string `default:"v1.102.1-cluster"`
+			Version  string `default:"v1.103.0-cluster"`
 			Port     string `default:"8480"`
 			Resource struct {
 				Limit struct {
@@ -204,7 +204,7 @@ type BaseOperatorConf struct {
 	DisableSelfServiceScrapeCreation bool `default:"false"`
 	VMBackup                         struct {
 		Image               string `default:"victoriametrics/vmbackupmanager"`
-		Version             string `default:"v1.102.1-enterprise"`
+		Version             string `default:"v1.103.0-enterprise"`
 		Port                string `default:"8300"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {
@@ -222,7 +222,7 @@ type BaseOperatorConf struct {
 	}
 	VMAuthDefault struct {
 		Image               string `default:"victoriametrics/vmauth"`
-		Version             string `default:"v1.102.1"`
+		Version             string `default:"v1.103.0"`
 		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8427"`
 		UseDefaultResources bool   `default:"true"`


### PR DESCRIPTION
Following https://docs.victoriametrics.com/release-guide/#bump-the-version-of-images