### PR TITLE
fix/vlselect hpa target

### DIFF
--- a/internal/controller/operator/factory/vlcluster/vlselect.go
+++ b/internal/controller/operator/factory/vlcluster/vlselect.go
@@ -71,7 +71,7 @@ func createOrUpdateVLSelectHPA(ctx context.Context, rclient client.Client, cr, p
 	}
 	targetRef := autoscalingv2.CrossVersionObjectReference{
 		Name:       cr.GetVLSelectName(),
-		Kind:       "StatefulSet",
+		Kind:       "Deployment",
 		APIVersion: "apps/v1",
 	}
 	b := newOptsBuilder(cr, cr.GetVLSelectName(), cr.VLSelectSelectorLabels())


### PR DESCRIPTION
This MR fixes the target selector for VLSelect since it spanws a deployment instead of a Statefulset.
