### PR TITLE
controllers/finalizers: respect the enabled status of PDB

### DIFF
--- a/internal/controller/operator/factory/finalize/vmagent.go
+++ b/internal/controller/operator/factory/finalize/vmagent.go
@@ -56,8 +56,10 @@ func OnVMAgentDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.
 	}
 
 	// check PDB
-	if err := finalizePBD(ctx, rclient, crd); err != nil {
-		return err
+	if crd.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, crd); err != nil {
+			return err
+		}
 	}
 	// remove vmagents service discovery rbac.
 	if config.IsClusterWideAccessAllowed() {

--- a/internal/controller/operator/factory/finalize/vmalert.go
+++ b/internal/controller/operator/factory/finalize/vmalert.go
@@ -38,8 +38,10 @@ func OnVMAlertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.
 	}
 
 	// check PDB
-	if err := finalizePBD(ctx, rclient, crd); err != nil {
-		return err
+	if crd.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, crd); err != nil {
+			return err
+		}
 	}
 	if err := deleteSA(ctx, rclient, crd); err != nil {
 		return err

--- a/internal/controller/operator/factory/finalize/vmalertmanager.go
+++ b/internal/controller/operator/factory/finalize/vmalertmanager.go
@@ -37,8 +37,10 @@ func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, crd *vmv
 	}
 
 	// check PDB
-	if err := finalizePBD(ctx, rclient, crd); err != nil {
-		return err
+	if crd.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, crd); err != nil {
+			return err
+		}
 	}
 
 	if err := deleteSA(ctx, rclient, crd); err != nil {

--- a/internal/controller/operator/factory/finalize/vmauth.go
+++ b/internal/controller/operator/factory/finalize/vmauth.go
@@ -51,8 +51,10 @@ func OnVMAuthDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.V
 	}
 
 	// check PDB
-	if err := finalizePBD(ctx, rclient, crd); err != nil {
-		return err
+	if crd.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, crd); err != nil {
+			return err
+		}
 	}
 
 	// check ingress

--- a/internal/controller/operator/factory/finalize/vmcluster.go
+++ b/internal/controller/operator/factory/finalize/vmcluster.go
@@ -57,8 +57,10 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 		}
 
 		// check PDB
-		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
-			return err
+		if crd.Spec.VMInsert.PodDisruptionBudget != nil {
+			if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -84,8 +86,10 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 		}
 
 		// check PDB
-		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
-			return err
+		if crd.Spec.VMSelect.PodDisruptionBudget != nil {
+			if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+				return err
+			}
 		}
 	}
 	if crd.Spec.VMStorage != nil {
@@ -104,8 +108,10 @@ func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 		}
 
 		// check PDB
-		if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
-			return err
+		if crd.Spec.VMStorage.PodDisruptionBudget != nil {
+			if err := finalizePBDWithName(ctx, rclient, obj.GetNameWithPrefix(crd.Name), crd.Namespace); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6994

This PR adds a missing check to PDB during `finalize()` phase, and skips if its not enabled. (Tested on our clusters and can confirm it works!)