### PR TITLE
Fix vmagent instances setting license args twice

### DIFF
--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -445,7 +445,6 @@ func makeSpecForVMAgent(cr *vmv1beta1.VMAgent, ssCache *scrapesSecretsCache) (*c
 	if len(cr.Spec.ExtraEnvs) > 0 {
 		args = append(args, "-envflag.enable=true")
 	}
-	args = cr.Spec.License.MaybeAddToArgs(args, vmv1beta1.SecretsDir)
 
 	var envs []corev1.EnvVar
 	envs = append(envs, cr.Spec.ExtraEnvs...)


### PR DESCRIPTION
This arg is currently set twice for vmagent. Once [here](https://github.com/solidDoWant/operator/blob/b26dcb35ccf227079a5bf0506d722c24d7dc6b41/internal/controller/operator/factory/vmagent/vmagent.go#L610-L611), and once on the on (the now deleted) line 448. This results in it being passed twice in the pod spec.