### PR TITLE
fix: use correct TokenId value when building rocketchat config

### DIFF
--- a/internal/controller/operator/factory/alertmanager/config.go
+++ b/internal/controller/operator/factory/alertmanager/config.go
@@ -809,7 +809,7 @@ func (cb *configBuilder) buildRocketchat(rc vmv1beta1.RocketchatConfig) error {
 		toYaml("api_url", *rc.APIURL)
 	}
 	if rc.TokenID != nil {
-		sv, err := cb.fetchSecretValue(rc.Token)
+		sv, err := cb.fetchSecretValue(rc.TokenID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When using rocketchat in alertmanager for alert, it appears same secret value gets inserted both into _token_id_ and _token_, although a different secret key is referenced in VmAlertManagerConfig.

```yaml
    ...
    rocketchat_configs:
    - api_url: <url>
      channel: <channel>
      token:
        name: alertmanager
        key: rocketchat_token
      token_id:
        name: alertmanager
        key: rocketchat_token_id
   ....
```

![image](https://github.com/user-attachments/assets/12222dc2-017f-4734-9b40-9f44563d3b82)

I think I located the issue in _config.go_, where the wrong variable is used to retrieve the secret value.
