### PR TITLE
config: update relabelingConfig to relabelConfigs and fix target_labe…

### DIFF
--- a/config/examples/vmagent_istio.yaml
+++ b/config/examples/vmagent_istio.yaml
@@ -31,10 +31,10 @@ spec:
         # use special workaround for local endpoint scrape
         # rewrite scheme to http, if pod IP is equal to local pod IP
         # it allows to have multiple vmagent replicas with istio
-        relabelingConfig:
+        relabelConfigs:
           - source_labels: [__meta_kubernetes_pod_ip]
             regex: "%{POD_IP}"
-            target_label: __scheme
+            target_label: __scheme__
             replacement: http
         tlsConfig:
           caFile: /etc/istio-certs/root-cert.pem


### PR DESCRIPTION
This pull request addresses an issue with the relabeling configuration in the vmAgent Istio example. The existing configuration contains incorrect key names, which could lead to unintended behavior or misconfigurations if someone follow this example.

Key Fixes:
Corrected Relabeling Configuration:
The property `relabelingConfig` has been updated to the correct `relabelConfigs` .
Fixed Target Label Syntax:
Updated `target_label: __scheme` to `target_label: __scheme__` .

