### PR TITLE
feat: allow dynamic config of terminationGracePeriodSeconds to work with storage.vminsertConnsShutdownDuration flag

### DIFF
--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -252,7 +251,7 @@ func performRollingUpdateOnSts(ctx context.Context, podMustRecreate bool, rclien
 	for _, pod := range podsForUpdate {
 		l.Info("updating pod", "pod", pod.Name)
 		// we have to delete pod and wait for it readiness
-		err := rclient.Delete(ctx, &pod, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(30))})
+		err := rclient.Delete(ctx, &pod)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Relates to https://github.com/VictoriaMetrics/operator/issues/744

Currently with larger vmclusters that may need more time to handle vmstorage rollouts, there's a `storage.vminsertConnsShutdownDuration` flag we can use to handle gracefully closing connections to vminsert while it rolls out. However the issue we're running into is that the operator uses a hard-coded value of 30s to set the grace period for delete, so we increasing the value used for the `storage.vminsertConnsShutdownDuration` flag doesn't help since vmstorage pods will always be killed after 30 seconds. 