### PR TITLE
upgrade golangci-lint, consistently use corev1 alias for import

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,41 @@
+version: "2"
 run:
-  timeout: 5m
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
-    - dupl
     - copyloopvar
+    - dupl
     - ginkgolinter
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ GINKGO_VERSION ?= v2.23.0
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.20
-GOLANGCI_LINT_VERSION ?= v1.64.6
+GOLANGCI_LINT_VERSION ?= v2.1.3
 CODEGENERATOR_VERSION ?= v0.32.2
 KIND_VERSION ?= v0.27.0
 OLM_VERSION ?= 0.31.0
@@ -412,7 +412,7 @@ $(OPM): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: kind
 kind: $(KIND)

--- a/api/operator/v1/vlsingle_types.go
+++ b/api/operator/v1/vlsingle_types.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -61,7 +61,7 @@ type VLSingleSpec struct {
 	// Storage is the definition of how storage will be used by the VLSingle
 	// by default it`s empty dir
 	// +optional
-	Storage *v1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
+	Storage *corev1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
 	// StorageMeta defines annotations and labels attached to PVC for given vlsingle CR
 	// +optional
 	StorageMetadata v1beta1.EmbeddedObjectMetadata `json:"storageMetadata,omitempty"`
@@ -236,7 +236,7 @@ func (cr *VLSingle) AnnotationsFiltered() map[string]string {
 	return dst
 }
 
-// SelectorLabels returns unque labels for object
+// SelectorLabels returns unique labels for object
 func (cr *VLSingle) SelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vlsingle",

--- a/api/operator/v1beta1/common_scrapeparams.go
+++ b/api/operator/v1beta1/common_scrapeparams.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // AttachMetadata configures metadata attachment
@@ -54,9 +54,9 @@ type VMScrapeParams struct {
 // Only VictoriaMetrics scrapers supports it.
 // See https://github.com/VictoriaMetrics/VictoriaMetrics/commit/a6a71ef861444eb11fe8ec6d2387f0fc0c4aea87
 type ProxyAuth struct {
-	BasicAuth       *BasicAuth            `json:"basic_auth,omitempty"`
-	BearerToken     *v1.SecretKeySelector `json:"bearer_token,omitempty"`
-	BearerTokenFile string                `json:"bearer_token_file,omitempty"`
+	BasicAuth       *BasicAuth                `json:"basic_auth,omitempty"`
+	BearerToken     *corev1.SecretKeySelector `json:"bearer_token,omitempty"`
+	BearerTokenFile string                    `json:"bearer_token_file,omitempty"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	TLSConfig *TLSConfig `json:"tls_config,omitempty"`
@@ -69,7 +69,7 @@ type OAuth2 struct {
 	ClientID SecretOrConfigMap `json:"client_id" yaml:"client_id,omitempty"`
 	// The secret containing the OAuth2 client secret
 	// +optional
-	ClientSecret *v1.SecretKeySelector `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
+	ClientSecret *corev1.SecretKeySelector `json:"client_secret,omitempty" yaml:"client_secret,omitempty"`
 	// ClientSecretFile defines path for client secret file.
 	// +optional
 	ClientSecretFile string `json:"client_secret_file,omitempty" yaml:"client_secret_file,omitempty"`
@@ -127,7 +127,7 @@ type Authorization struct {
 	// +optional
 	Type string `json:"type,omitempty"`
 	// Reference to the secret with value for authorization
-	Credentials *v1.SecretKeySelector `json:"credentials,omitempty"`
+	Credentials *corev1.SecretKeySelector `json:"credentials,omitempty"`
 	// File with value for authorization
 	// +optional
 	CredentialsFile string `json:"credentialsFile,omitempty" yaml:"credentials_file,omitempty"`
@@ -303,7 +303,7 @@ type EndpointAuth struct {
 	// the victoria-metrics operator.
 	// +optional
 	// +nullable
-	BearerTokenSecret *v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret *corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 	// BasicAuth allow an endpoint to authenticate over basic authentication
 	// +optional
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`

--- a/api/operator/v1beta1/vlogs_types.go
+++ b/api/operator/v1beta1/vlogs_types.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -63,7 +63,7 @@ type VLogsSpec struct {
 	// Storage is the definition of how storage will be used by the VLogs
 	// by default it`s empty dir
 	// +optional
-	Storage *v1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
+	Storage *corev1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
 	// StorageMeta defines annotations and labels attached to PVC for given vlogs CR
 	// +optional
 	StorageMetadata EmbeddedObjectMetadata `json:"storageMetadata,omitempty"`

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -108,7 +108,7 @@ type VMAgentSpec struct {
 	// This relabeling is applied to all the collected metrics before sending them to remote storage.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Key at Configmap with relabelConfig name",xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector"
-	RelabelConfig *v1.ConfigMapKeySelector `json:"relabelConfig,omitempty"`
+	RelabelConfig *corev1.ConfigMapKeySelector `json:"relabelConfig,omitempty"`
 	// InlineRelabelConfig - defines GlobalRelabelConfig for vmagent, can be defined directly at CRD.
 	// +optional
 	InlineRelabelConfig []*RelabelConfig `json:"inlineRelabelConfig,omitempty"`
@@ -220,7 +220,7 @@ type VMAgentSpec struct {
 	// notes to ensure that no incompatible scrape configs are going to break
 	// VMAgent after the upgrade.
 	// +optional
-	AdditionalScrapeConfigs *v1.SecretKeySelector `json:"additionalScrapeConfigs,omitempty"`
+	AdditionalScrapeConfigs *corev1.SecretKeySelector `json:"additionalScrapeConfigs,omitempty"`
 	// InsertPorts - additional listen ports for data ingestion.
 	InsertPorts *InsertPorts `json:"insertPorts,omitempty"`
 
@@ -299,7 +299,7 @@ type VMAgentSpec struct {
 	StatefulRollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"statefulRollingUpdateStrategy,omitempty"`
 
 	// ClaimTemplates allows adding additional VolumeClaimTemplates for VMAgent in StatefulMode
-	ClaimTemplates []v1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
+	ClaimTemplates []corev1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
 	// IngestOnlyMode switches vmagent into unmanaged mode
 	// it disables any config generation for scraping
 	// Currently it prevents vmagent from managing tls and auth options for remote write
@@ -449,12 +449,12 @@ type VMAgentRemoteWriteSpec struct {
 	BasicAuth *BasicAuth `json:"basicAuth,omitempty"`
 	// Optional bearer auth token to use for -remoteWrite.url
 	// +optional
-	BearerTokenSecret *v1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
+	BearerTokenSecret *corev1.SecretKeySelector `json:"bearerTokenSecret,omitempty"`
 
 	// ConfigMap with relabeling config which is applied to metrics before sending them to the corresponding -remoteWrite.url
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Key at Configmap with relabelConfig for remoteWrite",xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMapKeySelector"
-	UrlRelabelConfig *v1.ConfigMapKeySelector `json:"urlRelabelConfig,omitempty"`
+	UrlRelabelConfig *corev1.ConfigMapKeySelector `json:"urlRelabelConfig,omitempty"`
 	// InlineUrlRelabelConfig defines relabeling config for remoteWriteURL, it can be defined at crd spec.
 	// +optional
 	InlineUrlRelabelConfig []*RelabelConfig `json:"inlineUrlRelabelConfig,omitempty"`

--- a/api/operator/v1beta1/vmalert_types.go
+++ b/api/operator/v1beta1/vmalert_types.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -84,7 +84,7 @@ type VMAlertSpec struct {
 	// NotifierConfigRef reference for secret with notifier configuration for vmalert
 	// only one of notifier options could be chosen: notifierConfigRef or notifiers +  notifier
 	// +optional
-	NotifierConfigRef *v1.SecretKeySelector `json:"notifierConfigRef,omitempty"`
+	NotifierConfigRef *corev1.SecretKeySelector `json:"notifierConfigRef,omitempty"`
 
 	// RemoteWrite Optional URL to remote-write compatible storage to persist
 	// vmalert state and rule results to.

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -7,7 +7,7 @@ import (
 
 	amlabels "github.com/prometheus/alertmanager/pkg/labels"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -181,7 +181,7 @@ type VMAlertmanagerSpec struct {
 	// +optional
 	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 	// ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet
-	ClaimTemplates []v1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
+	ClaimTemplates []corev1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
 
 	// WebConfig defines configuration for webserver
 	// https://github.com/prometheus/alertmanager/blob/main/docs/https.md

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -50,7 +50,7 @@ type VMClusterSpec struct {
 	// to use for pulling images from registries
 	// see https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod
 	// +optional
-	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// License allows to configure license key to be used for enterprise features.
 	// Using license key is supported starting from VictoriaMetrics v1.94.0.
@@ -274,7 +274,7 @@ type VMSelect struct {
 	// +optional
 	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 	// ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet
-	ClaimTemplates []v1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
+	ClaimTemplates []corev1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
 
 	CommonDefaultableParams           `json:",inline"`
 	CommonApplicationDeploymentParams `json:",inline"`
@@ -445,7 +445,7 @@ type VMStorage struct {
 	RollingUpdateStrategy appsv1.StatefulSetUpdateStrategyType `json:"rollingUpdateStrategy,omitempty"`
 
 	// ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet
-	ClaimTemplates []v1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
+	ClaimTemplates []corev1.PersistentVolumeClaim `json:"claimTemplates,omitempty"`
 
 	CommonDefaultableParams           `json:",inline"`
 	CommonApplicationDeploymentParams `json:",inline"`
@@ -479,7 +479,7 @@ type VMBackup struct {
 	// CredentialsSecret is secret in the same namespace for access to remote storage
 	// The secret is mounted into /etc/vm/creds.
 	// +optional
-	CredentialsSecret *v1.SecretKeySelector `json:"credentialsSecret,omitempty"`
+	CredentialsSecret *corev1.SecretKeySelector `json:"credentialsSecret,omitempty"`
 
 	// Defines if hourly backups disabled (default false)
 	// +optional
@@ -510,22 +510,22 @@ type VMBackup struct {
 	// Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	// if not defined default resources from operator config will be used
 	// +optional
-	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// extra args like maxBytesPerSecond default 0
 	// +optional
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
 	// +optional
-	ExtraEnvs []v1.EnvVar `json:"extraEnvs,omitempty"`
+	ExtraEnvs []corev1.EnvVar `json:"extraEnvs,omitempty"`
 	// ExtraEnvsFrom defines source of env variables for the application container
 	// could either be secret or configmap
 	// +optional
-	ExtraEnvsFrom []v1.EnvFromSource `json:"extraEnvsFrom,omitempty"`
+	ExtraEnvsFrom []corev1.EnvFromSource `json:"extraEnvsFrom,omitempty"`
 
 	// VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.
 	// VolumeMounts specified will be appended to other VolumeMounts in the vmbackupmanager container,
 	// that are generated as a result of StorageSpec objects.
 	// +optional
-	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// Restore Allows to enable restore options for pod
 	// Read [more](https://docs.victoriametrics.com/vmbackupmanager#restore-commands)

--- a/api/operator/v1beta1/vmextra_types_test.go
+++ b/api/operator/v1beta1/vmextra_types_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"k8s.io/utils/ptr"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_buildPathWithPrefixFlag(t *testing.T) {
@@ -136,8 +136,8 @@ func TestLicense_MaybeAddToArgs(t *testing.T) {
 		{
 			name: "license key provided with reload interval",
 			license: License{
-				KeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "license-secret"},
+				KeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "license-secret"},
 					Key:                  "license-key",
 				},
 				ReloadInterval: ptr.To("30s"),
@@ -151,8 +151,8 @@ func TestLicense_MaybeAddToArgs(t *testing.T) {
 		{
 			name: "license key provided via secret with force offline",
 			license: License{
-				KeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: "license-secret"},
+				KeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "license-secret"},
 					Key:                  "license-key",
 				},
 				ForceOffline: ptr.To(true),

--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -11,13 +11,13 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/notifier"
 	"github.com/VictoriaMetrics/VictoriaMetrics/app/vmalert/templates"
 	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MaxConfigMapDataSize is a maximum `Data` field size of a ConfigMap.
 // Limit it to the half size of constant value, since it may be different for kubernetes versions.
-var MaxConfigMapDataSize = int(float64(v1.MaxSecretSize) * 0.5)
+var MaxConfigMapDataSize = int(float64(corev1.MaxSecretSize) * 0.5)
 
 var initVMAlertTemplatesOnce sync.Once
 

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -41,7 +41,7 @@ type VMSingleSpec struct {
 	// by default it`s empty dir
 	// this option is ignored if storageDataPath is set
 	// +optional
-	Storage *v1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
+	Storage *corev1.PersistentVolumeClaimSpec `json:"storage,omitempty"`
 
 	// StorageMeta defines annotations and labels attached to PVC for given vmsingle CR
 	// +optional

--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,10 +24,10 @@ type VMUserSpec struct {
 	Password *string `json:"password,omitempty"`
 	// PasswordRef allows fetching password from user-create secret by its name and key.
 	// +optional
-	PasswordRef *v1.SecretKeySelector `json:"passwordRef,omitempty"`
+	PasswordRef *corev1.SecretKeySelector `json:"passwordRef,omitempty"`
 	// TokenRef allows fetching token from user-created secrets by its name and key.
 	// +optional
-	TokenRef *v1.SecretKeySelector `json:"tokenRef,omitempty"`
+	TokenRef *corev1.SecretKeySelector `json:"tokenRef,omitempty"`
 	// GeneratePassword instructs operator to generate password for user
 	// if spec.password if empty.
 	// +optional
@@ -122,11 +122,11 @@ type TargetRefBasicAuth struct {
 	// The secret in the service scrape namespace that contains the username
 	// for authentication.
 	// It must be at them same namespace as CRD
-	Username v1.SecretKeySelector `json:"username"`
+	Username corev1.SecretKeySelector `json:"username"`
 	// The secret in the service scrape namespace that contains the password
 	// for authentication.
 	// It must be at them same namespace as CRD
-	Password v1.SecretKeySelector `json:"password"`
+	Password corev1.SecretKeySelector `json:"password"`
 }
 
 // VMUserStatus defines the observed state of VMUser

--- a/codespell/Makefile
+++ b/codespell/Makefile
@@ -2,7 +2,7 @@
 
 # Builds spellcheck image.
 codespell:
-	@docker build codespell -t codespell
+	@-docker build codespell -t codespell
 
 # Runs cspell container commands.
 codespell-check: codespell

--- a/internal/controller/operator/factory/build/common.go
+++ b/internal/controller/operator/factory/build/common.go
@@ -78,7 +78,7 @@ func (cb *TLSConfigBuilder) fetchSecretWithAssets(ss *corev1.SecretKeySelector, 
 		if v, ok := cb.SecretCache[ss.Name]; ok {
 			s = *v
 		} else {
-			if err := cb.Client.Get(cb.Ctx, types.NamespacedName{Namespace: cb.CurrentCRNamespace, Name: ss.Name}, &s); err != nil {
+			if err := cb.Get(cb.Ctx, types.NamespacedName{Namespace: cb.CurrentCRNamespace, Name: ss.Name}, &s); err != nil {
 				return fmt.Errorf("cannot fetch secret=%q for tlsAsset, err=%w", ss.Name, err)
 			}
 			cb.SecretCache[ss.Name] = &s
@@ -90,7 +90,7 @@ func (cb *TLSConfigBuilder) fetchSecretWithAssets(ss *corev1.SecretKeySelector, 
 		if v, ok := cb.ConfigmapCache[cs.Name]; ok {
 			c = *v
 		} else {
-			if err := cb.Client.Get(cb.Ctx, types.NamespacedName{Namespace: cb.CurrentCRNamespace, Name: cs.Name}, &c); err != nil {
+			if err := cb.Get(cb.Ctx, types.NamespacedName{Namespace: cb.CurrentCRNamespace, Name: cs.Name}, &c); err != nil {
 				return fmt.Errorf("cannot fetch configmap=%q for tlsAssert, err=%w", cs.Name, err)
 			}
 		}

--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -8,7 +8,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -152,7 +151,7 @@ func addServiceDefaults(objI any) {
 	}
 
 	if obj.Spec.InternalTrafficPolicy == nil {
-		if obj.Spec.Type == corev1.ServiceTypeNodePort || obj.Spec.Type == corev1.ServiceTypeLoadBalancer || obj.Spec.Type == v1.ServiceTypeClusterIP {
+		if obj.Spec.Type == corev1.ServiceTypeNodePort || obj.Spec.Type == corev1.ServiceTypeLoadBalancer || obj.Spec.Type == corev1.ServiceTypeClusterIP {
 			serviceInternalTrafficPolicyCluster := corev1.ServiceInternalTrafficPolicyCluster
 			obj.Spec.InternalTrafficPolicy = &serviceInternalTrafficPolicyCluster
 		}
@@ -177,7 +176,7 @@ func addVMAuthDefaults(objI any) {
 
 	if cr.Spec.ConfigSecret != "" {
 		// Removed if later with ConfigSecret field later
-		cr.Spec.ExternalConfig.SecretRef = &corev1.SecretKeySelector{
+		cr.Spec.SecretRef = &corev1.SecretKeySelector{
 			Key: "config.yaml",
 			LocalObjectReference: corev1.LocalObjectReference{
 				Name: cr.Spec.ConfigSecret,

--- a/internal/controller/operator/factory/build/security.go
+++ b/internal/controller/operator/factory/build/security.go
@@ -57,18 +57,18 @@ func containerSecurityContext(p *vmv1beta1.SecurityContext) *corev1.SecurityCont
 	}
 	var sc corev1.SecurityContext
 	if p.ContainerSecurityContext != nil {
-		sc.Privileged = p.ContainerSecurityContext.Privileged
-		sc.Capabilities = p.ContainerSecurityContext.Capabilities
-		sc.ReadOnlyRootFilesystem = p.ContainerSecurityContext.ReadOnlyRootFilesystem
-		sc.AllowPrivilegeEscalation = p.ContainerSecurityContext.AllowPrivilegeEscalation
-		sc.ProcMount = p.ContainerSecurityContext.ProcMount
+		sc.Privileged = p.Privileged
+		sc.Capabilities = p.Capabilities
+		sc.ReadOnlyRootFilesystem = p.ReadOnlyRootFilesystem
+		sc.AllowPrivilegeEscalation = p.AllowPrivilegeEscalation
+		sc.ProcMount = p.ProcMount
 	}
 	if p.PodSecurityContext != nil {
-		sc.RunAsUser = p.PodSecurityContext.RunAsUser
-		sc.RunAsGroup = p.PodSecurityContext.RunAsGroup
-		sc.RunAsNonRoot = p.PodSecurityContext.RunAsNonRoot
-		sc.AppArmorProfile = p.PodSecurityContext.AppArmorProfile
-		sc.SeccompProfile = p.PodSecurityContext.SeccompProfile
+		sc.RunAsUser = p.RunAsUser
+		sc.RunAsGroup = p.RunAsGroup
+		sc.RunAsNonRoot = p.RunAsNonRoot
+		sc.AppArmorProfile = p.AppArmorProfile
+		sc.SeccompProfile = p.SeccompProfile
 
 	}
 	return &sc

--- a/internal/controller/operator/factory/build/vmservicescrape.go
+++ b/internal/controller/operator/factory/build/vmservicescrape.go
@@ -3,7 +3,7 @@ package build
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -17,7 +17,7 @@ type serviceScrapeBuilder interface {
 }
 
 // VMServiceScrapeForServiceWithSpec build VMServiceScrape for VMAlertmanager
-func VMServiceScrapeForAlertmanager(service *v1.Service, amCR *vmv1beta1.VMAlertmanager) *vmv1beta1.VMServiceScrape {
+func VMServiceScrapeForAlertmanager(service *corev1.Service, amCR *vmv1beta1.VMAlertmanager) *vmv1beta1.VMServiceScrape {
 	var extraArgs map[string]string
 
 	isTLS := amCR.Spec.WebConfig != nil && amCR.Spec.WebConfig.TLSServerConfig != nil
@@ -33,14 +33,14 @@ func VMServiceScrapeForAlertmanager(service *v1.Service, amCR *vmv1beta1.VMAlert
 
 // VMServiceScrapeForServiceWithSpec creates corresponding object with `http` port endpoint obtained from given service
 // add additionalPortNames to the monitoring if needed
-func VMServiceScrapeForServiceWithSpec(service *v1.Service, builder serviceScrapeBuilder, additionalPortNames ...string) *vmv1beta1.VMServiceScrape {
+func VMServiceScrapeForServiceWithSpec(service *corev1.Service, builder serviceScrapeBuilder, additionalPortNames ...string) *vmv1beta1.VMServiceScrape {
 	serviceScrapeSpec, extraArgs, metricPath := builder.GetServiceScrape(), builder.GetExtraArgs(), builder.GetMetricPath()
 	return vmServiceScrapeForServiceWithSpec(service, serviceScrapeSpec, extraArgs, metricPath, additionalPortNames...)
 }
 
 // VMServiceScrapeForServiceWithSpec build VMServiceScrape for given service with optional spec
 // optionally could filter out ports from service
-func vmServiceScrapeForServiceWithSpec(service *v1.Service, serviceScrapeSpec *vmv1beta1.VMServiceScrapeSpec, extraArgs map[string]string, metricPath string, additionalPortNames ...string) *vmv1beta1.VMServiceScrape {
+func vmServiceScrapeForServiceWithSpec(service *corev1.Service, serviceScrapeSpec *vmv1beta1.VMServiceScrapeSpec, extraArgs map[string]string, metricPath string, additionalPortNames ...string) *vmv1beta1.VMServiceScrape {
 	var endPoints []vmv1beta1.Endpoint
 	var isTLS bool
 	v, ok := extraArgs["tls"]

--- a/internal/controller/operator/factory/finalize/vlcluster.go
+++ b/internal/controller/operator/factory/finalize/vlcluster.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v2 "k8s.io/api/autoscaling/v2"
-	v1 "k8s.io/api/core/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -55,10 +55,10 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLInsertName()),
@@ -69,7 +69,7 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 		objsToRemove = append(objsToRemove, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
 	}
 	if obj.HPA != nil {
-		objsToRemove = append(objsToRemove, &v2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
+		objsToRemove = append(objsToRemove, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
@@ -77,7 +77,7 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	}
 
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -95,10 +95,10 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLSelectName()),
@@ -109,14 +109,14 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 		objsToRemove = append(objsToRemove, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
 	}
 	if obj.HPA != nil {
-		objsToRemove = append(objsToRemove, &v2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
+		objsToRemove = append(objsToRemove, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -134,10 +134,10 @@ func OnVLStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCl
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLStorageName()),
@@ -168,8 +168,8 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: lbMeta},
-		&v1.Secret{ObjectMeta: lbMeta},
-		&v1.Service{ObjectMeta: lbMeta},
+		&corev1.Secret{ObjectMeta: lbMeta},
+		&corev1.Service{ObjectMeta: lbMeta},
 	}
 	if !ptr.Deref(cr.Spec.RequestsLoadBalancer.Spec.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: lbMeta})
@@ -183,7 +183,7 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
 				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
 		}
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.GetVLSelectLBName(),
 			Namespace: cr.Namespace,
 		}})
@@ -193,7 +193,7 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
 				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
 		}
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.GetVLInsertLBName(),
 			Namespace: cr.Namespace,
 		}})

--- a/internal/controller/operator/factory/finalize/vlogs.go
+++ b/internal/controller/operator/factory/finalize/vlogs.go
@@ -5,7 +5,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,16 +16,16 @@ func OnVLogsDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VL
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err
 	}
 	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &v1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
+		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
 			return err
 		}
 	}
 	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vlsingle.go
+++ b/internal/controller/operator/factory/finalize/vlsingle.go
@@ -5,7 +5,7 @@ import (
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,16 +16,16 @@ func OnVLSingleDelete(ctx context.Context, rclient client.Client, crd *vmv1.VLSi
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err
 	}
 	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace); err != nil {
 			return err
 		}
 	}
 	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vmalertmanager.go
+++ b/internal/controller/operator/factory/finalize/vmalertmanager.go
@@ -5,7 +5,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,22 +16,22 @@ func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, crd *vmv
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err
 	}
 	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
 			return err
 		}
 	}
 
 	// check config secret finalizer.
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
 		return err
 	}
 	if len(crd.Spec.ConfigSecret) > 0 {
 		// execute it for backward-compatibility
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Secret{}, crd.Spec.ConfigSecret, crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.Spec.ConfigSecret, crd.Namespace); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vmauth.go
+++ b/internal/controller/operator/factory/finalize/vmauth.go
@@ -5,7 +5,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,17 +19,17 @@ func OnVMAuthDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.V
 	}
 
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err
 	}
 	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
 			return err
 		}
 	}
 
 	// check secret
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
 		return err
 	}
 

--- a/internal/controller/operator/factory/finalize/vmcluster.go
+++ b/internal/controller/operator/factory/finalize/vmcluster.go
@@ -7,8 +7,8 @@ import (
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v2 "k8s.io/api/autoscaling/v2"
-	v1 "k8s.io/api/core/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -23,10 +23,10 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: crd.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMInsertName()),
@@ -37,7 +37,7 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 		objsToRemove = append(objsToRemove, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
 	}
 	if obj.HPA != nil {
-		objsToRemove = append(objsToRemove, &v2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
+		objsToRemove = append(objsToRemove, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
@@ -45,7 +45,7 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	}
 
 	if crd.Spec.RequestsLoadBalancer.Enabled && !crd.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMInsertLBName(), Namespace: crd.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMInsertLBName(), Namespace: crd.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -63,10 +63,10 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: crd.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMSelectName()),
@@ -77,14 +77,14 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 		objsToRemove = append(objsToRemove, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
 	}
 	if obj.HPA != nil {
-		objsToRemove = append(objsToRemove, &v2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
+		objsToRemove = append(objsToRemove, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMSelectLBName(), Namespace: crd.Namespace}})
 	}
 	if crd.Spec.RequestsLoadBalancer.Enabled && !crd.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMSelectLBName(), Namespace: crd.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMSelectLBName(), Namespace: crd.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -102,10 +102,10 @@ func OnVMStorageDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
-		&v1.Service{ObjectMeta: objMeta},
+		&corev1.Service{ObjectMeta: objMeta},
 	}
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
-		objsToRemove = append(objsToRemove, &v1.Service{
+		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: crd.Namespace,
 				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMStorageName()),
@@ -168,8 +168,8 @@ func OnVMClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: lbMeta},
-		&v1.Secret{ObjectMeta: lbMeta},
-		&v1.Service{ObjectMeta: lbMeta},
+		&corev1.Secret{ObjectMeta: lbMeta},
+		&corev1.Service{ObjectMeta: lbMeta},
 	}
 	if !ptr.Deref(cr.Spec.RequestsLoadBalancer.Spec.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: lbMeta})
@@ -183,7 +183,7 @@ func OnVMClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
 				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
 		}
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.GetVMSelectLBName(),
 			Namespace: cr.Namespace,
 		}})
