### PR TITLE
config/alerting: rm `BadObjects` rule as it is no-op

### DIFF
--- a/config/alerting/vmoperator-rules.yaml
+++ b/config/alerting/vmoperator-rules.yaml
@@ -56,16 +56,3 @@ spec:
         description: "Operator cannot handle reconciliation load for controller: `{{- $labels.name }}`, current depth: {{ $value }}"
         dashboard: "{{ $externalURL }}/d/1H179hunk/victoriametrics-operator?ds={{ $labels.dc }}&orgId=1&viewPanel=20"
         summary: "Too many `{{- $labels.name }}` in queue: {{ $value }}"
-    - alert: BadObjects
-      expr: |
-        sum(
-          operator_controller_bad_objects_count{job=~".*((victoria.*)|vm)-?operator"}
-        ) by(controller, cluster) > 0
-      for: 15m
-      labels:
-        severity: warning
-        show_at: dashboard
-      annotations:
-        description: "Operator got incorrect resources in controller {{ $labels.controller }}, check operator logs"
-        dashboard: "{{ $externalURL }}/d/1H179hunk/victoriametrics-operator?ds={{ $labels.dc }}&orgId=1"
-        summary: "Incorrect `{{ $labels.controller }}` resources in the cluster"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ To perform migration to the `VLSingle` please follow [this docs](https://docs.vi
 * FEATURE: [operator](https://docs.victoriametrics.com/operator/api): introduce new resource `VLSingle`. It replaces deprecated `VLogs`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1339) for details.
 * FEATURE: [operator](https://docs.victoriametrics.com/operator/api): manifests distributed via [GitHub release](https://github.com/VictoriaMetrics/operator/releases) artifacts now include the label `app.kubernetes.io/instance: default`, and the value of `app.kubernetes.io/name` has been changed to `victoria-metrics-operator`. See [#1364](https://github.com/VictoriaMetrics/operator/pull/1364) for details.
 
+* BUGFIX: [operator](https://docs.victoriametrics.com/operator/api): remove alerting rule `BadObjects` as metric `operator_controller_bad_objects_count` isn't exposed anymore.
+
 ## [v0.58.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.58.0)
 
 **Release date:** 14 May 2025


### PR DESCRIPTION
The rule `BadObjects` uses `operator_controller_bad_objects_count` metric that was stopped from being exposed in https://github.com/VictoriaMetrics/operator/commit/6f35883c2d4766e66d899b432ed5acbc505545d9#diff-08d1eedc31f3c6403917e8f48ad89b21a0490d80bd3606c7b103028e90cc17fb