### PR TITLE
internal/config: bump vm version to 1.104.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,7 +104,7 @@ type BaseOperatorConf struct {
 
 	VMAlertDefault struct {
 		Image               string `default:"victoriametrics/vmalert"`
-		Version             string `default:"v1.103.0"`
+		Version             string `default:"v1.104.0"`
 		ConfigReloadImage   string `default:"jimmidyson/configmap-reload:v0.3.0"`
 		Port                string `default:"8080"`
 		UseDefaultResources bool   `default:"true"`
@@ -124,7 +124,7 @@ type BaseOperatorConf struct {
 
 	VMAgentDefault struct {
 		Image               string `default:"victoriametrics/vmagent"`
-		Version             string `default:"v1.103.0"`
+		Version             string `default:"v1.104.0"`
 		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true"`
@@ -144,7 +144,7 @@ type BaseOperatorConf struct {
 
 	VMSingleDefault struct {
 		Image   string `default:"victoriametrics/victoria-metrics"`
-		Version string `default:"v1.103.0"`
+		Version string `default:"v1.104.0"`
 		// ignored
 		ConfigReloadImage   string `ignored:"true"`
 		Port                string `default:"8429"`
@@ -169,7 +169,7 @@ type BaseOperatorConf struct {
 		UseDefaultResources bool `default:"true"`
 		VMSelectDefault     struct {
 			Image    string `default:"victoriametrics/vmselect"`
-			Version  string `default:"v1.103.0-cluster"`
+			Version  string `default:"v1.104.0-cluster"`
 			Port     string `default:"8481"`
 			Resource struct {
 				Limit struct {
@@ -184,7 +184,7 @@ type BaseOperatorConf struct {
 		}
 		VMStorageDefault struct {
 			Image        string `default:"victoriametrics/vmstorage"`
-			Version      string `default:"v1.103.0-cluster"`
+			Version      string `default:"v1.104.0-cluster"`
 			VMInsertPort string `default:"8400"`
 			VMSelectPort string `default:"8401"`
 			Port         string `default:"8482"`
@@ -201,7 +201,7 @@ type BaseOperatorConf struct {
 		}
 		VMInsertDefault struct {
 			Image    string `default:"victoriametrics/vminsert"`
-			Version  string `default:"v1.103.0-cluster"`
+			Version  string `default:"v1.104.0-cluster"`
 			Port     string `default:"8480"`
 			Resource struct {
 				Limit struct {
@@ -239,7 +239,7 @@ type BaseOperatorConf struct {
 	DisableSelfServiceScrapeCreation bool `default:"false"`
 	VMBackup                         struct {
 		Image               string `default:"victoriametrics/vmbackupmanager"`
-		Version             string `default:"v1.103.0-enterprise"`
+		Version             string `default:"v1.104.0-enterprise"`
 		Port                string `default:"8300"`
 		UseDefaultResources bool   `default:"true"`
 		Resource            struct {
@@ -255,7 +255,7 @@ type BaseOperatorConf struct {
 	}
 	VMAuthDefault struct {
 		Image               string `default:"victoriametrics/vmauth"`
-		Version             string `default:"v1.103.0"`
+		Version             string `default:"v1.104.0"`
 		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0"`
 		Port                string `default:"8427"`
 		UseDefaultResources bool   `default:"true"`


### PR DESCRIPTION
Please note, I followed https://docs.victoriametrics.com/release-guide/#operator and it seems incorrect starting on step 2. Please, update the release guide according to the expected procedures for VM version update.