### PR TITLE
docs: Fix docker build uid issue. Move docs related make commands into docs dir. Move docs tasks into docs/Makefile.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,43 @@
+UID := "$(shell id -u)"
+PLATFORM := $(shell uname -m)
+DOCKER_PLATFORM := "linux/$(if $(findstring $(PLATFORM),arm64),arm64,amd64)"
+
+REPODIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+WORKDIR := $(REPODIR)/..
+
+CONTAINER_TOOL ?= docker
+
+# These commands must be run from the repository root
+
+
+docs-image:
+	if [ ! -d $(WORKDIR)/vmdocs ]; then \
+		git clone --depth 1 git@github.com:VictoriaMetrics/vmdocs $(WORKDIR)/vmdocs; \
+	fi; \
+	cd $(WORKDIR)/vmdocs && \
+	git checkout main && \
+	git pull origin main && \
+	cd .. && \
+	docker build \
+		-t vmdocs-docker-package \
+		--build-arg UID=$(UID) \
+		--platform $(DOCKER_PLATFORM) \
+		vmdocs
+
+docs-debug: docs docs-image
+	$(CONTAINER_TOOL) run \
+		--rm \
+		--name vmdocs \
+		-p 1313:1313 \
+		-v ./docs:/opt/docs/content/operator vmdocs
+
+docs-images-to-webp: docs-image
+	$(CONTAINER_TOOL) run \
+		--rm \
+		--platform $(DOCKER_PLATFORM) \
+		--entrypoint /usr/bin/find \
+		--name vmdocs \
+		-v ./docs:/opt/docs/content/operator vmdocs \
+			content/operator \
+				-regex ".*\.\(png\|jpg\|jpeg\)" \
+				-exec sh -c 'cwebp -preset drawing -m 6 -o $$(echo {} | cut -f-1 -d.).webp {} && rm -rf {}' {} \;


### PR DESCRIPTION



Locally I was getting the error because of undefined UID var. I've fixed it alinging the solution with how docs organized in VictoriaMetrics repo.

```
# make docs-debug

...

3.531 OK: 33 MiB in 44 packages
5.535 adduser: uid '0' in use
------
Dockerfile:14
--------------------
  13 |
  14 | >>> RUN \
  15 | >>>   apk add \
  16 | >>>     curl \
  17 | >>>     jq \
  18 | >>>     libstdc++ \
  19 | >>>     libwebp-tools \
  20 | >>>     gcompat && \
21 | >>>   apk add
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
  22 | >>>     icu-libs && \
23 | >>>   apk add
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
  24 | >>>     dart-sass && \
  25 | >>>   curl \
  26 | >>>     -fsSL ${HUGO_URL} \
  27 | >>>     --output hugo.tar.gz && \
  28 | >>>   tar -xzf hugo.tar.gz && \
  29 | >>>   mv hugo /usr/bin/ && \
  30 | >>>   mkdir /opt/docs && \
  31 | >>>   deluser node && \
  32 | >>>   adduser -u ${UID} -D hugo
  33 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add     curl     jq
libstdc++     libwebp-tools     gcompat &&   apk add
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/main/
icu-libs &&   apk add
--repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
dart-sass &&   curl     -fsSL ${HUGO_URL}     --output hugo.tar.gz &&
tar -xzf hugo.tar.gz &&   mv hugo /usr/bin/ &&   mkdir /opt/docs &&
deluser node &&   adduser -u ${UID} -D hugo" did not complete
successfully: exit code: 1
```