### PR TITLE
Fix request load balancer ignoring pod metadata

### DIFF
--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -94,6 +94,23 @@ func (cr *VMCluster) VMAuthLBSelectorLabels() map[string]string {
 	}
 }
 
+// VMAuthLBPodLabels returns pod labels for vmclusterlb-vmauth-balancer cluster component
+func (cr *VMCluster) VMAuthLBPodLabels() map[string]string {
+	selectorLabels := cr.VMAuthLBSelectorLabels()
+	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
+		return selectorLabels
+	}
+	return labels.Merge(cr.Spec.RequestsLoadBalancer.Spec.PodMetadata.Labels, selectorLabels)
+}
+
+// VMAuthLBPodAnnotations returns pod annotations for vmstorage cluster component
+func (cr *VMCluster) VMAuthLBPodAnnotations() map[string]string {
+	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
+		return make(map[string]string)
+	}
+	return cr.Spec.RequestsLoadBalancer.Spec.PodMetadata.Annotations
+}
+
 // GetVMAuthLBName returns prefixed name for the loadbalanacer components
 func (cr *VMCluster) GetVMAuthLBName() string {
 	return fmt.Sprintf("vmclusterlb-%s", cr.Name)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ aliases:
 * FEATURE: [operator](https://docs.victoriametrics.com/operator: log fields changes diff for `Deployment`, `StatefulSet`, `Service`, `PDB`, `HPA` and `VMServiceScrape` during reconcile process. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1271) for details.
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): properly track immutable fields changes for `StatefulSet`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1271) for details.
+* BUGFIX: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): properly propagate `podMetadata` to `requestsLoadBalancer` `Deployment`. See [this PR](https://github.com/VictoriaMetrics/operator/pull/1275/) for details. Thanks to the @solidDoWant
 
 ## [v0.54.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.54.1)
 

--- a/internal/controller/operator/factory/vmcluster/vmcluster.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster.go
@@ -1521,7 +1521,8 @@ func buildVMauthLBDeployment(cr *vmv1beta1.VMCluster) (*appsv1.Deployment, error
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: cr.VMAuthLBSelectorLabels(),
+					Labels:      cr.VMAuthLBPodLabels(),
+					Annotations: cr.VMAuthLBPodAnnotations(),
 				},
 				Spec: corev1.PodSpec{
 					Volumes:            volumes,


### PR DESCRIPTION
The VMCluster request load balancer resource currently completely ignores the pod metadata field. This PR sets the load balancer labels and annotations in the same way that other they're set for other components.