@@ -193,7 +193,7 @@ func OnVMClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
 				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
 		}
-		objsToRemove = append(objsToRemove, &v1.Service{ObjectMeta: metav1.ObjectMeta{
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.GetVMInsertLBName(),
 			Namespace: cr.Namespace,
 		}})

--- a/internal/controller/operator/factory/finalize/vmsingle.go
+++ b/internal/controller/operator/factory/finalize/vmsingle.go
@@ -5,7 +5,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,20 +16,20 @@ func OnVMSingleDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
 		return err
 	}
 	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &v1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
+		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
 			return err
 		}
 	}
 	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &v1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
 			return err
 		}
 	}
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.ConfigMap{}, crd.StreamAggrConfigName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.ConfigMap{}, crd.StreamAggrConfigName(), crd.Namespace); err != nil {
 		return err
 	}
 	if err := deleteSA(ctx, rclient, crd); err != nil {

--- a/internal/controller/operator/factory/finalize/vmuser.go
+++ b/internal/controller/operator/factory/finalize/vmuser.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"github.com/VictoriaMetrics/operator/api/operator/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // OnVMUserDelete deletes all vmuser related resources
 func OnVMUserDelete(ctx context.Context, rclient client.Client, crd *v1beta1.VMUser) error {
-	if err := removeFinalizeObjByName(ctx, rclient, &v1.Secret{}, crd.SecretName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.SecretName(), crd.Namespace); err != nil {
 		return err
 	}
 

--- a/internal/controller/operator/factory/k8stools/placeholders_test.go
+++ b/internal/controller/operator/factory/k8stools/placeholders_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -22,14 +22,14 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "render without placeholders",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "value_1",
 						"key_2": "value_2",
 					},
 				},
 			},
