### PR TITLE
vmuser: fix reconciling the vmauth config

### DIFF
--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -581,7 +581,7 @@ func (cr *VMAuth) AsCRDOwner() []metav1.OwnerReference {
 // IsUnmanaged checks if object should managed any  config objects
 func (cr *VMAuth) IsUnmanaged() bool {
 	return (!cr.Spec.SelectAllByDefault && cr.Spec.UserSelector == nil && cr.Spec.UserNamespaceSelector == nil) ||
-		cr.Spec.ExternalConfig.SecretRef == nil ||
+		cr.Spec.ExternalConfig.SecretRef != nil ||
 		cr.Spec.ExternalConfig.LocalPath != ""
 }
 


### PR DESCRIPTION
Due to a logic bug in `VMAuth.IsUnmanaged()`, the VMUser reconiliation does not update the corresponding VMAuth resources' configuration:
https://github.com/VictoriaMetrics/operator/blob/master/internal/controller/operator/vmuser_controller.go#L99

This bug is hidden/mitigated currently because the VMAuth reconciliation by default is requeued every 60 seconds:
https://github.com/VictoriaMetrics/operator/blob/master/internal/controller/operator/vmauth_controller.go#L101