### PR TITLE
docs: add apiVersion to example VLogs CRD

### DIFF
--- a/docs/resources/vlogs.md
+++ b/docs/resources/vlogs.md
@@ -112,6 +112,7 @@ Also, you can specify requests without limits - in this case default values for 
 ## Examples
 
 ```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
 kind: VLogs
 metadata:
   name: example


### PR DESCRIPTION
The apiVersion was missing in the example CRD for VLogs in the documentation. In this merge request, I’ve added it.