### PR TITLE
reconcile/statefulset: fixes vmagent statefulmode transition

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ aliases:
 
 - [api](https://docs.victoriametrics.com/operator/api): adds new fields `maxDiskUsagePerUrl` and`forceVMProto` to the `VMagent` `remoteWriteSpec`
 - [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): fixes the protocol of generated CRD target access url for vminsert and vmstorage when TLS is enabled.
+- [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly make transition to `statefulMode`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1127) for details.
 
 ## [v0.48.3](https://github.com/VictoriaMetrics/operator/releases/tag/v0.48.3) - 29 Sep 2024
 


### PR DESCRIPTION
Previously, during Deployment -> StatefulSet transition, it was possible to be in state, where deployment was not scheduled successfully. If `VMAgent` spec changed into `statefulMode`, operator incorrectly lists pods that belong to `Deployment` for sts rolling update.

 It produces error and could only be fixed by manual `Deployment` deletion.

 This commit filters all pods, that don't have `StatefulSet` in `OwnerReferences`. It fixes incorrect behavior of this kind of transition.

Related issue: https://github.com/VictoriaMetrics/operator/issues/1127