### PR TITLE
docs/configuration: Enchance env variables related stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ VictoriaMetrics provides [helm charts](https://github.com/VictoriaMetrics/helm-c
 
 ## Configuration
 
- Operator configured by env variables, list of it can be found at [link](https://docs.victoriametrics.com/operator/vars.html)
+ Operator configured by env variables, list of it can be found at [link](https://docs.victoriametrics.com/operator/configuration/#environment-variables)
 
  It defines default configuration options, like images for components, timeouts, features.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -740,7 +740,7 @@ Operator will preserve `annotations`, but any changes to it will be ignored. `la
 
 ### Features
 
-- [vmoperator](https://docs.victoriametrics.com/operator/) add ability to print default values for all [operator variables](https://docs.victoriametrics.com/operator/vars). See [this issue](https://github.com/VictoriaMetrics/operator/issues/675) for details.
+- [vmoperator](https://docs.victoriametrics.com/operator/) add ability to print default values for all [operator variables](https://docs.victoriametrics.com/operator/configuration/#environment-variables). See [this issue](https://github.com/VictoriaMetrics/operator/issues/675) for details.
 
 ## [v0.37.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.37.1)
 
@@ -821,8 +821,8 @@ Operator will preserve `annotations`, but any changes to it will be ignored. `la
 - [vmcluster](https://docs.victoriametrics.com/operator/api#vmagent): add [example config](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmcluster_with_additional_claim.yaml) for cluster with custom storage claims.
 - [vmrule](https://docs.victoriametrics.com/operator/api#vmrule): support `update_entries_limit` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/691) for details.
 - [vmrule](https://docs.victoriametrics.com/operator/api#vmrule): support `keep_firing_for` field in rules, refer to [alerting rules](https://docs.victoriametrics.com/vmalert/#alerting-rules). See [this PR](https://github.com/VictoriaMetrics/operator/pull/711) for details.
-- [vmoperator parameters](https://docs.victoriametrics.com/operator/vars): Add option `VM_ENABLESTRICTSECURITY` and enable strict security context by default. See [this issue](https://github.com/VictoriaMetrics/operator/issues/637), [this](https://github.com/VictoriaMetrics/operator/pull/692/) and [this](https://github.com/VictoriaMetrics/operator/pull/712) PR for details.
-- [vmoperator parameters](https://docs.victoriametrics.com/operator/vars): change option `VM_PSPAUTOCREATEENABLED` default value from `true` to `false` cause PodSecurityPolicy already got deprecated since [kubernetes v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125). See [this pr](https://github.com/VictoriaMetrics/operator/pull/726) for details.
+- [vmoperator parameters](https://docs.victoriametrics.com/operator/configuration/#environment-variables): Add option `VM_ENABLESTRICTSECURITY` and enable strict security context by default. See [this issue](https://github.com/VictoriaMetrics/operator/issues/637), [this](https://github.com/VictoriaMetrics/operator/pull/692/) and [this](https://github.com/VictoriaMetrics/operator/pull/712) PR for details.
+- [vmoperator parameters](https://docs.victoriametrics.com/operator/configuration/#environment-variables): change option `VM_PSPAUTOCREATEENABLED` default value from `true` to `false` cause PodSecurityPolicy already got deprecated since [kubernetes v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#psp-v125). See [this pr](https://github.com/VictoriaMetrics/operator/pull/726) for details.
 
 ## [v0.35.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.35.1)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,7 +36,7 @@ With Operator deployment:
 You can use `VM_CONTAINERREGISTRY` parameter for operator:
 
 - See details about tuning [operator settings here](https://docs.victoriametrics.com/operator/setup#settings).
-- See [available operator settings](https://docs.victoriametrics.com/operator/vars) here.
+- See [available operator settings](https://docs.victoriametrics.com/operator/configuration/#environment-variables) here.
 
 ## How to set up automatic backups?
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,125 +1,124 @@
-
-| variable name | variable default value | variable required | variable description |
-| --- | --- | --- | --- |
-| VM_METRICS_VERSION | v1.117.0 | false |  |
-| VM_LOGS_VERSION | v1.21.0 | false |  |
-| VM_USECUSTOMCONFIGRELOADER | false | false | enables custom config reloader for vmauth and vmagent, it should speed-up config reloading process. |
-| VM_CONTAINERREGISTRY | - | false | container registry name prefix, e.g. docker.io |
-| VM_CUSTOMCONFIGRELOADERIMAGE | victoriametrics/operator:config-reloader-v0.57.0 | false |  |
-| VM_PSPAUTOCREATEENABLED | false | false |  |
-| VM_CONFIG_RELOADER_LIMIT_CPU | unlimited | false | defines global resource.limits.cpu for all config-reloader containers |
-| VM_CONFIG_RELOADER_LIMIT_MEMORY | unlimited | false | defines global resource.limits.memory for all config-reloader containers |
-| VM_CONFIG_RELOADER_REQUEST_CPU | - | false | defines global resource.requests.cpu for all config-reloader containers |
-| VM_CONFIG_RELOADER_REQUEST_MEMORY | - | false | defines global resource.requests.memory for all config-reloader containers |
-| VM_VLOGSDEFAULT_IMAGE | victoriametrics/victoria-logs | false |  |
-| VM_VLOGSDEFAULT_VERSION | ${VM_LOGS_VERSION}-victorialogs | false |  |
-| VM_VLOGSDEFAULT_PORT | 9428 | false |  |
-| VM_VLOGSDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VLOGSDEFAULT_RESOURCE_LIMIT_MEM | 1500Mi | false |  |
-| VM_VLOGSDEFAULT_RESOURCE_LIMIT_CPU | 1200m | false |  |
-| VM_VLOGSDEFAULT_RESOURCE_REQUEST_MEM | 500Mi | false |  |
-| VM_VLOGSDEFAULT_RESOURCE_REQUEST_CPU | 150m | false |  |
-| VM_VMALERTDEFAULT_IMAGE | victoriametrics/vmalert | false |  |
-| VM_VMALERTDEFAULT_VERSION | ${VM_METRICS_VERSION} | false |  |
-| VM_VMALERTDEFAULT_CONFIGRELOADIMAGE | jimmidyson/configmap-reload:v0.3.0 | false |  |
-| VM_VMALERTDEFAULT_PORT | 8080 | false |  |
-| VM_VMALERTDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMALERTDEFAULT_RESOURCE_LIMIT_MEM | 500Mi | false |  |
-| VM_VMALERTDEFAULT_RESOURCE_LIMIT_CPU | 200m | false |  |
-| VM_VMALERTDEFAULT_RESOURCE_REQUEST_MEM | 200Mi | false |  |
-| VM_VMALERTDEFAULT_RESOURCE_REQUEST_CPU | 50m | false |  |
-| VM_VMALERTDEFAULT_CONFIGRELOADERCPU | 10m | false | deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMALERTDEFAULT_CONFIGRELOADERMEMORY | 25Mi | false | deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
-| VM_VMSERVICESCRAPEDEFAULT_ENFORCEENDPOINTSLICES | false | false | Use endpointslices instead of endpoints as discovery role for vmservicescrape when generate scrape config for vmagent. |
-| VM_VMAGENTDEFAULT_IMAGE | victoriametrics/vmagent | false |  |
-| VM_VMAGENTDEFAULT_VERSION | ${VM_METRICS_VERSION} | false |  |
-| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1 | false |  |
-| VM_VMAGENTDEFAULT_PORT | 8429 | false |  |
-| VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMAGENTDEFAULT_RESOURCE_LIMIT_MEM | 500Mi | false |  |
-| VM_VMAGENTDEFAULT_RESOURCE_LIMIT_CPU | 200m | false |  |
-| VM_VMAGENTDEFAULT_RESOURCE_REQUEST_MEM | 200Mi | false |  |
-| VM_VMAGENTDEFAULT_RESOURCE_REQUEST_CPU | 50m | false |  |
-| VM_VMAGENTDEFAULT_CONFIGRELOADERCPU | 10m | false | deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMAGENTDEFAULT_CONFIGRELOADERMEMORY | 25Mi | false | deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
-| VM_VMSINGLEDEFAULT_IMAGE | victoriametrics/victoria-metrics | false |  |
-| VM_VMSINGLEDEFAULT_VERSION | ${VM_METRICS_VERSION} | false |  |
-| VM_VMSINGLEDEFAULT_PORT | 8429 | false |  |
-| VM_VMSINGLEDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMSINGLEDEFAULT_RESOURCE_LIMIT_MEM | 1500Mi | false |  |
-| VM_VMSINGLEDEFAULT_RESOURCE_LIMIT_CPU | 1200m | false |  |
-| VM_VMSINGLEDEFAULT_RESOURCE_REQUEST_MEM | 500Mi | false |  |
-| VM_VMSINGLEDEFAULT_RESOURCE_REQUEST_CPU | 150m | false |  |
-| VM_VMCLUSTERDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_IMAGE | victoriametrics/vmselect | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_VERSION | ${VM_METRICS_VERSION}-cluster | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_PORT | 8481 | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_MEM | 1000Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_CPU | 500m | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_MEM | 500Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_CPU | 100m | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_IMAGE | victoriametrics/vmstorage | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VERSION | ${VM_METRICS_VERSION}-cluster | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMINSERTPORT | 8400 | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMSELECTPORT | 8401 | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_PORT | 8482 | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_LIMIT_MEM | 1500Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_LIMIT_CPU | 1000m | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_MEM | 500Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_CPU | 250m | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_IMAGE | victoriametrics/vminsert | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_VERSION | ${VM_METRICS_VERSION}-cluster | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_PORT | 8480 | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_MEM | 500Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_CPU | 500m | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_MEM | 200Mi | false |  |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_CPU | 150m | false |  |
-| VM_VMALERTMANAGER_CONFIGRELOADERIMAGE | jimmidyson/configmap-reload:v0.3.0 | false |  |
-| VM_VMALERTMANAGER_CONFIGRELOADERCPU | 10m | false | deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMALERTMANAGER_CONFIGRELOADERMEMORY | 25Mi | false | deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
-| VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE | prom/alertmanager | false |  |
-| VM_VMALERTMANAGER_ALERTMANAGERVERSION | v0.28.1 | false |  |
-| VM_VMALERTMANAGER_LOCALHOST | 127.0.0.1 | false |  |
-| VM_VMALERTMANAGER_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMALERTMANAGER_RESOURCE_LIMIT_MEM | 256Mi | false |  |
-| VM_VMALERTMANAGER_RESOURCE_LIMIT_CPU | 100m | false |  |
-| VM_VMALERTMANAGER_RESOURCE_REQUEST_MEM | 56Mi | false |  |
-| VM_VMALERTMANAGER_RESOURCE_REQUEST_CPU | 30m | false |  |
-| VM_DISABLESELFSERVICESCRAPECREATION | false | false |  |
-| VM_VMBACKUP_IMAGE | victoriametrics/vmbackupmanager | false |  |
-| VM_VMBACKUP_VERSION | ${VM_METRICS_VERSION}-enterprise | false |  |
-| VM_VMBACKUP_PORT | 8300 | false |  |
-| VM_VMBACKUP_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMBACKUP_RESOURCE_LIMIT_MEM | 500Mi | false |  |
-| VM_VMBACKUP_RESOURCE_LIMIT_CPU | 500m | false |  |
-| VM_VMBACKUP_RESOURCE_REQUEST_MEM | 200Mi | false |  |
-| VM_VMBACKUP_RESOURCE_REQUEST_CPU | 150m | false |  |
-| VM_VMAUTHDEFAULT_IMAGE | victoriametrics/vmauth | false |  |
-| VM_VMAUTHDEFAULT_VERSION | ${VM_METRICS_VERSION} | false |  |
-| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE | quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1 | false |  |
-| VM_VMAUTHDEFAULT_PORT | 8427 | false |  |
-| VM_VMAUTHDEFAULT_USEDEFAULTRESOURCES | true | false |  |
-| VM_VMAUTHDEFAULT_RESOURCE_LIMIT_MEM | 300Mi | false |  |
-| VM_VMAUTHDEFAULT_RESOURCE_LIMIT_CPU | 200m | false |  |
-| VM_VMAUTHDEFAULT_RESOURCE_REQUEST_MEM | 100Mi | false |  |
-| VM_VMAUTHDEFAULT_RESOURCE_REQUEST_CPU | 50m | false |  |
-| VM_VMAUTHDEFAULT_CONFIGRELOADERCPU | 10m | false | deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMAUTHDEFAULT_CONFIGRELOADERMEMORY | 25Mi | false | deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
-| VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR | true | false |  |
-| VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE | true | false |  |
-| VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE | true | false |  |
-| VM_ENABLEDPROMETHEUSCONVERTER_PROBE | true | false |  |
-| VM_ENABLEDPROMETHEUSCONVERTER_ALERTMANAGERCONFIG | true | false |  |
-| VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG | true | false |  |
-| VM_FILTERCHILDLABELPREFIXES | - | false |  |
-| VM_FILTERCHILDANNOTATIONPREFIXES | - | false |  |
-| VM_PROMETHEUSCONVERTERADDARGOCDIGNOREANNOTATIONS | false | false | adds compare-options and sync-options for prometheus objects converted by operator. It helps to properly use converter with ArgoCD |
-| VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES | false | false |  |
-| VM_FILTERPROMETHEUSCONVERTERLABELPREFIXES | - | false | allows filtering for converted labels, labels with matched prefix will be ignored |
-| VM_FILTERPROMETHEUSCONVERTERANNOTATIONPREFIXES | - | false | allows filtering for converted annotations, annotations with matched prefix will be ignored |
-| VM_CLUSTERDOMAINNAME | - | false | Defines domain name suffix for in-cluster addresses most known ClusterDomainName is .cluster.local |
-| VM_APPREADYTIMEOUT | 80s | false | Defines deadline for deployment/statefulset to transit into ready state to wait for transition to ready state |
-| VM_PODWAITREADYTIMEOUT | 80s | false | Defines single pod deadline to wait for transition to ready state |
-| VM_PODWAITREADYINTERVALCHECK | 5s | false | Defines poll interval for pods ready check at statefulset rollout update |
-| VM_FORCERESYNCINTERVAL | 60s | false | configures force resync interval for VMAgent, VMAlert, VMAlertmanager and VMAuth. |
-| VM_ENABLESTRICTSECURITY | false | false | EnableStrictSecurity will add default `securityContext` to pods and containers created by operator Default PodSecurityContext include: 1. RunAsNonRoot: true 2. RunAsUser/RunAsGroup/FSGroup: 65534 '65534' refers to 'nobody' in all the used default images like alpine, busybox. If you're using customize image, please make sure '65534' is a valid uid in there or specify SecurityContext. 3. FSGroupChangePolicy: &onRootMismatch If KubeVersion>=1.20, use `FSGroupChangePolicy="onRootMismatch"` to skip the recursive permission change when the root of the volume already has the correct permissions 4. SeccompProfile:      type: RuntimeDefault Use `RuntimeDefault` seccomp profile by default, which is defined by the container runtime, instead of using the Unconfined (seccomp disabled) mode. Default container SecurityContext include: 1. AllowPrivilegeEscalation: false 2. ReadOnlyRootFilesystem: true 3. Capabilities:      drop:        - all turn off `EnableStrictSecurity` by default, see https://github.com/VictoriaMetrics/operator/issues/749 for details |
+| Environment variables |
+| --- |
+| VM_METRICS_VERSION: `v1.117.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
+| VM_LOGS_VERSION: `v1.21.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
+| VM_USECUSTOMCONFIGRELOADER: `false` <a href="#variables-vm-usecustomconfigreloader" id="variables-vm-usecustomconfigreloader">#</a><br>enables custom config reloader for vmauth and vmagent, it should speed-up config reloading process. |
+| VM_CONTAINERREGISTRY: `-` <a href="#variables-vm-containerregistry" id="variables-vm-containerregistry">#</a><br>container registry name prefix, e.g. docker.io |
+| VM_CUSTOMCONFIGRELOADERIMAGE: `victoriametrics/operator:config-reloader-v0.57.0` <a href="#variables-vm-customconfigreloaderimage" id="variables-vm-customconfigreloaderimage">#</a> |
+| VM_PSPAUTOCREATEENABLED: `false` <a href="#variables-vm-pspautocreateenabled" id="variables-vm-pspautocreateenabled">#</a> |
+| VM_CONFIG_RELOADER_LIMIT_CPU: `unlimited` <a href="#variables-vm-config-reloader-limit-cpu" id="variables-vm-config-reloader-limit-cpu">#</a><br>defines global resource.limits.cpu for all config-reloader containers |
+| VM_CONFIG_RELOADER_LIMIT_MEMORY: `unlimited` <a href="#variables-vm-config-reloader-limit-memory" id="variables-vm-config-reloader-limit-memory">#</a><br>defines global resource.limits.memory for all config-reloader containers |
+| VM_CONFIG_RELOADER_REQUEST_CPU: `-` <a href="#variables-vm-config-reloader-request-cpu" id="variables-vm-config-reloader-request-cpu">#</a><br>defines global resource.requests.cpu for all config-reloader containers |
+| VM_CONFIG_RELOADER_REQUEST_MEMORY: `-` <a href="#variables-vm-config-reloader-request-memory" id="variables-vm-config-reloader-request-memory">#</a><br>defines global resource.requests.memory for all config-reloader containers |
+| VM_VLOGSDEFAULT_IMAGE: `victoriametrics/victoria-logs` <a href="#variables-vm-vlogsdefault-image" id="variables-vm-vlogsdefault-image">#</a> |
+| VM_VLOGSDEFAULT_VERSION: `${VM_LOGS_VERSION}-victorialogs` <a href="#variables-vm-vlogsdefault-version" id="variables-vm-vlogsdefault-version">#</a> |
+| VM_VLOGSDEFAULT_PORT: `9428` <a href="#variables-vm-vlogsdefault-port" id="variables-vm-vlogsdefault-port">#</a> |
+| VM_VLOGSDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vlogsdefault-usedefaultresources" id="variables-vm-vlogsdefault-usedefaultresources">#</a> |
+| VM_VLOGSDEFAULT_RESOURCE_LIMIT_MEM: `1500Mi` <a href="#variables-vm-vlogsdefault-resource-limit-mem" id="variables-vm-vlogsdefault-resource-limit-mem">#</a> |
+| VM_VLOGSDEFAULT_RESOURCE_LIMIT_CPU: `1200m` <a href="#variables-vm-vlogsdefault-resource-limit-cpu" id="variables-vm-vlogsdefault-resource-limit-cpu">#</a> |
+| VM_VLOGSDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vlogsdefault-resource-request-mem" id="variables-vm-vlogsdefault-resource-request-mem">#</a> |
+| VM_VLOGSDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vlogsdefault-resource-request-cpu" id="variables-vm-vlogsdefault-resource-request-cpu">#</a> |
+| VM_VMALERTDEFAULT_IMAGE: `victoriametrics/vmalert` <a href="#variables-vm-vmalertdefault-image" id="variables-vm-vmalertdefault-image">#</a> |
+| VM_VMALERTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmalertdefault-version" id="variables-vm-vmalertdefault-version">#</a> |
+| VM_VMALERTDEFAULT_CONFIGRELOADIMAGE: `jimmidyson/configmap-reload:v0.3.0` <a href="#variables-vm-vmalertdefault-configreloadimage" id="variables-vm-vmalertdefault-configreloadimage">#</a> |
+| VM_VMALERTDEFAULT_PORT: `8080` <a href="#variables-vm-vmalertdefault-port" id="variables-vm-vmalertdefault-port">#</a> |
+| VM_VMALERTDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmalertdefault-usedefaultresources" id="variables-vm-vmalertdefault-usedefaultresources">#</a> |
+| VM_VMALERTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmalertdefault-resource-limit-mem" id="variables-vm-vmalertdefault-resource-limit-mem">#</a> |
+| VM_VMALERTDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmalertdefault-resource-limit-cpu" id="variables-vm-vmalertdefault-resource-limit-cpu">#</a> |
+| VM_VMALERTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmalertdefault-resource-request-mem" id="variables-vm-vmalertdefault-resource-request-mem">#</a> |
+| VM_VMALERTDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmalertdefault-resource-request-cpu" id="variables-vm-vmalertdefault-resource-request-cpu">#</a> |
+| VM_VMALERTDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmalertdefault-configreloadercpu" id="variables-vm-vmalertdefault-configreloadercpu">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMALERTDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmalertdefault-configreloadermemory" id="variables-vm-vmalertdefault-configreloadermemory">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
+| VM_VMSERVICESCRAPEDEFAULT_ENFORCEENDPOINTSLICES: `false` <a href="#variables-vm-vmservicescrapedefault-enforceendpointslices" id="variables-vm-vmservicescrapedefault-enforceendpointslices">#</a><br>Use endpointslices instead of endpoints as discovery role for vmservicescrape when generate scrape config for vmagent. |
+| VM_VMAGENTDEFAULT_IMAGE: `victoriametrics/vmagent` <a href="#variables-vm-vmagentdefault-image" id="variables-vm-vmagentdefault-image">#</a> |
+| VM_VMAGENTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmagentdefault-version" id="variables-vm-vmagentdefault-version">#</a> |
+| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmagentdefault-configreloadimage" id="variables-vm-vmagentdefault-configreloadimage">#</a> |
+| VM_VMAGENTDEFAULT_PORT: `8429` <a href="#variables-vm-vmagentdefault-port" id="variables-vm-vmagentdefault-port">#</a> |
+| VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmagentdefault-usedefaultresources" id="variables-vm-vmagentdefault-usedefaultresources">#</a> |
+| VM_VMAGENTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmagentdefault-resource-limit-mem" id="variables-vm-vmagentdefault-resource-limit-mem">#</a> |
+| VM_VMAGENTDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmagentdefault-resource-limit-cpu" id="variables-vm-vmagentdefault-resource-limit-cpu">#</a> |
+| VM_VMAGENTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmagentdefault-resource-request-mem" id="variables-vm-vmagentdefault-resource-request-mem">#</a> |
+| VM_VMAGENTDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmagentdefault-resource-request-cpu" id="variables-vm-vmagentdefault-resource-request-cpu">#</a> |
+| VM_VMAGENTDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmagentdefault-configreloadercpu" id="variables-vm-vmagentdefault-configreloadercpu">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMAGENTDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmagentdefault-configreloadermemory" id="variables-vm-vmagentdefault-configreloadermemory">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
+| VM_VMSINGLEDEFAULT_IMAGE: `victoriametrics/victoria-metrics` <a href="#variables-vm-vmsingledefault-image" id="variables-vm-vmsingledefault-image">#</a> |
+| VM_VMSINGLEDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmsingledefault-version" id="variables-vm-vmsingledefault-version">#</a> |
+| VM_VMSINGLEDEFAULT_PORT: `8429` <a href="#variables-vm-vmsingledefault-port" id="variables-vm-vmsingledefault-port">#</a> |
+| VM_VMSINGLEDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmsingledefault-usedefaultresources" id="variables-vm-vmsingledefault-usedefaultresources">#</a> |
+| VM_VMSINGLEDEFAULT_RESOURCE_LIMIT_MEM: `1500Mi` <a href="#variables-vm-vmsingledefault-resource-limit-mem" id="variables-vm-vmsingledefault-resource-limit-mem">#</a> |
+| VM_VMSINGLEDEFAULT_RESOURCE_LIMIT_CPU: `1200m` <a href="#variables-vm-vmsingledefault-resource-limit-cpu" id="variables-vm-vmsingledefault-resource-limit-cpu">#</a> |
+| VM_VMSINGLEDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vmsingledefault-resource-request-mem" id="variables-vm-vmsingledefault-resource-request-mem">#</a> |
+| VM_VMSINGLEDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmsingledefault-resource-request-cpu" id="variables-vm-vmsingledefault-resource-request-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmclusterdefault-usedefaultresources" id="variables-vm-vmclusterdefault-usedefaultresources">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_IMAGE: `victoriametrics/vmselect` <a href="#variables-vm-vmclusterdefault-vmselectdefault-image" id="variables-vm-vmclusterdefault-vmselectdefault-image">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vmselectdefault-version" id="variables-vm-vmclusterdefault-vmselectdefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_PORT: `8481` <a href="#variables-vm-vmclusterdefault-vmselectdefault-port" id="variables-vm-vmclusterdefault-vmselectdefault-port">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_MEM: `1000Mi` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-limit-mem" id="variables-vm-vmclusterdefault-vmselectdefault-resource-limit-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vmselectdefault-resource-limit-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-request-mem" id="variables-vm-vmclusterdefault-vmselectdefault-resource-request-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_CPU: `100m` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vmselectdefault-resource-request-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_IMAGE: `victoriametrics/vmstorage` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-image" id="variables-vm-vmclusterdefault-vmstoragedefault-image">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-version" id="variables-vm-vmclusterdefault-vmstoragedefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMINSERTPORT: `8400` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-vminsertport" id="variables-vm-vmclusterdefault-vmstoragedefault-vminsertport">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMSELECTPORT: `8401` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-vmselectport" id="variables-vm-vmclusterdefault-vmstoragedefault-vmselectport">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_PORT: `8482` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-port" id="variables-vm-vmclusterdefault-vmstoragedefault-port">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_LIMIT_MEM: `1500Mi` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-limit-mem" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-limit-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_LIMIT_CPU: `1000m` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-limit-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-request-mem" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-request-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_CPU: `250m` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-request-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_IMAGE: `victoriametrics/vminsert` <a href="#variables-vm-vmclusterdefault-vminsertdefault-image" id="variables-vm-vmclusterdefault-vminsertdefault-image">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vminsertdefault-version" id="variables-vm-vmclusterdefault-vminsertdefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_PORT: `8480` <a href="#variables-vm-vmclusterdefault-vminsertdefault-port" id="variables-vm-vmclusterdefault-vminsertdefault-port">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-limit-mem" id="variables-vm-vmclusterdefault-vminsertdefault-resource-limit-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-request-mem" id="variables-vm-vmclusterdefault-vminsertdefault-resource-request-mem">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vminsertdefault-resource-request-cpu">#</a> |
+| VM_VMALERTMANAGER_CONFIGRELOADERIMAGE: `jimmidyson/configmap-reload:v0.3.0` <a href="#variables-vm-vmalertmanager-configreloaderimage" id="variables-vm-vmalertmanager-configreloaderimage">#</a> |
+| VM_VMALERTMANAGER_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmalertmanager-configreloadercpu" id="variables-vm-vmalertmanager-configreloadercpu">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMALERTMANAGER_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmalertmanager-configreloadermemory" id="variables-vm-vmalertmanager-configreloadermemory">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
+| VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE: `prom/alertmanager` <a href="#variables-vm-vmalertmanager-alertmanagerdefaultbaseimage" id="variables-vm-vmalertmanager-alertmanagerdefaultbaseimage">#</a> |
+| VM_VMALERTMANAGER_ALERTMANAGERVERSION: `v0.28.1` <a href="#variables-vm-vmalertmanager-alertmanagerversion" id="variables-vm-vmalertmanager-alertmanagerversion">#</a> |
+| VM_VMALERTMANAGER_LOCALHOST: `127.0.0.1` <a href="#variables-vm-vmalertmanager-localhost" id="variables-vm-vmalertmanager-localhost">#</a> |
+| VM_VMALERTMANAGER_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmalertmanager-usedefaultresources" id="variables-vm-vmalertmanager-usedefaultresources">#</a> |
+| VM_VMALERTMANAGER_RESOURCE_LIMIT_MEM: `256Mi` <a href="#variables-vm-vmalertmanager-resource-limit-mem" id="variables-vm-vmalertmanager-resource-limit-mem">#</a> |
+| VM_VMALERTMANAGER_RESOURCE_LIMIT_CPU: `100m` <a href="#variables-vm-vmalertmanager-resource-limit-cpu" id="variables-vm-vmalertmanager-resource-limit-cpu">#</a> |
+| VM_VMALERTMANAGER_RESOURCE_REQUEST_MEM: `56Mi` <a href="#variables-vm-vmalertmanager-resource-request-mem" id="variables-vm-vmalertmanager-resource-request-mem">#</a> |
+| VM_VMALERTMANAGER_RESOURCE_REQUEST_CPU: `30m` <a href="#variables-vm-vmalertmanager-resource-request-cpu" id="variables-vm-vmalertmanager-resource-request-cpu">#</a> |
+| VM_DISABLESELFSERVICESCRAPECREATION: `false` <a href="#variables-vm-disableselfservicescrapecreation" id="variables-vm-disableselfservicescrapecreation">#</a> |
+| VM_VMBACKUP_IMAGE: `victoriametrics/vmbackupmanager` <a href="#variables-vm-vmbackup-image" id="variables-vm-vmbackup-image">#</a> |
+| VM_VMBACKUP_VERSION: `${VM_METRICS_VERSION}-enterprise` <a href="#variables-vm-vmbackup-version" id="variables-vm-vmbackup-version">#</a> |
+| VM_VMBACKUP_PORT: `8300` <a href="#variables-vm-vmbackup-port" id="variables-vm-vmbackup-port">#</a> |
+| VM_VMBACKUP_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmbackup-usedefaultresources" id="variables-vm-vmbackup-usedefaultresources">#</a> |
+| VM_VMBACKUP_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmbackup-resource-limit-mem" id="variables-vm-vmbackup-resource-limit-mem">#</a> |
+| VM_VMBACKUP_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmbackup-resource-limit-cpu" id="variables-vm-vmbackup-resource-limit-cpu">#</a> |
+| VM_VMBACKUP_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmbackup-resource-request-mem" id="variables-vm-vmbackup-resource-request-mem">#</a> |
+| VM_VMBACKUP_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmbackup-resource-request-cpu" id="variables-vm-vmbackup-resource-request-cpu">#</a> |
+| VM_VMAUTHDEFAULT_IMAGE: `victoriametrics/vmauth` <a href="#variables-vm-vmauthdefault-image" id="variables-vm-vmauthdefault-image">#</a> |
+| VM_VMAUTHDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmauthdefault-version" id="variables-vm-vmauthdefault-version">#</a> |
+| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmauthdefault-configreloadimage" id="variables-vm-vmauthdefault-configreloadimage">#</a> |
+| VM_VMAUTHDEFAULT_PORT: `8427` <a href="#variables-vm-vmauthdefault-port" id="variables-vm-vmauthdefault-port">#</a> |
+| VM_VMAUTHDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmauthdefault-usedefaultresources" id="variables-vm-vmauthdefault-usedefaultresources">#</a> |
+| VM_VMAUTHDEFAULT_RESOURCE_LIMIT_MEM: `300Mi` <a href="#variables-vm-vmauthdefault-resource-limit-mem" id="variables-vm-vmauthdefault-resource-limit-mem">#</a> |
+| VM_VMAUTHDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmauthdefault-resource-limit-cpu" id="variables-vm-vmauthdefault-resource-limit-cpu">#</a> |
+| VM_VMAUTHDEFAULT_RESOURCE_REQUEST_MEM: `100Mi` <a href="#variables-vm-vmauthdefault-resource-request-mem" id="variables-vm-vmauthdefault-resource-request-mem">#</a> |
+| VM_VMAUTHDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmauthdefault-resource-request-cpu" id="variables-vm-vmauthdefault-resource-request-cpu">#</a> |
+| VM_VMAUTHDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmauthdefault-configreloadercpu" id="variables-vm-vmauthdefault-configreloadercpu">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMAUTHDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmauthdefault-configreloadermemory" id="variables-vm-vmauthdefault-configreloadermemory">#</a><br>deprecated use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
+| VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR: `true` <a href="#variables-vm-enabledprometheusconverter-podmonitor" id="variables-vm-enabledprometheusconverter-podmonitor">#</a> |
+| VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE: `true` <a href="#variables-vm-enabledprometheusconverter-servicescrape" id="variables-vm-enabledprometheusconverter-servicescrape">#</a> |
+| VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE: `true` <a href="#variables-vm-enabledprometheusconverter-prometheusrule" id="variables-vm-enabledprometheusconverter-prometheusrule">#</a> |
+| VM_ENABLEDPROMETHEUSCONVERTER_PROBE: `true` <a href="#variables-vm-enabledprometheusconverter-probe" id="variables-vm-enabledprometheusconverter-probe">#</a> |
+| VM_ENABLEDPROMETHEUSCONVERTER_ALERTMANAGERCONFIG: `true` <a href="#variables-vm-enabledprometheusconverter-alertmanagerconfig" id="variables-vm-enabledprometheusconverter-alertmanagerconfig">#</a> |
+| VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG: `true` <a href="#variables-vm-enabledprometheusconverter-scrapeconfig" id="variables-vm-enabledprometheusconverter-scrapeconfig">#</a> |
+| VM_FILTERCHILDLABELPREFIXES: `-` <a href="#variables-vm-filterchildlabelprefixes" id="variables-vm-filterchildlabelprefixes">#</a> |
+| VM_FILTERCHILDANNOTATIONPREFIXES: `-` <a href="#variables-vm-filterchildannotationprefixes" id="variables-vm-filterchildannotationprefixes">#</a> |
+| VM_PROMETHEUSCONVERTERADDARGOCDIGNOREANNOTATIONS: `false` <a href="#variables-vm-prometheusconverteraddargocdignoreannotations" id="variables-vm-prometheusconverteraddargocdignoreannotations">#</a><br>adds compare-options and sync-options for prometheus objects converted by operator. It helps to properly use converter with ArgoCD |
+| VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES: `false` <a href="#variables-vm-enabledprometheusconverterownerreferences" id="variables-vm-enabledprometheusconverterownerreferences">#</a> |
+| VM_FILTERPROMETHEUSCONVERTERLABELPREFIXES: `-` <a href="#variables-vm-filterprometheusconverterlabelprefixes" id="variables-vm-filterprometheusconverterlabelprefixes">#</a><br>allows filtering for converted labels, labels with matched prefix will be ignored |
+| VM_FILTERPROMETHEUSCONVERTERANNOTATIONPREFIXES: `-` <a href="#variables-vm-filterprometheusconverterannotationprefixes" id="variables-vm-filterprometheusconverterannotationprefixes">#</a><br>allows filtering for converted annotations, annotations with matched prefix will be ignored |
+| VM_CLUSTERDOMAINNAME: `-` <a href="#variables-vm-clusterdomainname" id="variables-vm-clusterdomainname">#</a><br>Defines domain name suffix for in-cluster addresses most known ClusterDomainName is .cluster.local |
+| VM_APPREADYTIMEOUT: `80s` <a href="#variables-vm-appreadytimeout" id="variables-vm-appreadytimeout">#</a><br>Defines deadline for deployment/statefulset to transit into ready state to wait for transition to ready state |
+| VM_PODWAITREADYTIMEOUT: `80s` <a href="#variables-vm-podwaitreadytimeout" id="variables-vm-podwaitreadytimeout">#</a><br>Defines single pod deadline to wait for transition to ready state |
+| VM_PODWAITREADYINTERVALCHECK: `5s` <a href="#variables-vm-podwaitreadyintervalcheck" id="variables-vm-podwaitreadyintervalcheck">#</a><br>Defines poll interval for pods ready check at statefulset rollout update |
+| VM_FORCERESYNCINTERVAL: `60s` <a href="#variables-vm-forceresyncinterval" id="variables-vm-forceresyncinterval">#</a><br>configures force resync interval for VMAgent, VMAlert, VMAlertmanager and VMAuth. |
+| VM_ENABLESTRICTSECURITY: `false` <a href="#variables-vm-enablestrictsecurity" id="variables-vm-enablestrictsecurity">#</a><br>EnableStrictSecurity will add default `securityContext` to pods and containers created by operator Default PodSecurityContext include: 1. RunAsNonRoot: true 2. RunAsUser/RunAsGroup/FSGroup: 65534 '65534' refers to 'nobody' in all the used default images like alpine, busybox. If you're using customize image, please make sure '65534' is a valid uid in there or specify SecurityContext. 3. FSGroupChangePolicy: &onRootMismatch If KubeVersion>=1.20, use `FSGroupChangePolicy="onRootMismatch"` to skip the recursive permission change when the root of the volume already has the correct permissions 4. SeccompProfile:      type: RuntimeDefault Use `RuntimeDefault` seccomp profile by default, which is defined by the container runtime, instead of using the Unconfined (seccomp disabled) mode. Default container SecurityContext include: 1. AllowPrivilegeEscalation: false 2. ReadOnlyRootFilesystem: true 3. Capabilities:      drop:        - all turn off `EnableStrictSecurity` by default, see https://github.com/VictoriaMetrics/operator/issues/749 for details |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -116,7 +116,7 @@ You can interact with VictoriaMetrics resources in the same way as you would wit
 For example, to get a list of `VMSingle` resources, you can run `kubectl get vmsingle -n vm`. 
 This knowledge will help you manage and inspect the custom resources within the cluster efficiently in later sections.
 
-The operator is configured using [environment variables](https://docs.victoriametrics.com/operator/vars/). 
+The operator is configured using [environment variables](https://docs.victoriametrics.com/operator/configuration/#environment-variables). 
 You can consult the documentation or explore the variables directly in your cluster (note that `kubectl exec` may require [additional permissions](https://discuss.kubernetes.io/t/adding-permission-to-exec-commands-in-containers-inside-pods-in-a-certain-namespace/22821/2)).
 Here’s an example showing how to get the default CPU and memory limits applied to the VMSingle resource:
 ```sh 

--- a/docs/vars.md
+++ b/docs/vars.md
@@ -1,13 +1,11 @@
 ---
 weight: 11
 title: Variables
-menu:
-  docs:
-    parent: "operator"
-    weight: 11
+menu: false
 aliases:
   - /operator/vars/
   - /operator/vars/index.html
   - /operator/vars.html
 ---
-{{% content "env.md" %}}
+
+The page is deprecated. The content has been moved to [operator/configuration/#environment-variables](https://docs.victoriametrics.com/operator/configuration/#environment-variables).

--- a/internal/config/print.go
+++ b/internal/config/print.go
@@ -28,11 +28,11 @@ var formats = map[string]string{
         [description]	{{ index $.Descriptions $idx }}
 {{ end -}}
 `,
-	"markdown": `
-| variable name | variable default value | variable required | variable description |
-| --- | --- | --- | --- |
+	"markdown": `| Environment variables |
+| --- |
 {{- range $idx, $item := .Params }}
-| {{ $item.Key }} | {{ if eq (len $item.DefaultValue) 0 -}}-{{- else -}}{{ $item.DefaultValue }}{{- end }} | {{ $item.Required }} | {{ index $.Descriptions $idx }} |
+| {{ $item.Key }}: ` + "`" + `{{ if gt (len $item.DefaultValue) 0 -}}{{ $item.DefaultValue }}{{- else -}}-{{- end }}` + "`" + ` <a href="#variables-{{ $item.Key | anchorize }}" id="variables-{{ $item.Key | anchorize }}">#</a>
+{{- if gt (len (index $.Descriptions $idx)) 0 -}}<br>{{ index $.Descriptions $idx }}{{- end }} |
 {{- end }}
 `,
 
@@ -62,7 +62,14 @@ func (boc *BaseOperatorConf) PrintDefaults(format string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get field params: %w", err)
 	}
-	tmpl, err := template.New("env").Parse(tpl)
+	tmpl, err := template.New("env").Funcs(map[string]any{
+		"anchorize": func(val string) string {
+			val = strings.ToLower(val)
+			val = strings.ReplaceAll(val, "_", "-")
+			val = strings.ReplaceAll(val, " ", "-")
+			return val
+		},
+	}).Parse(tpl)
 	if err != nil {
 		return fmt.Errorf("failed to parse template: %w", err)
 	}


### PR DESCRIPTION
PR Enhance the operator configuration via env variables. 

Example:
<img width="935" alt="Screenshot 2025-05-22 at 20 12 40" src="https://github.com/user-attachments/assets/82a026d4-9b9b-464b-b440-db50a1e29d04" />


Scripts https://github.com/VictoriaMetrics/debug-notes/pull/7