### PR TITLE
controller/operator/factory/alertmanager: include `.spec.configMaps` to config-reloader

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 - [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): Moved `spec.configSecret` to `spec.externalConfig.secretRef.name` and added `spec.externalConfig.localPath` to be able to provide custom configs via sidecar.
 - [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster): adds `requestsLoadBalancer` configuration to the `VMCluster.spec`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1130) for details.
 - [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster): properly configure monitoring for `VMCluster` with enabled `backup`.
+- [vmalertmanager](https://docs.victoriametrics.com/operator/resources/vmalertmanager): properly trigger reload when `ConfigMap` provided via `.spec.configMap` are changed.
 
 
 ## [v0.48.4](https://github.com/VictoriaMetrics/operator/releases/tag/v0.48.4) - 15 Oct 2024

--- a/internal/controller/operator/factory/alertmanager/statefulset.go
+++ b/internal/controller/operator/factory/alertmanager/statefulset.go
@@ -329,6 +329,7 @@ func makeStatefulSetSpec(cr *vmv1beta1.VMAlertmanager) (*appsv1.StatefulSetSpec,
 			MountPath: path.Join(vmv1beta1.ConfigMapsDir, c),
 		}
 		amVolumeMounts = append(amVolumeMounts, cmVolumeMount)
+		crVolumeMounts = append(crVolumeMounts, cmVolumeMount)
 	}
 
 	volumeByName := make(map[string]struct{})


### PR DESCRIPTION
Properly include ConfigMaps provided via `.spec.configMaps` into a list of watched directories in order to trigger the reload.
Previously, a user-defined `ConfigMap` change would require a manual reload trigger or an additional sidecar.