### PR TITLE
config: sync installer operator labels with Helm-installed version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,11 @@ publish:
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
-	mkdir -p dist
+	mkdir -p dist && rm -rf dist/*
 	cd config/manager && $(KUSTOMIZE) edit set image manager=$(REGISTRY)/$(ORG)/$(REPO):$(TAG)
 	$(KUSTOMIZE) build config/base > dist/install-no-webhook.yaml
 	$(KUSTOMIZE) build config/base-with-webhook > dist/install-with-webhook.yaml
+	$(KUSTOMIZE) build config/crd/overlay > dist/crd.yaml
 
 olm: operator-sdk opm yq docs
 	rm -rf bundle*

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -2,8 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    # deprecated, could not be removed because of deployment match selector immutability
     control-plane: vm-operator
-    app.kubernetes.io/name: vm-operator
+
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: victoria-metrics-operator
     app.kubernetes.io/managed-by: kustomize
   name: operator-metrics-service
   namespace: vm

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: vm-operator
-    app.kubernetes.io/name: vm-operator
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: victoria-metrics-operator
     app.kubernetes.io/managed-by: kustomize
   name: vm
 ---
@@ -13,8 +13,11 @@ metadata:
   name: operator
   namespace: vm
   labels:
+    # deprecated, could not be removed because of deployment match selector immutability
     control-plane: vm-operator
-    app.kubernetes.io/name: vm-operator
+
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: victoria-metrics-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
@@ -26,7 +29,12 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        # deprecated, could not be removed because of deployment match selector immutability
         control-plane: vm-operator
+
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/name: victoria-metrics-operator
+        app.kubernetes.io/managed-by: kustomize
     spec:
       affinity:
         nodeAffinity:

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -8,4 +8,5 @@ spec:
   - port: 443
     targetPort: 9443
   selector:
-    control-plane: vm-operator
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: victoria-metrics-operator

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -68,9 +68,9 @@ head -n 10 operator-and-crds.yaml
 # kind: Namespace
 # metadata:
 # labels:
+# app.kubernetes.io/instance: vmoperator
 # app.kubernetes.io/managed-by: kustomize
-# app.kubernetes.io/name: vm-operator
-# control-plane: vm-operator
+# app.kubernetes.io/name=victoria-metrics-operator
 # name: vm
 # ---
 ```
@@ -90,7 +90,7 @@ Once it's running, it will start watching for VictoriaMetrics custom resources a
 
 You can confirm the operator is running by checking the pod status:
 ```sh
-kubectl get pods -n vm -l "control-plane=vm-operator"
+kubectl get pods -n vm -l "app.kubernetes.io/name=victoria-metrics-operator"
 
 # Output:
 # NAME                           READY   STATUS    RESTARTS   AGE
@@ -117,7 +117,7 @@ The operator is configured using [environment variables](https://docs.victoriame
 You can consult the documentation or explore the variables directly in your cluster (note that `kubectl exec` may require [additional permissions](https://discuss.kubernetes.io/t/adding-permission-to-exec-commands-in-containers-inside-pods-in-a-certain-namespace/22821/2)).
 Here’s an example showing how to get the default CPU and memory limits applied to the VMSingle resource:
 ```sh 
-OPERATOR_POD_NAME=$(kubectl get pod -l "control-plane=vm-operator"  -n vm -o jsonpath="{.items[0].metadata.name}");
+OPERATOR_POD_NAME=$(kubectl get pod -l "app.kubernetes.io/name=victoria-metrics-operator"  -n vm -o jsonpath="{.items[0].metadata.name}");
 kubectl exec -n vm "$OPERATOR_POD_NAME" -- /app --printDefaults 2>&1 | grep VMSINGLEDEFAULT_RESOURCE;
 
 # Output:

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -19,6 +19,7 @@ menu:
 1. Make sure that the release branch has no security issues.
 1. Update config-reloader image in [config.go](https://github.com/VictoriaMetrics/operator/blob/a8dd788070d4c012753f7e8e32a3b13e0c50f9af/internal/config/config.go#L108) with the name of new tag.
 1. Run `make docs` in order to update variables documentation files.
+1. Run `make build-installer` to build Github tag artefacts. Everything inside `/dist` should be included to the release.
 1. Cut new version in [CHANGELOG.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/CHANGELOG.md)
 1. create release tag with `git tag vX.X.X` command and push it to the origin - `git push origin vX.X.X`
 1. Go to github [Releases Page](https://github.com/VictoriaMetrics/operator/releases) and `Draft new Release` with the name of pushed tag.


### PR DESCRIPTION
The goal of this update is to ensure that the examples in the Operator quick start guide are also applicable when the Operator is installed via Helm charts.

Fixes https://github.com/VictoriaMetrics/operator/issues/1337

Tested in Kind with https://github.com/VictoriaMetrics/debug-notes/tree/main/operator/quick-start,

installed v0.58.0, than this version, than again v0.58.0. worked