### PR TITLE
Fix VLogs resource using invalid image tag by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ type BaseOperatorConf struct {
 
 	VLogsDefault struct {
 		Image   string `default:"victoriametrics/victoria-logs"`
-		Version string `default:"v1.17.0-victorialog"`
+		Version string `default:"v1.17.0-victorialogs"`
 		// ignored
 		ConfigReloadImage   string `ignored:"true"`
 		Port                string `default:"9428"`


### PR DESCRIPTION
[This commit](https://github.com/VictoriaMetrics/operator/commit/f0aa09cd76ed3a2918085b14cf3f5e4037d98a92) removed the `s` from the default `VLog` container image tag. [As shown here](https://hub.docker.com/layers/victoriametrics/victoria-logs/v1.17.0-victorialogs/images/sha256-cc9bee8039d8e03eaf62a3ecb77ed6b389509f9ed1cb10a3626d137d7580bb2c), the tag should end in `victorialogs` not `victorialog`.