### PR TITLE
removed unneeded id from nodescrape target name

### DIFF
--- a/internal/controller/operator/factory/vmagent/nodescrape.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape.go
@@ -13,7 +13,6 @@ func generateNodeScrapeConfig(
 	ctx context.Context,
 	vmagentCR *vmv1beta1.VMAgent,
 	cr *vmv1beta1.VMNodeScrape,
-	i int,
 	apiserverConfig *vmv1beta1.APIServerConfig,
 	ssCache *scrapesSecretsCache,
 	se vmv1beta1.VMAgentSecurityEnforcements,
@@ -22,7 +21,7 @@ func generateNodeScrapeConfig(
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
-			Value: fmt.Sprintf("nodeScrape/%s/%s/%d", cr.Namespace, cr.Name, i),
+			Value: fmt.Sprintf("nodeScrape/%s/%s", cr.Namespace, cr.Name),
 		},
 	}
 

--- a/internal/controller/operator/factory/vmagent/nodescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape_test.go
@@ -18,7 +18,6 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 	type args struct {
 		cr              vmv1beta1.VMAgent
 		m               *vmv1beta1.VMNodeScrape
-		i               int
 		apiserverConfig *vmv1beta1.APIServerConfig
 		ssCache         *scrapesSecretsCache
 		se              vmv1beta1.VMAgentSecurityEnforcements
@@ -33,7 +32,6 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 			args: args{
 				apiserverConfig: nil,
 				ssCache:         &scrapesSecretsCache{},
-				i:               1,
 				m: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
@@ -49,7 +47,7 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 					},
 				},
 			},
-			want: `job_name: nodeScrape/default/nodes-basic/1
+			want: `job_name: nodeScrape/default/nodes-basic
 kubernetes_sd_configs:
 - role: node
 honor_labels: false
@@ -81,7 +79,6 @@ relabel_configs:
 						},
 					},
 				},
-				i: 1,
 				m: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
@@ -138,7 +135,7 @@ relabel_configs:
 					},
 				},
 			},
-			want: `job_name: nodeScrape/default/nodes-basic/1
+			want: `job_name: nodeScrape/default/nodes-basic
 kubernetes_sd_configs:
 - role: node
 honor_labels: true
@@ -208,7 +205,6 @@ basic_auth:
 					},
 				},
 				ssCache: &scrapesSecretsCache{},
-				i:       1,
 				m: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
@@ -226,7 +222,7 @@ basic_auth:
 					},
 				},
 			},
-			want: `job_name: nodeScrape/default/nodes-basic/1
+			want: `job_name: nodeScrape/default/nodes-basic
 kubernetes_sd_configs:
 - role: node
   selectors:
@@ -251,7 +247,7 @@ relabel_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateNodeScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
+			got := generateNodeScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Errorf("cannot marshal NodeScrapeConfig to yaml,err :%e", err)

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -1113,13 +1113,12 @@ func generateConfig(
 				cr.Spec.VMAgentSecurityEnforcements,
 			))
 	}
-	for i, identifier := range sos.nss {
+	for _, identifier := range sos.nss {
 		scrapeConfigs = append(scrapeConfigs,
 			generateNodeScrapeConfig(
 				ctx,
 				cr,
 				identifier,
-				i,
 				apiserverConfig,
 				secretsCache,
 				cr.Spec.VMAgentSecurityEnforcements,

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
@@ -679,7 +679,7 @@ scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: http://blackbox
-- job_name: nodeScrape/default/test-vms/0
+- job_name: nodeScrape/default/test-vms
   kubernetes_sd_configs:
   - role: node
   honor_labels: false
@@ -990,7 +990,7 @@ scrape_configs:
     replacement: ${1}
   - target_label: endpoint
     replacement: "8011"
-- job_name: nodeScrape/default/test-good/0
+- job_name: nodeScrape/default/test-good
   kubernetes_sd_configs:
   - role: node
   honor_labels: false
@@ -1549,7 +1549,7 @@ scrape_configs:
       ca_file: /etc/vmagent-tls/certs/default_configmap_tls-default_CA
       cert_file: /etc/vmagent-tls/certs/default_tls-auth_CERT
       key_file: /etc/vmagent-tls/certs/default_tls-auth_SECRET_KEY
-- job_name: nodeScrape/default/k8s-nodes/0
+- job_name: nodeScrape/default/k8s-nodes
   kubernetes_sd_configs:
   - role: node
   honor_labels: false


### PR DESCRIPTION
job name for scrapes has a following convention `<scrape-type>/<scrape-name>/<idx>` when multiple targets are available in scrape configuration and `<scrape-type>/<scrape-name>`, when a single target can be configured. nodescrape has a single target configurable but for some reason its job name uses`nodescrape/<scrape-name>/<idx>` naming. this PR removes confusing index from nodescrape job name