### PR TITLE
build/security: removes AppArmorProfile and SeccompProfile from defaults

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 - [api](https://docs.victoriametrics.com/operator/api): adds new fields `maxDiskUsagePerUrl` and`forceVMProto` to the `VMagent` `remoteWriteSpec`
 - [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): fixes the protocol of generated CRD target access url for vminsert and vmstorage when TLS is enabled.
 - [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly make transition to `statefulMode`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1127) for details.
+- [operator](https://docs.victoriametrics.com/operator/): fixes pod scheduling with `useStrictSecurity` enabled by removing default values for `AppArmorProfile` and `SeccompProfile`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1120) for details.
 
 ## [v0.48.3](https://github.com/VictoriaMetrics/operator/releases/tag/v0.48.3) - 29 Sep 2024
 

--- a/internal/controller/operator/factory/build/security.go
+++ b/internal/controller/operator/factory/build/security.go
@@ -17,15 +17,9 @@ var (
 	containerUserGroup     int64 = 65534
 	runNonRoot                   = true
 	defaultSecurityContext       = &corev1.SecurityContext{
-		RunAsUser:    &containerUserGroup,
-		RunAsGroup:   &containerUserGroup,
-		RunAsNonRoot: &runNonRoot,
-		AppArmorProfile: &corev1.AppArmorProfile{
-			Type: corev1.AppArmorProfileTypeRuntimeDefault,
-		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
+		RunAsUser:                &containerUserGroup,
+		RunAsGroup:               &containerUserGroup,
+		RunAsNonRoot:             &runNonRoot,
 		ReadOnlyRootFilesystem:   ptr.To(true),
 		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{

--- a/test/e2e/vmauth_test.go
+++ b/test/e2e/vmauth_test.go
@@ -92,7 +92,7 @@ var _ = Describe("test vmauth Controller", func() {
 					},
 					Spec: v1beta1vm.VMAuthSpec{
 						CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
-							//						UseStrictSecurity:   ptr.To(true),
+							UseStrictSecurity:   ptr.To(true),
 							UseDefaultResources: ptr.To(false),
 						},
 						CommonConfigReloaderParams: v1beta1vm.CommonConfigReloaderParams{

--- a/test/e2e/vmsingle_test.go
+++ b/test/e2e/vmsingle_test.go
@@ -159,6 +159,39 @@ var _ = Describe("test  vmsingle Controller", func() {
 						Expect(createdDeploy.Spec.Template.Spec.Containers[0].Resources).To(Equal(corev1.ResourceRequirements{}))
 						Expect(createdDeploy.Spec.Template.Spec.Containers[1].Resources).To(Equal(corev1.ResourceRequirements{}))
 					}),
+				Entry("with strict security", "strict-security",
+					&vmv1beta1.VMSingle{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+						},
+						Spec: vmv1beta1.VMSingleSpec{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+								ReplicaCount: ptr.To[int32](1),
+							},
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
+								UseStrictSecurity: ptr.To(true),
+							},
+							RetentionPeriod:      "1",
+							RemovePvcAfterDelete: true,
+							Storage: &corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("1Gi"),
+									},
+								},
+							},
+						},
+					},
+					func(cr *vmv1beta1.VMSingle) {
+						createdChildObjects := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
+						var createdDeploy appsv1.Deployment
+						Expect(k8sClient.Get(ctx, createdChildObjects, &createdDeploy)).To(Succeed())
+						Expect(createdDeploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+						Expect(createdDeploy.Spec.Template.Spec.Containers[0].SecurityContext).NotTo(BeNil())
+						Expect(createdDeploy.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).NotTo(BeNil())
+						Expect(*createdDeploy.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
+
+					}),
 			)
 
 			existSingle := &vmv1beta1.VMSingle{


### PR DESCRIPTION
It allow to use strictSecurity with hosts without AppArmor and Seccomp (windows nodes for instance). This change doesn't affect security, neither adds breaking changes, since AppArmor and Seccomp are rarely used. And set by default to the same values, as operator added.

Related issue https://github.com/VictoriaMetrics/operator/issues/1120