-			want: &v1.ConfigMap{
+			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"key_1": "value_1",
 					"key_2": "value_2",
@@ -39,7 +39,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "render without placeholders, but with specified values",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "value_1",
 						"key_2": "value_2",
@@ -50,7 +50,7 @@ func TestRenderPlaceholders(t *testing.T) {
 					"%PLACEHOLDER_2%": "new_value_2",
 				},
 			},
-			want: &v1.ConfigMap{
+			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"key_1": "value_1",
 					"key_2": "value_2",
@@ -60,7 +60,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "render with placeholders and specified values",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "%PLACEHOLDER_1%",
 						"key_2": "%PLACEHOLDER_2%",
@@ -74,7 +74,7 @@ func TestRenderPlaceholders(t *testing.T) {
 					"%PLACEHOLDER_4%": "new_value_4",
 				},
 			},
-			want: &v1.ConfigMap{
+			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"key_1": "new_value_1",
 					"key_2": "new_value_2",
@@ -86,7 +86,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "render without combined placeholders in different places of resource",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-%PLACEHOLDER_3%-%PLACEHOLDER_4%-configmap",
 					},
@@ -103,7 +103,7 @@ func TestRenderPlaceholders(t *testing.T) {
 					"%PLACEHOLDER_4%": "new-value-4",
 				},
 			},
