### PR TITLE
{make,ci}: publish images to both docker and quay

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,6 +85,9 @@ jobs:
           TAG=${TAG} make test-e2e
           if [ -n '${{secrets.REPO_KEY}}' ]; then
             echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
+            if [ -n '${{secrets.QUAY_ACCESSKEY}}' ]; then
+              echo ${{secrets.QUAY_ACCESSKEY}} | docker login quay.io --username '${{secrets.QUAY_USER}}' --password-stdin
+            fi
             make publish
           else
             echo "there is no docker secret, just build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           make lint test build build-installer
           echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
+          echo ${{secrets.QUAY_ACCESSKEY}} | docker login quay.io --username '${{secrets.QUAY_USER}}' --password-stdin
           make publish
           TAG=${TAG} make olm
           gh release upload ${{github.event.release.tag_name}} ./dist/install-no-webhook.yaml#install-no-webhook.yaml --clobber || echo "fix me NOT enough security permissions"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Image URL to use all building/pushing image targets
 REGISTRY ?= docker.io
+PUBLISH_REGISTRIES ?= docker.io quay.io
 REPO = operator
 ROOT ?= ./cmd
 ORG ?= victoriametrics
@@ -198,7 +199,9 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 		--build-arg ROOT=$(ROOT) \
 		--build-arg BUILDINFO=$(BUILDINFO) \
 		${DOCKER_BUILD_ARGS} \
-		--tag $(REGISTRY)/$(ORG)/$(REPO):$(TAG) \
+		$(foreach registry,$(PUBLISH_REGISTRIES), \
+		--tag $(registry)/$(ORG)/$(REPO):$(TAG) \
+		) \
 		-f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm vm-builder
 	rm Dockerfile.cross


### PR DESCRIPTION
Updates workflows and release tasks for make to push images to both quay and dockerhub.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/4116