### PR TITLE
Fix doc VMAuth HA example

### DIFF
--- a/docs/resources/vmauth.md
+++ b/docs/resources/vmauth.md
@@ -119,7 +119,7 @@ kind: VMAuth
 metadata:
   name: vmauth-example
 spec:
-    replicas: 3
+    replicaCount: 3
     # ...
 ```
 


### PR DESCRIPTION
Hello,

I think the example should use replicaCount instead of replicas (https://docs.victoriametrics.com/operator/api/#vmauthspec-replicacount).

Thank you :)