-			want: &v1.ConfigMap{
+			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-new-value-3-new-value-4-configmap",
 				},
@@ -117,7 +117,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "placeholder with % in value",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "%PLACEHOLDER_1%",
 						"key_2": "%PLACEHOLDER_2%",
@@ -128,7 +128,7 @@ func TestRenderPlaceholders(t *testing.T) {
 					"%PLACEHOLDER_2%": "%PLACEHOLDER_2%",
 				},
 			},
-			want: &v1.ConfigMap{
+			want: &corev1.ConfigMap{
 				Data: map[string]string{
 					"key_1": "%PLACEHOLDER_1%",
 					"key_2": "%PLACEHOLDER_2%",
@@ -138,7 +138,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "placeholder with incorrect name 1",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "%PLACEHOLDER_1%",
 					},
@@ -152,7 +152,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "placeholder with incorrect name 2",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "%PLACEHOLDER_1%",
 					},
@@ -166,7 +166,7 @@ func TestRenderPlaceholders(t *testing.T) {
 		{
 			name: "placeholder with incorrect name 3",
 			args: args{
-				resource: &v1.ConfigMap{
+				resource: &corev1.ConfigMap{
 					Data: map[string]string{
 						"key_1": "%PLACEHOLDER_1%",
 					},
@@ -180,7 +180,7 @@ func TestRenderPlaceholders(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resource := tt.args.resource.(*v1.ConfigMap)
+			resource := tt.args.resource.(*corev1.ConfigMap)
 			_, err := k8stools.RenderPlaceholders(resource, tt.args.placeholders)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RenderPlaceholders() error = %v, wantErr = %v", err, tt.wantErr)

--- a/internal/controller/operator/factory/k8stools/selectors.go
+++ b/internal/controller/operator/factory/k8stools/selectors.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/VictoriaMetrics/operator/internal/config"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +69,7 @@ func VisitObjectsForSelectorsAtNs[T any, PT interface {
 // SelectNamespaces select namespaces by given label selector
 func SelectNamespaces(ctx context.Context, rclient client.Client, selector labels.Selector) ([]string, error) {
 	var matchedNs []string
-	ns := &v1.NamespaceList{}
+	ns := &corev1.NamespaceList{}
 
 	if err := rclient.List(ctx, ns, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return nil, err

--- a/internal/controller/operator/factory/reconcile/deploy_test.go
+++ b/internal/controller/operator/factory/reconcile/deploy_test.go
@@ -92,7 +92,7 @@ func TestDeployOk(t *testing.T) {
 		}
 
 		dep.Spec.Replicas = ptr.To[int32](10)
-		dep.Spec.Template.ObjectMeta.Annotations = map[string]string{"new-annotation": "value"}
+		dep.Spec.Template.Annotations = map[string]string{"new-annotation": "value"}
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("expect 1 failed to update created deploy: %s", err)
 		}
@@ -108,8 +108,8 @@ func TestDeployOk(t *testing.T) {
 		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
 
 		// expected 2 updates
-		prevDeploy.Spec.Template.ObjectMeta.Annotations = dep.Spec.Template.ObjectMeta.Annotations
-		dep.Spec.Template.ObjectMeta.Annotations = nil
+		prevDeploy.Spec.Template.Annotations = dep.Spec.Template.Annotations
+		dep.Spec.Template.Annotations = nil
 
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("expect 2 failed to update deploy: %s", err)

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -310,7 +310,7 @@ func performRollingUpdateOnSts(ctx context.Context, podMustRecreate bool, rclien
 
 // PodIsReady check is pod is ready
 func PodIsReady(pod *corev1.Pod, minReadySeconds int32) bool {
-	if pod.ObjectMeta.DeletionTimestamp != nil {
+	if pod.DeletionTimestamp != nil {
 		return false
 	}
 

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -250,8 +250,8 @@ func shouldRecreateSTSOnStorageChange(ctx context.Context, actualPVC, newPVC *co
 	}
 
 	// compare meta and spec for pvc
-	if !equality.Semantic.DeepEqual(newPVC.ObjectMeta.Labels, actualPVC.ObjectMeta.Labels) ||
-		!equality.Semantic.DeepEqual(newPVC.ObjectMeta.Annotations, actualPVC.ObjectMeta.Annotations) ||
+	if !equality.Semantic.DeepEqual(newPVC.Labels, actualPVC.Labels) ||
+		!equality.Semantic.DeepEqual(newPVC.Annotations, actualPVC.Annotations) ||
 		!equality.Semantic.DeepDerivative(newPVC.Spec, actualPVC.Spec) {
 		metaD := diffDeep(actualPVC.ObjectMeta, newPVC.ObjectMeta)
 		specD := diffDeep(actualPVC.Spec, newPVC.Spec)

--- a/internal/controller/operator/factory/reconcile/statefulset_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_test.go
@@ -470,7 +470,7 @@ func TestStatefulsetReconcileOk(t *testing.T) {
 
 		// expect 1 UpdateCalls
 		reloadSts()
-		sts.Spec.Template.ObjectMeta.Annotations = map[string]string{"new-annotation": "value"}
+		sts.Spec.Template.Annotations = map[string]string{"new-annotation": "value"}
 
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect 1 update")
 
@@ -485,8 +485,8 @@ func TestStatefulsetReconcileOk(t *testing.T) {
 		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
 
 		// expected 2 updates
-		prevSts.Spec.Template.ObjectMeta.Annotations = sts.Spec.Template.ObjectMeta.Annotations
-		sts.Spec.Template.ObjectMeta.Annotations = nil
+		prevSts.Spec.Template.Annotations = sts.Spec.Template.Annotations
+		sts.Spec.Template.Annotations = nil
 
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect 2 updates")
 		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())

--- a/internal/controller/operator/factory/vmagent/probe.go
+++ b/internal/controller/operator/factory/vmagent/probe.go
@@ -28,7 +28,7 @@ func generateProbeConfig(
 	if cr.Spec.VMProberSpec.Path == "" {
 		cr.Spec.VMProberSpec.Path = "/probe"
 	}
-	cr.Spec.EndpointScrapeParams.Path = cr.Spec.VMProberSpec.Path
+	cr.Spec.Path = cr.Spec.VMProberSpec.Path
 
 	if len(cr.Spec.Module) > 0 {
 		if cr.Spec.Params == nil {
@@ -37,7 +37,7 @@ func generateProbeConfig(
 		cr.Spec.Params["module"] = []string{cr.Spec.Module}
 	}
 	if len(cr.Spec.VMProberSpec.Scheme) > 0 {
-		cr.Spec.EndpointScrapeParams.Scheme = cr.Spec.VMProberSpec.Scheme
+		cr.Spec.Scheme = cr.Spec.VMProberSpec.Scheme
 	}
 
 	setScrapeIntervalToWithLimit(ctx, &cr.Spec.EndpointScrapeParams, vmagentCR)

--- a/internal/controller/operator/factory/vmalert/rules_test.go
+++ b/internal/controller/operator/factory/vmalert/rules_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +33,7 @@ func Test_selectNamespaces(t *testing.T) {
 		{
 			name:         "select 1 ns",
 			args:         args{selector: labels.SelectorFromValidatedSet(labels.Set{})},
-			predefinedNs: []runtime.Object{&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}}},
+			predefinedNs: []runtime.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}}},
 			want:         []string{"ns1"},
 			wantErr:      false,
 		},
@@ -41,8 +41,8 @@ func Test_selectNamespaces(t *testing.T) {
 			name: "select 1 ns with label selector",
 			args: args{selector: labels.SelectorFromValidatedSet(labels.Set{"name": "kube-system"})},
 			predefinedNs: []runtime.Object{
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"name": "kube-system"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"name": "kube-system"}}},
 			},
 			want:    []string{"kube-system"},
 			wantErr: false,
@@ -109,7 +109,7 @@ groups:
 			},
 			predefinedObjects: []runtime.Object{
 				// we need namespace for filter + object inside this namespace
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 				&vmv1beta1.VMRule{ObjectMeta: metav1.ObjectMeta{Name: "error-alert", Namespace: "default"}, Spec: vmv1beta1.VMRuleSpec{
 					Groups: []vmv1beta1.RuleGroup{{
 						Name: "error-alert", Interval: "10s",
@@ -149,8 +149,8 @@ groups:
 			},
 			predefinedObjects: []runtime.Object{
 				// we need namespace for filter + object inside this namespace
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
 				&vmv1beta1.VMRule{ObjectMeta: metav1.ObjectMeta{Name: "error-alert", Namespace: "default"}, Spec: vmv1beta1.VMRuleSpec{
 					Groups: []vmv1beta1.RuleGroup{{Name: "error-alert", Interval: "10s", Rules: []vmv1beta1.Rule{
 						{Record: "recording", Expr: "10", For: "10s", Labels: nil, Annotations: nil},
@@ -184,8 +184,8 @@ groups:
 			},
 			predefinedObjects: []runtime.Object{
 				// we need namespace for filter + object inside this namespace
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
 				&vmv1beta1.VMRule{
 					ObjectMeta: metav1.ObjectMeta{Name: "error-alert", Namespace: "default"},
 					Spec: vmv1beta1.VMRuleSpec{
@@ -235,8 +235,8 @@ groups:
 			},
 			predefinedObjects: []runtime.Object{
 				// we need namespace for filter + object inside this namespace
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-				&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Labels: map[string]string{"monitoring": "enabled"}}},
 				&vmv1beta1.VMRule{
 					ObjectMeta: metav1.ObjectMeta{Name: "error-alert", Namespace: "default"},
 					Spec: vmv1beta1.VMRuleSpec{
@@ -465,20 +465,20 @@ func Test_deduplicateRules(t *testing.T) {
 
 func Test_rulesCMDiff(t *testing.T) {
 	type args struct {
-		currentCMs []v1.ConfigMap
-		newCMs     []v1.ConfigMap
+		currentCMs []corev1.ConfigMap
+		newCMs     []corev1.ConfigMap
 	}
 	tests := []struct {
 		name     string
 		args     args
-		toCreate []v1.ConfigMap
-		toUpdate []v1.ConfigMap
+		toCreate []corev1.ConfigMap
+		toUpdate []corev1.ConfigMap
 	}{
 		{
 			name: "create one new",
 			args: args{
-				currentCMs: []v1.ConfigMap{},
-				newCMs: []v1.ConfigMap{
+				currentCMs: []corev1.ConfigMap{},
+				newCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "rules-cm-1",
@@ -486,7 +486,7 @@ func Test_rulesCMDiff(t *testing.T) {
 					},
 				},
 			},
-			toCreate: []v1.ConfigMap{
+			toCreate: []corev1.ConfigMap{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "rules-cm-1",
@@ -497,27 +497,27 @@ func Test_rulesCMDiff(t *testing.T) {
 		{
 			name: "skip exist",
 			args: args{
-				currentCMs: []v1.ConfigMap{
+				currentCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "rules-cm-1",
 						},
 					},
 				},
-				newCMs: []v1.ConfigMap{},
+				newCMs: []corev1.ConfigMap{},
 			},
 		},
 		{
 			name: "update one",
 			args: args{
-				currentCMs: []v1.ConfigMap{
+				currentCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "rules-cm-1",
 						},
 					},
 				},
-				newCMs: []v1.ConfigMap{
+				newCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "rules-cm-1",
@@ -526,7 +526,7 @@ func Test_rulesCMDiff(t *testing.T) {
 					},
 				},
 			},
-			toUpdate: []v1.ConfigMap{
+			toUpdate: []corev1.ConfigMap{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "rules-cm-1",
@@ -540,7 +540,7 @@ func Test_rulesCMDiff(t *testing.T) {
 		{
 			name: "update two",
 			args: args{
-				currentCMs: []v1.ConfigMap{
+				currentCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "rules-cm-0",
@@ -562,7 +562,7 @@ func Test_rulesCMDiff(t *testing.T) {
 						},
 					},
 				},
-				newCMs: []v1.ConfigMap{
+				newCMs: []corev1.ConfigMap{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "rules-cm-0",
@@ -581,7 +581,7 @@ func Test_rulesCMDiff(t *testing.T) {
 					},
 				},
 			},
-			toUpdate: []v1.ConfigMap{
+			toUpdate: []corev1.ConfigMap{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "rules-cm-0",

--- a/internal/controller/operator/factory/vmauth/vmusers_config.go
+++ b/internal/controller/operator/factory/vmauth/vmusers_config.go
@@ -771,32 +771,32 @@ func genURLMaps(userName string, refs []vmv1beta1.TargetRef, result yaml.MapSlic
 				Value: ref.Hosts,
 			})
 		}
-		if ref.URLMapCommon.DiscoverBackendIPs != nil {
+		if ref.DiscoverBackendIPs != nil {
 			urlMap = append(urlMap, yaml.MapItem{
 				Key:   "discover_backend_ips",
-				Value: *ref.URLMapCommon.DiscoverBackendIPs,
+				Value: *ref.DiscoverBackendIPs,
 			},
 			)
 		}
-		urlMap = appendIfNotEmpty(ref.URLMapCommon.SrcHeaders, "src_headers", urlMap)
-		urlMap = appendIfNotEmpty(ref.URLMapCommon.SrcQueryArgs, "src_query_args", urlMap)
-		if len(ref.URLMapCommon.RequestHeaders) > 0 {
+		urlMap = appendIfNotEmpty(ref.SrcHeaders, "src_headers", urlMap)
+		urlMap = appendIfNotEmpty(ref.SrcQueryArgs, "src_query_args", urlMap)
+		if len(ref.RequestHeaders) > 0 {
 			urlMap = append(urlMap, yaml.MapItem{
 				Key:   "headers",
-				Value: ref.URLMapCommon.RequestHeaders,
+				Value: ref.RequestHeaders,
 			})
 		}
-		if len(ref.URLMapCommon.ResponseHeaders) > 0 {
-			urlMap = append(urlMap, yaml.MapItem{Key: "response_headers", Value: ref.URLMapCommon.ResponseHeaders})
+		if len(ref.ResponseHeaders) > 0 {
+			urlMap = append(urlMap, yaml.MapItem{Key: "response_headers", Value: ref.ResponseHeaders})
 		}
-		if len(ref.URLMapCommon.RetryStatusCodes) > 0 {
-			urlMap = append(urlMap, yaml.MapItem{Key: "retry_status_codes", Value: ref.URLMapCommon.RetryStatusCodes})
+		if len(ref.RetryStatusCodes) > 0 {
+			urlMap = append(urlMap, yaml.MapItem{Key: "retry_status_codes", Value: ref.RetryStatusCodes})
 		}
-		if ref.URLMapCommon.DropSrcPathPrefixParts != nil {
-			urlMap = append(urlMap, yaml.MapItem{Key: "drop_src_path_prefix_parts", Value: ref.URLMapCommon.DropSrcPathPrefixParts})
+		if ref.DropSrcPathPrefixParts != nil {
+			urlMap = append(urlMap, yaml.MapItem{Key: "drop_src_path_prefix_parts", Value: ref.DropSrcPathPrefixParts})
 		}
-		if ref.URLMapCommon.LoadBalancingPolicy != nil {
-			urlMap = append(urlMap, yaml.MapItem{Key: "load_balancing_policy", Value: ref.URLMapCommon.LoadBalancingPolicy})
+		if ref.LoadBalancingPolicy != nil {
+			urlMap = append(urlMap, yaml.MapItem{Key: "load_balancing_policy", Value: ref.LoadBalancingPolicy})
 		}
 		urlMaps = append(urlMaps, urlMap)
 	}

--- a/internal/controller/operator/suite_test.go
+++ b/internal/controller/operator/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	operatorv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
+	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
@@ -69,10 +69,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = vmv1beta1.AddToScheme(scheme.Scheme)
+	err = vmv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = operatorv1.AddToScheme(scheme.Scheme)
+	err = vmv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -27,7 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/finalize"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
@@ -57,7 +57,7 @@ func (r *VLClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *run
 func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	reqLogger := r.Log.WithValues("vlcluster", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, reqLogger)
-	instance := &operatorv1.VLCluster{}
+	instance := &vmv1beta1.VLCluster{}
 
 	defer func() {
 		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
@@ -98,7 +98,7 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *VLClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1.VLCluster{}).
+		For(&vmv1beta1.VLCluster{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/operator/vlcluster_controller_test.go
+++ b/internal/controller/operator/vlcluster_controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 )
 
 var _ = Describe("VLCluster Controller", func() {
@@ -40,13 +40,13 @@ var _ = Describe("VLCluster Controller", func() {
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
-		vlcluster := &operatorv1.VLCluster{}
+		vlcluster := &vmv1beta1.VLCluster{}
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind VLCluster")
 			err := k8sClient.Get(ctx, typeNamespacedName, vlcluster)
 			if err != nil && errors.IsNotFound(err) {
-				resource := &operatorv1.VLCluster{
+				resource := &vmv1beta1.VLCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
 						Namespace: "default",
@@ -59,7 +59,7 @@ var _ = Describe("VLCluster Controller", func() {
 
 		AfterEach(func() {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &operatorv1.VLCluster{}
+			resource := &vmv1beta1.VLCluster{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -27,7 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/finalize"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
@@ -58,7 +58,7 @@ func (r *VLSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runt
 func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	reqLogger := r.Log.WithValues("vlsingle", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, reqLogger)
-	instance := &operatorv1.VLSingle{}
+	instance := &vmv1beta1.VLSingle{}
 
 	defer func() {
 		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
@@ -99,7 +99,7 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 // SetupWithManager sets up the controller with the Manager.
 func (r *VLSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1.VLSingle{}).
+		For(&vmv1beta1.VLSingle{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vlsingle_controller_test.go
+++ b/internal/controller/operator/vlsingle_controller_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 )
 
 var _ = Describe("VLSingle Controller", func() {
@@ -40,13 +40,13 @@ var _ = Describe("VLSingle Controller", func() {
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
-		vlsingle := &operatorv1.VLSingle{}
+		vlsingle := &vmv1beta1.VLSingle{}
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind VLSingle")
 			err := k8sClient.Get(ctx, typeNamespacedName, vlsingle)
 			if err != nil && errors.IsNotFound(err) {
-				resource := &operatorv1.VLSingle{
+				resource := &vmv1beta1.VLSingle{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
 						Namespace: "default",
@@ -59,7 +59,7 @@ var _ = Describe("VLSingle Controller", func() {
 
 		AfterEach(func() {
 			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &operatorv1.VLSingle{}
+			resource := &vmv1beta1.VLSingle{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,7 +138,7 @@ func (r *VMAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&vmv1beta1.VMAgent{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
-		Owns(&v1.ServiceAccount{}).
+		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)
 }

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,7 +115,7 @@ func (r *VMAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAlert{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&v1.ServiceAccount{}).
+		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)
 }

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -113,7 +113,7 @@ func (r *VMAlertmanagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAlertmanager{}).
 		Owns(&appsv1.StatefulSet{}).
-		Owns(&v1.ServiceAccount{}).
+		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)
 }

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -126,7 +126,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 func (r *VMUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMUser{}).
-		Owns(&v1.Secret{}, builder.OnlyMetadata).
+		Owns(&corev1.Secret{}, builder.OnlyMetadata).
 		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 	"github.com/VictoriaMetrics/operator/internal/manager"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint
+	. "github.com/onsi/gomega"    //nolint
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -64,7 +64,7 @@ var _ = Describe("test vlsingle Controller", func() {
 			verify func(*vmv1.VLCluster)
 		}
 
-		DescribeTable("should peform update steps",
+		DescribeTable("should perform update steps",
 			func(name string, initCR *vmv1.VLCluster, steps ...testStep) {
 				initCR.Name = name
 				initCR.Namespace = namespace

--- a/test/e2e/vmauth_test.go
+++ b/test/e2e/vmauth_test.go
@@ -434,7 +434,7 @@ var _ = Describe("test vmauth Controller", func() {
 					testStep{
 						modify: func(cr *v1beta1vm.VMAuth) {
 							cr.Spec.ConfigSecret = ""
-							cr.Spec.ExternalConfig.SecretRef = &corev1.SecretKeySelector{
+							cr.Spec.SecretRef = &corev1.SecretKeySelector{
 								Key: "config.yaml",
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "auth-ext-config",
@@ -491,7 +491,7 @@ var _ = Describe("test vmauth Controller", func() {
 							})
 						},
 						modify: func(cr *v1beta1vm.VMAuth) {
-							cr.Spec.ExternalConfig.LocalPath = "/etc/local-config/vmauth.yaml"
+							cr.Spec.LocalPath = "/etc/local-config/vmauth.yaml"
 							cr.Spec.Volumes = append(cr.Spec.Volumes, corev1.Volume{
 								Name: "local-cfg",
 								VolumeSource: corev1.VolumeSource{

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1vm "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,7 +31,7 @@ var _ = Describe("e2e vmcluster", func() {
 			ctx = context.Background()
 		})
 		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, &v1beta1vm.VMCluster{
+			Expect(k8sClient.Delete(ctx, &vmv1beta1.VMCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      namespacedName.Name,
@@ -42,7 +41,7 @@ var _ = Describe("e2e vmcluster", func() {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      namespacedName.Name,
 					Namespace: namespace,
-				}, &v1beta1vm.VMCluster{})
+				}, &vmv1beta1.VMCluster{})
 				if errors.IsNotFound(err) {
 					return nil
 				}
@@ -50,47 +49,47 @@ var _ = Describe("e2e vmcluster", func() {
 			}, eventualDeletionTimeout, 1).WithContext(ctx).Should(Succeed())
 		})
 
-		DescribeTable("should create vmcluster", func(name string, cr *v1beta1vm.VMCluster, verify func(cr *v1beta1vm.VMCluster)) {
+		DescribeTable("should create vmcluster", func(name string, cr *vmv1beta1.VMCluster, verify func(cr *vmv1beta1.VMCluster)) {
 			namespacedName.Name = name
 			cr.Name = name
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())
 			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &v1beta1vm.VMCluster{}, namespacedName)
+				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, namespacedName)
 			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).Should(Succeed())
 			if verify != nil {
-				var createdCluster v1beta1vm.VMCluster
+				var createdCluster vmv1beta1.VMCluster
 				Expect(k8sClient.Get(ctx, namespacedName, &createdCluster)).To(Succeed())
 				verify(&createdCluster)
 			}
 
 		},
-			Entry("without any components", "empty", &v1beta1vm.VMCluster{
+			Entry("without any components", "empty", &vmv1beta1.VMCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      namespacedName.Name,
 				},
-				Spec: v1beta1vm.VMClusterSpec{RetentionPeriod: "1"},
+				Spec: vmv1beta1.VMClusterSpec{RetentionPeriod: "1"},
 			}, nil,
 			),
 			Entry("with all components", "all-services",
-				&v1beta1vm.VMCluster{
+				&vmv1beta1.VMCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
 						Name:      namespacedName.Name,
 					},
-					Spec: v1beta1vm.VMClusterSpec{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
@@ -98,40 +97,40 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 				nil,
 			),
-			Entry("with vmstorage and vmselect", "with-select", &v1beta1vm.VMCluster{
+			Entry("with vmstorage and vmselect", "with-select", &vmv1beta1.VMCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      namespacedName.Name,
 				},
-				Spec: v1beta1vm.VMClusterSpec{
+				Spec: vmv1beta1.VMClusterSpec{
 					RetentionPeriod: "1",
-					VMStorage: &v1beta1vm.VMStorage{
-						CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+					VMStorage: &vmv1beta1.VMStorage{
+						CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 					},
-					VMSelect: &v1beta1vm.VMSelect{
-						CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+					VMSelect: &vmv1beta1.VMSelect{
+						CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 					},
 				},
 			}, nil,
 			),
-			Entry("with vmstorage and vminsert", "with-insert", &v1beta1vm.VMCluster{
+			Entry("with vmstorage and vminsert", "with-insert", &vmv1beta1.VMCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      namespacedName.Name,
 				},
-				Spec: v1beta1vm.VMClusterSpec{
+				Spec: vmv1beta1.VMClusterSpec{
 					RetentionPeriod: "1",
-					VMStorage: &v1beta1vm.VMStorage{
-						CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+					VMStorage: &vmv1beta1.VMStorage{
+						CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 					},
-					VMInsert: &v1beta1vm.VMInsert{
-						CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+					VMInsert: &vmv1beta1.VMInsert{
+						CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 					},
@@ -139,44 +138,44 @@ var _ = Describe("e2e vmcluster", func() {
 			},
 				nil),
 			Entry("with security enable and without default resources", "all-secure",
-				&v1beta1vm.VMCluster{
+				&vmv1beta1.VMCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
 						Name:      namespacedName.Name,
 					},
-					Spec: v1beta1vm.VMClusterSpec{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseStrictSecurity:   ptr.To(true),
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseStrictSecurity:   ptr.To(true),
 								UseDefaultResources: ptr.To(false),
 							},
 
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMInsert: &vmv1beta1.VMInsert{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseStrictSecurity:   ptr.To(true),
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
 					},
 				},
-				func(cr *v1beta1vm.VMCluster) {
+				func(cr *vmv1beta1.VMCluster) {
 					clusterNsnObjects := map[types.NamespacedName]client.Object{
 						{Namespace: cr.Namespace, Name: cr.GetVMInsertName()}:  &appsv1.Deployment{},
 						{Namespace: cr.Namespace, Name: cr.GetVMStorageName()}: &appsv1.StatefulSet{},
@@ -197,63 +196,63 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 			),
 			Entry("with external security enable and UseStrictSecurity:false", "all-secure-external",
-				&v1beta1vm.VMCluster{
+				&vmv1beta1.VMCluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
 						Name:      namespacedName.Name,
 					},
-					Spec: v1beta1vm.VMClusterSpec{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
-								SecurityContext: &v1beta1vm.SecurityContext{
+								SecurityContext: &vmv1beta1.SecurityContext{
 									PodSecurityContext: &corev1.PodSecurityContext{
 										RunAsNonRoot: ptr.To(true),
 										RunAsUser:    ptr.To(int64(65534)),
 										RunAsGroup:   ptr.To(int64(65534)),
 									},
-									ContainerSecurityContext: &v1beta1vm.ContainerSecurityContext{
+									ContainerSecurityContext: &vmv1beta1.ContainerSecurityContext{
 										Privileged: ptr.To(false),
 									},
 								},
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
 
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
-								SecurityContext: &v1beta1vm.SecurityContext{
+								SecurityContext: &vmv1beta1.SecurityContext{
 									PodSecurityContext: &corev1.PodSecurityContext{
 										RunAsNonRoot: ptr.To(true),
 										RunAsUser:    ptr.To(int64(65534)),
 										RunAsGroup:   ptr.To(int64(65534)),
 									},
-									ContainerSecurityContext: &v1beta1vm.ContainerSecurityContext{
+									ContainerSecurityContext: &vmv1beta1.ContainerSecurityContext{
 										Privileged: ptr.To(false),
 									},
 								},
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						VMInsert: &vmv1beta1.VMInsert{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
-								SecurityContext: &v1beta1vm.SecurityContext{
+								SecurityContext: &vmv1beta1.SecurityContext{
 									PodSecurityContext: &corev1.PodSecurityContext{
 										RunAsNonRoot: ptr.To(true),
 										RunAsUser:    ptr.To(int64(65534)),
 										RunAsGroup:   ptr.To(int64(65534)),
 									},
-									ContainerSecurityContext: &v1beta1vm.ContainerSecurityContext{
+									ContainerSecurityContext: &vmv1beta1.ContainerSecurityContext{
 										Privileged: ptr.To(false),
 									},
 								},
@@ -261,7 +260,7 @@ var _ = Describe("e2e vmcluster", func() {
 						},
 					},
 				},
-				func(cr *v1beta1vm.VMCluster) {
+				func(cr *vmv1beta1.VMCluster) {
 					clusterNsnObjects := map[types.NamespacedName]client.Object{
 						{Namespace: cr.Namespace, Name: cr.GetVMInsertName()}:  &appsv1.Deployment{},
 						{Namespace: cr.Namespace, Name: cr.GetVMStorageName()}: &appsv1.StatefulSet{},
@@ -285,7 +284,7 @@ var _ = Describe("e2e vmcluster", func() {
 	})
 	Context("update", func() {
 		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, &v1beta1vm.VMCluster{
+			Expect(k8sClient.Delete(ctx, &vmv1beta1.VMCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      namespacedName.Name,
@@ -295,19 +294,19 @@ var _ = Describe("e2e vmcluster", func() {
 				return k8sClient.Get(context.Background(), types.NamespacedName{
 					Name:      namespacedName.Name,
 					Namespace: namespace,
-				}, &v1beta1vm.VMCluster{})
+				}, &vmv1beta1.VMCluster{})
 
 			}, eventualDeletionTimeout).WithContext(ctx).Should(MatchError(errors.IsNotFound, "want not found error"))
 		})
 
 		type testStep struct {
-			setup  func(*v1beta1vm.VMCluster)
-			modify func(*v1beta1vm.VMCluster)
-			verify func(*v1beta1vm.VMCluster)
+			setup  func(*vmv1beta1.VMCluster)
+			modify func(*vmv1beta1.VMCluster)
+			verify func(*vmv1beta1.VMCluster)
 		}
 
 		DescribeTable("should update exist cluster",
-			func(name string, initCR *v1beta1vm.VMCluster, steps ...testStep) {
+			func(name string, initCR *vmv1beta1.VMCluster, steps ...testStep) {
 				namespacedName.Name = name
 				initCR.Namespace = namespace
 				initCR.Name = name
@@ -322,7 +321,7 @@ var _ = Describe("e2e vmcluster", func() {
 					}
 					// update and wait ready
 					Eventually(func() error {
-						var toUpdate v1beta1.VMCluster
+						var toUpdate vmv1beta1.VMCluster
 						if err := k8sClient.Get(ctx, namespacedName, &toUpdate); err != nil {
 							return err
 						}
@@ -335,64 +334,64 @@ var _ = Describe("e2e vmcluster", func() {
 					Eventually(func() error {
 						return expectObjectStatusOperational(ctx, k8sClient, initCR, namespacedName)
 					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).Should(Succeed())
-					var updated v1beta1vm.VMCluster
+					var updated vmv1beta1.VMCluster
 					Expect(k8sClient.Get(ctx, namespacedName, &updated)).To(Succeed())
 					step.verify(&updated)
 				}
 			},
 			Entry("by scaling select and storage replicas to 2", "storage-select-r-2",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage.ReplicaCount = ptr.To[int32](2)
 						cr.Spec.VMSelect.ReplicaCount = ptr.To[int32](2)
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMStorageSelectorLabels())).To(BeEmpty())
 						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMSelectSelectorLabels())).To(BeEmpty())
 					},
 				},
 			),
 			Entry("by adding vmbackupmanager to vmstorage ", "with-backup",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage.InitContainers = []corev1.Container{
 							{
 								Name:  "create-dir",
@@ -421,7 +420,7 @@ var _ = Describe("e2e vmcluster", func() {
 						cr.Spec.VMStorage.Volumes = []corev1.Volume{
 							{Name: "backup", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 						}
-						cr.Spec.VMStorage.VMBackup = &v1beta1.VMBackup{
+						cr.Spec.VMStorage.VMBackup = &vmv1beta1.VMBackup{
 							AcceptEULA:  true,
 							Destination: "fs:///opt/backup-dir",
 							VolumeMounts: []corev1.VolumeMount{
@@ -430,7 +429,7 @@ var _ = Describe("e2e vmcluster", func() {
 						}
 
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						nss := types.NamespacedName{
 							Namespace: namespace,
 							Name:      cr.GetVMStorageName(),
@@ -438,39 +437,39 @@ var _ = Describe("e2e vmcluster", func() {
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
 						Expect(svc.Spec.Ports).To(HaveLen(4))
-						var vss v1beta1.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(vss.Spec.Endpoints).To(HaveLen(2))
 					},
 				},
 			),
 			Entry("by scaling storage and insert replicas to 2", "storage-insert-r-2",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage.ReplicaCount = ptr.To[int32](2)
 						cr.Spec.VMInsert.ReplicaCount = ptr.To[int32](2)
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMStorageSelectorLabels())).To(BeEmpty())
 						Eventually(func() string {
 							return expectPodCount(k8sClient, 2, namespace, cr.VMInsertSelectorLabels())
@@ -479,62 +478,62 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 			),
 			Entry("by changing storage revisionHistoryLimit to 2", "storage-revision-2",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage.RevisionHistoryLimitCount = ptr.To[int32](2)
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
-						var updatedCluster v1beta1vm.VMCluster
+					verify: func(cr *vmv1beta1.VMCluster) {
+						var updatedCluster vmv1beta1.VMCluster
 						Expect(k8sClient.Get(ctx, namespacedName, &updatedCluster)).To(Succeed())
 						Expect(*updatedCluster.Spec.VMStorage.RevisionHistoryLimitCount).To(Equal(int32(2)))
 					},
 				},
 			),
 			Entry("by adding clusterNative ports", "storage-native-r-2",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMInsert.ClusterNativePort = "8035"
 						cr.Spec.VMSelect.ClusterNativePort = "8036"
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						var updatedSvc corev1.Service
 						Expect(k8sClient.Get(ctx,
 							types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name},
@@ -552,35 +551,35 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 			),
 			Entry("by deleting select component", "select-delete",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					setup: func(cr *v1beta1vm.VMCluster) {
+					setup: func(cr *vmv1beta1.VMCluster) {
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &appsv1.StatefulSet{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 					},
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMSelect = nil
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Eventually(func() error {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &appsv1.StatefulSet{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
@@ -588,66 +587,66 @@ var _ = Describe("e2e vmcluster", func() {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &corev1.Service{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
 						Eventually(func() error {
-							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &v1beta1vm.VMServiceScrape{})
+							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &vmv1beta1.VMServiceScrape{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
 
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
-						cr.Spec.VMSelect = &v1beta1vm.VMSelect{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+					modify: func(cr *vmv1beta1.VMCluster) {
+						cr.Spec.VMSelect = &vmv1beta1.VMSelect{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &appsv1.StatefulSet{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 					},
 				},
 			),
 			Entry("by deleting storage and insert components", "storage-insert-delete",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					setup: func(cr *v1beta1vm.VMCluster) {
+					setup: func(cr *vmv1beta1.VMCluster) {
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &appsv1.StatefulSet{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &appsv1.Deployment{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 					},
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage = nil
 						cr.Spec.VMInsert = nil
 						cr.Spec.VMSelect.ExtraArgs = map[string]string{
 							"storageNode": "http://non-exist-vmstorage:8402",
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Eventually(func() error {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &appsv1.StatefulSet{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
@@ -655,7 +654,7 @@ var _ = Describe("e2e vmcluster", func() {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &corev1.Service{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
 						Eventually(func() error {
-							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &v1beta1vm.VMServiceScrape{})
+							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &vmv1beta1.VMServiceScrape{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
 						Eventually(func() error {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &appsv1.Deployment{})
@@ -664,44 +663,44 @@ var _ = Describe("e2e vmcluster", func() {
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
-						cr.Spec.VMStorage = &v1beta1vm.VMStorage{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+					modify: func(cr *vmv1beta1.VMCluster) {
+						cr.Spec.VMStorage = &vmv1beta1.VMStorage{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						}
-						cr.Spec.VMInsert = &v1beta1vm.VMInsert{
-							CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+						cr.Spec.VMInsert = &vmv1beta1.VMInsert{
+							CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 								UseDefaultResources: ptr.To(false),
 							},
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &appsv1.StatefulSet{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &appsv1.Deployment{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &corev1.Service{})).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &v1beta1vm.VMServiceScrape{})).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vminsert-" + cr.Name}, &vmv1beta1.VMServiceScrape{})).To(Succeed())
 					},
 				},
 			),
 			Entry("by deleting deleting and renaming additional services", "select-additional-svc",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
-							ServiceSpec: &v1beta1vm.AdditionalServiceSpec{
-								EmbeddedObjectMetadata: v1beta1vm.EmbeddedObjectMetadata{
+							ServiceSpec: &vmv1beta1.AdditionalServiceSpec{
+								EmbeddedObjectMetadata: vmv1beta1.EmbeddedObjectMetadata{
 									Name: "my-service-name",
 								},
 								Spec: corev1.ServiceSpec{
@@ -716,11 +715,11 @@ var _ = Describe("e2e vmcluster", func() {
 								},
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
-							ServiceSpec: &v1beta1vm.AdditionalServiceSpec{
+							ServiceSpec: &vmv1beta1.AdditionalServiceSpec{
 								Spec: corev1.ServiceSpec{
 									Type: corev1.ServiceTypeClusterIP,
 									Ports: []corev1.ServicePort{
@@ -736,15 +735,15 @@ var _ = Describe("e2e vmcluster", func() {
 					},
 				},
 				testStep{
-					setup: func(cr *v1beta1vm.VMCluster) {
+					setup: func(cr *vmv1beta1.VMCluster) {
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name + "-additional-service"}, &corev1.Service{})).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "my-service-name"}, &corev1.Service{})).To(Succeed())
 					},
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMSelect.ServiceSpec = nil
 						cr.Spec.VMStorage.ServiceSpec.Name = ""
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Eventually(func() error {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmselect-" + cr.Name + "-additional-service"}, &corev1.Service{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
@@ -753,10 +752,10 @@ var _ = Describe("e2e vmcluster", func() {
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.VMStorage.ServiceSpec.UseAsDefault = true
-						cr.Spec.VMSelect.ServiceSpec = &v1beta1vm.AdditionalServiceSpec{
-							EmbeddedObjectMetadata: v1beta1vm.EmbeddedObjectMetadata{
+						cr.Spec.VMSelect.ServiceSpec = &vmv1beta1.AdditionalServiceSpec{
+							EmbeddedObjectMetadata: vmv1beta1.EmbeddedObjectMetadata{
 								Name: "my-service-name-v2",
 							},
 							Spec: corev1.ServiceSpec{
@@ -771,7 +770,7 @@ var _ = Describe("e2e vmcluster", func() {
 							},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						Eventually(func() error {
 							return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name + "-additional-service"}, &corev1.Service{})
 						}, eventualDeletionTimeout).Should(MatchError(errors.IsNotFound, "IsNotFound"))
@@ -783,28 +782,28 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 			),
 			Entry("by adding imagePullSecret", "storage-image-pull-secret",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod:  "1",
 						ImagePullSecrets: nil,
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					setup: func(v *v1beta1vm.VMCluster) {
+					setup: func(v *vmv1beta1.VMCluster) {
 						pullSecret := corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{Name: "test-pull-secret", Namespace: namespace},
 							Data: map[string][]byte{
@@ -814,12 +813,12 @@ var _ = Describe("e2e vmcluster", func() {
 						}
 						Expect(k8sClient.Create(ctx, &pullSecret)).To(Succeed())
 					},
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 							{Name: "test-pull-secret"},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						var sts appsv1.StatefulSet
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMStorageName()}
 						Expect(k8sClient.Get(ctx, nss, &sts)).To(Succeed())
@@ -831,30 +830,30 @@ var _ = Describe("e2e vmcluster", func() {
 				},
 			),
 			Entry("by switching to vmauth loadbalancer", "with-load-balancing",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						RequestsLoadBalancer: v1beta1vm.VMAuthLoadBalancer{
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
 							Enabled: false,
 						},
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					setup: func(cr *v1beta1vm.VMCluster) {
+					setup: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
 							payload: `up{bar="baz"} 123
@@ -866,10 +865,10 @@ up{baz="bar"} 123
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
 						})
 					},
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Enabled = true
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						By("switching enabling loadbalanacer")
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
@@ -880,7 +879,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
@@ -899,10 +898,10 @@ up{baz="bar"} 123
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Enabled = false
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						By("disabling loadbalancer")
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
@@ -915,7 +914,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(MatchError(errors.IsNotFound, "IsNotFound"))
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(MatchError(errors.IsNotFound, "IsNotFound"))
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)).To(Succeed())
@@ -935,34 +934,34 @@ up{baz="bar"} 123
 				},
 			),
 			Entry("by switching partially to vmauth loadbalanacer", "with-partial-load-balancing",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						RequestsLoadBalancer: v1beta1vm.VMAuthLoadBalancer{
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
 							Enabled: false,
 						},
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Enabled = true
 						cr.Spec.RequestsLoadBalancer.DisableInsertBalancing = true
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
 							payload: `up{bar="baz"} 123
@@ -982,7 +981,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(MatchError(errors.IsNotFound, "IsNotFound"))
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
@@ -992,12 +991,12 @@ up{baz="bar"} 123
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Enabled = true
 						cr.Spec.RequestsLoadBalancer.DisableInsertBalancing = false
 						cr.Spec.RequestsLoadBalancer.Spec.ReplicaCount = ptr.To[int32](2)
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
 						Expect(k8sClient.Get(ctx, nss, &lbDep)).To(Succeed())
@@ -1008,7 +1007,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
@@ -1027,13 +1026,13 @@ up{baz="bar"} 123
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Enabled = true
 						cr.Spec.RequestsLoadBalancer.DisableInsertBalancing = false
 						cr.Spec.RequestsLoadBalancer.DisableSelectBalancing = true
 						cr.Spec.RequestsLoadBalancer.Spec.ReplicaCount = ptr.To[int32](2)
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						By("disabling select loadbalancing")
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
@@ -1045,7 +1044,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(MatchError(errors.IsNotFound, "IsNotFound"))
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(MatchError(errors.IsNotFound, "IsNotFound"))
@@ -1065,48 +1064,48 @@ up{baz="bar"} 123
 				},
 			),
 			Entry("by running with load-balancer and modify vmauth", "with-load-balancing-modify-auth",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
 						RetentionPeriod: "1",
-						RequestsLoadBalancer: v1beta1vm.VMAuthLoadBalancer{
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
 							Enabled: true,
-							Spec: v1beta1vm.VMAuthLoadBalancerSpec{
-								CommonDefaultableParams: v1beta1vm.CommonDefaultableParams{
+							Spec: vmv1beta1.VMAuthLoadBalancerSpec{
+								CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 									Port: "8431",
 								},
 							},
 						},
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](2),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Spec.ReplicaCount = ptr.To[int32](2)
 						cr.Spec.RequestsLoadBalancer.Spec.UseStrictSecurity = ptr.To(true)
-						cr.Spec.RequestsLoadBalancer.Spec.AdditionalServiceSpec = &v1beta1vm.AdditionalServiceSpec{
+						cr.Spec.RequestsLoadBalancer.Spec.AdditionalServiceSpec = &vmv1beta1.AdditionalServiceSpec{
 							Spec: corev1.ServiceSpec{
 								Type:      corev1.ServiceTypeClusterIP,
 								ClusterIP: corev1.ClusterIPNone,
 							},
 						}
-						cr.Spec.RequestsLoadBalancer.Spec.PodDisruptionBudget = &v1beta1vm.EmbeddedPodDisruptionBudgetSpec{
+						cr.Spec.RequestsLoadBalancer.Spec.PodDisruptionBudget = &vmv1beta1.EmbeddedPodDisruptionBudgetSpec{
 							MaxUnavailable: ptr.To(intstr.Parse("1")),
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
 							payload: `up{bar="baz"} 123
@@ -1130,7 +1129,7 @@ up{baz="bar"} 123
 						Expect(svc.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
 						Expect(svc.Spec.Ports).To(HaveLen(1))
 						Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.Parse("8431")))
-						var vss v1beta1vm.VMServiceScrape
+						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
@@ -1141,14 +1140,14 @@ up{baz="bar"} 123
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
+					modify: func(cr *vmv1beta1.VMCluster) {
 						cr.Spec.RequestsLoadBalancer.Spec.ReplicaCount = ptr.To[int32](1)
 						cr.Spec.RequestsLoadBalancer.Spec.UseStrictSecurity = ptr.To(false)
 						cr.Spec.RequestsLoadBalancer.Spec.AdditionalServiceSpec = nil
 						cr.Spec.RequestsLoadBalancer.Spec.PodDisruptionBudget = nil
 						cr.Spec.RequestsLoadBalancer.Spec.Port = ""
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
 							payload: `up{bar="baz"} 123
@@ -1175,35 +1174,35 @@ up{baz="bar"} 123
 				},
 			),
 			Entry("by changing annotations for created objects", "manage-annotations",
-				&v1beta1vm.VMCluster{
-					Spec: v1beta1vm.VMClusterSpec{
-						RequestsLoadBalancer: v1beta1vm.VMAuthLoadBalancer{Enabled: true},
+				&vmv1beta1.VMCluster{
+					Spec: vmv1beta1.VMClusterSpec{
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{Enabled: true},
 						RetentionPeriod:      "1",
-						VMStorage: &v1beta1vm.VMStorage{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMSelect: &v1beta1vm.VMSelect{
-							CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 								ReplicaCount: ptr.To[int32](1),
 							},
 						},
-						VMInsert: &v1beta1vm.VMInsert{CommonApplicationDeploymentParams: v1beta1vm.CommonApplicationDeploymentParams{
+						VMInsert: &vmv1beta1.VMInsert{CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 							ReplicaCount: ptr.To[int32](1),
 						},
 						},
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
-						cr.Spec.ManagedMetadata = &v1beta1vm.ManagedObjectsMetadata{
+					modify: func(cr *vmv1beta1.VMCluster) {
+						cr.Spec.ManagedMetadata = &vmv1beta1.ManagedObjectsMetadata{
 							// attempt to change selector label should fail
 							Labels:      map[string]string{"label-1": "value-1", "label-2": "value-2", "managed-by": "wrong-value"},
 							Annotations: map[string]string{"annotation-1": "value-a-1", "annotation-2": "value-a-2"},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						expectedAnnotations := map[string]string{"annotation-1": "value-a-1", "annotation-2": "value-a-2"}
 						expectedLabels := map[string]string{"label-1": "value-1", "label-2": "value-2", "managed-by": "vm-operator"}
 						selectN, insertN, storageN, lbName, saName := cr.GetVMSelectName(), cr.GetVMInsertName(), cr.GetVMStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()
@@ -1223,12 +1222,12 @@ up{baz="bar"} 123
 					},
 				},
 				testStep{
-					modify: func(cr *v1beta1vm.VMCluster) {
-						cr.Spec.ManagedMetadata = &v1beta1vm.ManagedObjectsMetadata{
+					modify: func(cr *vmv1beta1.VMCluster) {
+						cr.Spec.ManagedMetadata = &vmv1beta1.ManagedObjectsMetadata{
 							Annotations: map[string]string{"annotation-1": "value-a-1"},
 						}
 					},
-					verify: func(cr *v1beta1vm.VMCluster) {
+					verify: func(cr *vmv1beta1.VMCluster) {
 						expectedAnnotations := map[string]string{"annotation-1": "value-a-1", "annotation-2": ""}
 						expectedLabels := map[string]string{"label-1": "", "label-2": "", "managed-by": "vm-operator"}
 						selectN, insertN, storageN, lbName, saName := cr.GetVMSelectName(), cr.GetVMInsertName(), cr.GetVMStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint
 )
 
 const (
@@ -109,6 +109,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
hey @f41gh7, extracted part of straightforward changes from [this PR](https://github.com/VictoriaMetrics/operator/pull/1384), this should be easy to review:
- consistently use `corev1` alias for `k8s.io/api/core/v1` package
- golangci lint upgrade