### PR TITLE
Fix for filtering Prometheus Operator's object labels/annotations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ To perform migration to the `VLSingle` please follow [this docs](https://docs.vi
 * FEATURE: [operator](https://docs.victoriametrics.com/operator): introduce new flags for leader election configuration - `leader-elect-lease-duration`, `leader-elect-renew-deadline`. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1362) for details.
 * FEATURE: [operator](https://docs.victoriametrics.com/operator): add `spec.configMaps` as `volumeMounts` for watch with `config-reloader` container for `VMAgent` and `VMAlert` components. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1370) for details.
 
+* BUGFIX: [converter](https://docs.victoriametrics.com/operator/migration/#objects-conversion): properly apply filter prefixes for objects with `VM_FILTERPROMETHEUSCONVERTERLABELPREFIXES` and `VM_FILTERPROMETHEUSCONVERTERANNOTATIONPREFIXES` env variables. See this PR [1391](https://github.com/VictoriaMetrics/operator/pull/1391) for details. Thanks to the @padlyuck
 * BUGFIX: [operator](https://docs.victoriametrics.com/operator/api): remove alerting rule `BadObjects` as metric `operator_controller_bad_objects_count` isn't exposed anymore.
 * BUGFIX: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): fixes typo at `addDefaults` function for `VMCLuster`, it prevents possible panic if `VMInsert` is not configured. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1375) for details.
 

--- a/internal/controller/operator/converter/apis.go
+++ b/internal/controller/operator/converter/apis.go
@@ -516,10 +516,13 @@ func FilterPrefixes(src map[string]string, filterPrefixes []string) map[string]s
 	}
 	dst := make(map[string]string, len(src))
 	for k, v := range src {
+		ignoreKey := false
 		for _, filterPref := range filterPrefixes {
-			if strings.HasPrefix(k, filterPref) {
-				continue
+			if ignoreKey = strings.HasPrefix(k, filterPref); ignoreKey {
+				break
 			}
+		}
+		if !ignoreKey {
 			dst[k] = v
 		}
 	}

--- a/internal/controller/operator/converter/apis_test.go
+++ b/internal/controller/operator/converter/apis_test.go
@@ -277,8 +277,8 @@ func TestConvertServiceMonitor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ConvertServiceMonitor(tt.args.serviceMon, &config.BaseOperatorConf{
-				FilterPrometheusConverterLabelPrefixes:      []string{"helm.sh"},
-				FilterPrometheusConverterAnnotationPrefixes: []string{"app.kubernetes"},
+				FilterPrometheusConverterLabelPrefixes:      []string{"app.kubernetes", "helm.sh"},
+				FilterPrometheusConverterAnnotationPrefixes: []string{"another-annotation-filter", "app.kubernetes"},
 			})
 			if !reflect.DeepEqual(*got, tt.want) {
 				t.Errorf("ConvertServiceMonitor() got = \n%v, \nwant \n%v", got, tt.want)


### PR DESCRIPTION
In case when filtering prefixes more than one per label or annotation filtering doesn't work.
```
VM_FILTERPROMETHEUSCONVERTERLABELPREFIXES=filter-1,filter-2
VM_FILTERPROMETHEUSCONVERTERANNOTATIONPREFIXES=filter-1,filter-2
```
This PR fixes an issue.