### PR TITLE
feat: support for global discoveryRole configuration and per-ServiceMonitor discoveryRole

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 	"github.com/kelseyhightower/envconfig"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -280,6 +280,7 @@ type BaseOperatorConf struct {
 		Probe              bool `default:"true"`
 		AlertmanagerConfig bool `default:"true"`
 		ScrapeConfig       bool `default:"true"`
+		DiscoveryRole      string
 	}
 	FilterChildLabelPrefixes      []string `default:""`
 	FilterChildAnnotationPrefixes []string `default:""`

--- a/internal/controller/operator/converter/apis.go
+++ b/internal/controller/operator/converter/apis.go
@@ -5,6 +5,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/vmagent"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,6 +99,7 @@ func ConvertServiceMonitor(serviceMon *promv1.ServiceMonitor, conf *config.BaseO
 			Labels:      FilterPrefixes(serviceMon.Labels, conf.FilterPrometheusConverterLabelPrefixes),
 		},
 		Spec: vmv1beta1.VMServiceScrapeSpec{
+			DiscoveryRole:   vmagent.ServiceMonitorDiscoveryRole(serviceMon, conf.EnabledPrometheusConverter.DiscoveryRole),
 			JobLabel:        serviceMon.Spec.JobLabel,
 			TargetLabels:    serviceMon.Spec.TargetLabels,
 			PodTargetLabels: serviceMon.Spec.PodTargetLabels,

--- a/internal/controller/operator/factory/k8stools/version.go
+++ b/internal/controller/operator/factory/k8stools/version.go
@@ -67,3 +67,12 @@ func MustConvertObjectVersionsJSON[A, B any](src *A, objectName string) *B {
 	}
 	return &dst
 }
+
+// IsEndpointSliceSupported check if EndpointSlice is supported by kubernetes API server
+// https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
+func IsEndpointSliceSupported() bool {
+	if ServerMajorVersion == 1 && ServerMinorVersion >= 21 {
+		return true
+	}
+	return false
+}

--- a/internal/controller/operator/factory/k8stools/version_test.go
+++ b/internal/controller/operator/factory/k8stools/version_test.go
@@ -1,1 +1,39 @@
 package k8stools
+
+import "testing"
+
+func TestIsEndpointSlicesSupported(t *testing.T) {
+	tests := []struct {
+		name  string
+		want  bool
+		major uint64
+		minor uint64
+	}{
+		{
+			name:  "yes",
+			major: 1,
+			minor: 28,
+			want:  true,
+		},
+		{
+			name:  "yes",
+			major: 1,
+			minor: 21,
+			want:  true,
+		},
+		{
+			name:  "no",
+			major: 1,
+			minor: 20,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ServerMinorVersion = tt.minor
+			ServerMajorVersion = tt.major
+			if got := IsEndpointSliceSupported(); got != tt.want {
+				t.Errorf("IsEndpointSliceSupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -825,6 +825,9 @@ const (
 	kubernetesSDRolePod            = "pod"
 	kubernetesSDRoleIngress        = "ingress"
 	kubernetesSDRoleNode           = "node"
+
+	// discoveryRoleAnnotation is the annotation used to identify the service discovery role.
+	discoveryRoleAnnotation = "operator.victoriametrics.com/discovery-role"
 )
 
 var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)


### PR DESCRIPTION
see https://github.com/VictoriaMetrics/operator/issues/1162

1. **Global discoveryRole Configuration**: Add support for a global configuration in VictoriaMetrics-Operator to allow users to specify the discoveryRole (such as endpointslice) by default across all VMServiceScrape resources.
```yaml
env:
  - name: VM_ENABLEDPROMETHEUSCONVERTER_DISCOVERYROLE
    value: "endpointslices"

```
2. **Per-ServiceMonitor discoveryRole Configuration**: Enable the ability to configure the discoveryRole field individually within ServiceMonitor resources. This would provide finer control over discovery methods at the service level.
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  annotations:
    operator.victoriametrics.com/discovery-role: endpointslices
```
