### PR TITLE
vmagent: change the default ClusterRole and ClusterRoleBinding name t…

### DIFF
--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -587,7 +587,7 @@ func (cr VMAgent) IsOwnsServiceAccount() bool {
 }
 
 func (cr VMAgent) GetClusterRoleName() string {
-	return fmt.Sprintf("monitoring:%s:vmagent-cluster-access-%s", cr.Namespace, cr.Name)
+	return fmt.Sprintf("monitoring:%s:vmagent-%s", cr.Namespace, cr.Name)
 }
 
 func (cr VMAgent) GetNSName() string {

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -587,7 +587,7 @@ func (cr VMAgent) IsOwnsServiceAccount() bool {
 }
 
 func (cr VMAgent) GetClusterRoleName() string {
-	return fmt.Sprintf("monitoring:vmagent-cluster-access-%s", cr.Name)
+	return fmt.Sprintf("monitoring:%s:vmagent-cluster-access-%s", cr.Namespace, cr.Name)
 }
 
 func (cr VMAgent) GetNSName() string {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,13 @@ aliases:
 
 ## tip
 
+- **Update note 1: the default ClusterRole and ClusterRoleBinding names change to `monitoring:<vmagent-namespace>:vmagent-cluster-access-<vmagentName>` when `vmagentSpec.ServiceAccountName` is null, the old `monitoring:vmagent-cluster-access-<vmagentName>` ClusterRole and ClusterRoleBinding need to be cleared manually.**
+
+- [alerts]: added cluster label for multicluster alerts.
+- [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): change the default ClusterRole and ClusterRoleBinding name to avoid resource collisions when `vmagentSpec.ServiceAccountName` is null. See [this issue](https://github.com/VictoriaMetrics/operator/issues/891).
 - [vmoperator](https://docs.victoriametrics.com/operator/): bump default version of VictoriaMetrics components to [1.107.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.107.0).
+- [vmoperator](https://docs.victoriametrics.com/operator/): fix the behaviors of `vmagentSpec.ScrapeConfigSelector` and `vmagentSpec.scrapeConfigNamespaceSelector` when `vmagentSpec.selectAllByDefault=false`. Previously, the VMScrapeConfig could be ignored.
+- [vmoperator](https://docs.victoriametrics.com/operator/): fix the behaviors of `xxxNamespaceSelector` when `vmagentSpec.selectAllByDefault=true`. See [this doc](https://docs.victoriametrics.com/operator/resources/vmagent/#scraping) for detailed rules.
 
 ## [v0.50.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.50.0) - 22 Nov 2024
 
@@ -21,11 +27,8 @@ aliases:
 - [vmoperator](https://docs.victoriametrics.com/operator/): bump default version of VictoriaMetrics components to [1.106.1](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.106.1).
 - [vmoperator](https://docs.victoriametrics.com/operator/): add new variable `VM_VMSERVICESCRAPEDEFAULT_ENFORCEENDPOINTSLICES` to use `endpointslices` instead of `endpoints` as discovery role for VMServiceScrape when generate scrape config for VMAgent.
 - [vmoperator](https://docs.victoriametrics.com/operator/): adds new flag `loggerJSONFields` to the operator logger configuration. It allows to change json encoder fields. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1157) for details.
-- [vmoperator](https://docs.victoriametrics.com/operator/): fix the behaviors of `vmagentSpec.ScrapeConfigSelector` and `vmagentSpec.scrapeConfigNamespaceSelector` when `vmagentSpec.selectAllByDefault=false`. Previously, the VMScrapeConfig could be ignored.
-- [vmoperator](https://docs.victoriametrics.com/operator/): fix the behaviors of `xxxNamespaceSelector` when `vmagentSpec.selectAllByDefault=true`. See [this doc](https://docs.victoriametrics.com/operator/resources/vmagent/#scraping) for detailed rules.
 - [api](https://docs.victoriametrics.com/operator/api): adds new status field `observedGeneration`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1155) for details.
 - [api](https://docs.victoriametrics.com/operator/api): unify `updateStatus` field for CRD objects. It replaces `status`, `clusterStatus` and `singleStatus` for `VLogs`, `VMCluster` and `VMSingle` with generic `updateStatus`.
-- [alerts]: added cluster label for multicluster alerts.
 
 ## [v0.49.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.49.1) - 11 Nov 2024
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,6 @@ aliases:
 
 ## tip
 
-- **Update note 1: the default ClusterRole and ClusterRoleBinding names change to `monitoring:<vmagent-namespace>:vmagent-cluster-access-<vmagentName>` when `vmagentSpec.ServiceAccountName` is null, the old `monitoring:vmagent-cluster-access-<vmagentName>` ClusterRole and ClusterRoleBinding need to be cleared manually.**
-
 - [alerts]: added cluster label for multicluster alerts.
 - [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): change the default ClusterRole and ClusterRoleBinding name to avoid resource collisions when `vmagentSpec.ServiceAccountName` is null. See [this issue](https://github.com/VictoriaMetrics/operator/issues/891).
 - [vmoperator](https://docs.victoriametrics.com/operator/): bump default version of VictoriaMetrics components to [1.107.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.107.0).

--- a/internal/controller/operator/factory/vmagent/rbac.go
+++ b/internal/controller/operator/factory/vmagent/rbac.go
@@ -204,11 +204,13 @@ func ensureVMAgentCRBExist(ctx context.Context, cr *vmv1beta1.VMAgent, rclient c
 func buildVMAgentClusterRoleBinding(cr *vmv1beta1.VMAgent) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.GetClusterRoleName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.AllLabels(),
-			Annotations:     cr.AnnotationsFiltered(),
-			Finalizers:      []string{vmv1beta1.FinalizerName},
+			Name:        cr.GetClusterRoleName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.AllLabels(),
+			Annotations: cr.AnnotationsFiltered(),
+			Finalizers:  []string{vmv1beta1.FinalizerName},
+			// Kubernetes does not allow namespace-scoped resources to own cluster-scoped resources,
+			// use crd instead
 			OwnerReferences: cr.AsCRDOwner(),
 		},
 		Subjects: []rbacv1.Subject{
@@ -229,11 +231,13 @@ func buildVMAgentClusterRoleBinding(cr *vmv1beta1.VMAgent) *rbacv1.ClusterRoleBi
 func buildVMAgentClusterRole(cr *vmv1beta1.VMAgent) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.GetClusterRoleName(),
-			Namespace:       cr.GetNamespace(),
-			Labels:          cr.AllLabels(),
-			Annotations:     cr.AnnotationsFiltered(),
-			Finalizers:      []string{vmv1beta1.FinalizerName},
+			Name:        cr.GetClusterRoleName(),
+			Namespace:   cr.GetNamespace(),
+			Labels:      cr.AllLabels(),
+			Annotations: cr.AnnotationsFiltered(),
+			Finalizers:  []string{vmv1beta1.FinalizerName},
+			// Kubernetes does not allow namespace-scoped resources to own cluster-scoped resources,
+			// use crd instead
 			OwnerReferences: cr.AsCRDOwner(),
 		},
 		Rules: clusterWidePolicyRules,


### PR DESCRIPTION
…o avoid resource collisions when `vmagentSpec.ServiceAccountName` is null
cluster-scoped resources can't be reused by multiple namespace-scoped objects, since they could have different labels&annotations.

address https://github.com/VictoriaMetrics/operator/issues/891

