### PR TITLE
refactoring: consistently name variables in method signatures

### DIFF
--- a/internal/controller/operator/factory/finalize/common.go
+++ b/internal/controller/operator/factory/finalize/common.go
@@ -16,7 +16,7 @@ import (
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 )
 
-type crdObject interface {
+type crObject interface {
 	AnnotationsFiltered() map[string]string
 	GetLabels() map[string]string
 	PrefixedName() string
@@ -173,32 +173,32 @@ func SafeDeleteWithFinalizer(ctx context.Context, rclient client.Client, r clien
 	return nil
 }
 
-func deleteSA(ctx context.Context, rclient client.Client, crd crdObject) error {
-	if !crd.IsOwnsServiceAccount() {
+func deleteSA(ctx context.Context, rclient client.Client, cr crObject) error {
+	if !cr.IsOwnsServiceAccount() {
 		return nil
 	}
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.ServiceAccount{}, crd.GetServiceAccountName(), crd.GetNamespace()); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.ServiceAccount{}, cr.GetServiceAccountName(), cr.GetNamespace()); err != nil {
 		return err
 	}
-	return SafeDelete(ctx, rclient, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: crd.GetNamespace(), Name: crd.GetServiceAccountName()}})
+	return SafeDelete(ctx, rclient, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: cr.GetNamespace(), Name: cr.GetServiceAccountName()}})
 }
 
-func finalizePBD(ctx context.Context, rclient client.Client, crd crdObject) error {
-	return removeFinalizeObjByName(ctx, rclient, &policyv1.PodDisruptionBudget{}, crd.PrefixedName(), crd.GetNamespace())
+func finalizePBD(ctx context.Context, rclient client.Client, cr crObject) error {
+	return removeFinalizeObjByName(ctx, rclient, &policyv1.PodDisruptionBudget{}, cr.PrefixedName(), cr.GetNamespace())
 }
 
-func removeConfigReloaderRole(ctx context.Context, rclient client.Client, crd crdObject) error {
-	if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.RoleBinding{}, crd.PrefixedName(), crd.GetNamespace()); err != nil {
+func removeConfigReloaderRole(ctx context.Context, rclient client.Client, cr crObject) error {
+	if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.RoleBinding{}, cr.PrefixedName(), cr.GetNamespace()); err != nil {
 		return err
 	}
-	if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.Role{}, crd.PrefixedName(), crd.GetNamespace()); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.Role{}, cr.PrefixedName(), cr.GetNamespace()); err != nil {
 		return err
 	}
-	if err := SafeDelete(ctx, rclient, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: crd.PrefixedName(), Namespace: crd.GetNamespace()}}); err != nil {
+	if err := SafeDelete(ctx, rclient, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.GetNamespace()}}); err != nil {
 		return err
 	}
 
-	if err := SafeDelete(ctx, rclient, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: crd.PrefixedName(), Namespace: crd.GetNamespace()}}); err != nil {
+	if err := SafeDelete(ctx, rclient, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.GetNamespace()}}); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/operator/factory/finalize/vlogs.go
+++ b/internal/controller/operator/factory/finalize/vlogs.go
@@ -11,28 +11,28 @@ import (
 )
 
 // OnVLogsDelete deletes all vlogs related resources
-func OnVLogsDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VLogs) error {
+func OnVLogsDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VLogs) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
-	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
+	if cr.Spec.Storage != nil {
+		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, cr.PrefixedName(), cr.Namespace, cr.Spec.RemovePvcAfterDelete); err != nil {
 			return err
 		}
 	}
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
 
-	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
+	return removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace)
 }

--- a/internal/controller/operator/factory/finalize/vlsingle.go
+++ b/internal/controller/operator/factory/finalize/vlsingle.go
@@ -11,28 +11,28 @@ import (
 )
 
 // OnVLSingleDelete deletes all vlogs related resources
-func OnVLSingleDelete(ctx context.Context, rclient client.Client, crd *vmv1.VLSingle) error {
+func OnVLSingleDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLSingle) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
-	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if cr.Spec.Storage != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.PersistentVolumeClaim{}, cr.PrefixedName(), cr.Namespace); err != nil {
 			return err
 		}
 	}
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
 
-	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
+	return removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace)
 }

--- a/internal/controller/operator/factory/finalize/vmalert.go
+++ b/internal/controller/operator/factory/finalize/vmalert.go
@@ -12,17 +12,17 @@ import (
 )
 
 // OnVMAlertDelete deletes all vmalert related resources
-func OnVMAlertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMAlert) error {
+func OnVMAlertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlert) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	var cmList corev1.ConfigMapList
-	if err := rclient.List(ctx, &cmList, crd.RulesConfigMapSelector()); err != nil {
+	if err := rclient.List(ctx, &cmList, cr.RulesConfigMapSelector()); err != nil {
 		return err
 	}
 	for _, cm := range cmList.Items {
@@ -33,26 +33,26 @@ func OnVMAlertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.
 		}
 	}
 	// check secret
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.TLSAssetName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, cr.TLSAssetName(), cr.Namespace); err != nil {
 		return err
 	}
 
 	// check PDB
-	if crd.Spec.PodDisruptionBudget != nil {
-		if err := finalizePBD(ctx, rclient, crd); err != nil {
+	if cr.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, cr); err != nil {
 			return err
 		}
 	}
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
 
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
-	if err := removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/operator/factory/finalize/vmalertmanager.go
+++ b/internal/controller/operator/factory/finalize/vmalertmanager.go
@@ -11,45 +11,45 @@ import (
 )
 
 // OnVMAlertManagerDelete deletes all alertmanager related resources
-func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMAlertmanager) error {
+func OnVMAlertManagerDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlertmanager) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.StatefulSet{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.StatefulSet{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
 
 	// check config secret finalizer.
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, cr.ConfigSecretName(), cr.Namespace); err != nil {
 		return err
 	}
-	if len(crd.Spec.ConfigSecret) > 0 {
+	if len(cr.Spec.ConfigSecret) > 0 {
 		// execute it for backward-compatibility
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.Spec.ConfigSecret, crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, cr.Spec.ConfigSecret, cr.Namespace); err != nil {
 			return err
 		}
 	}
 
 	// check PDB
-	if crd.Spec.PodDisruptionBudget != nil {
-		if err := finalizePBD(ctx, rclient, crd); err != nil {
+	if cr.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, cr); err != nil {
 			return err
 		}
 	}
 
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
-	if err := removeConfigReloaderRole(ctx, rclient, crd); err != nil {
+	if err := removeConfigReloaderRole(ctx, rclient, cr); err != nil {
 		return err
 	}
 
-	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
+	return removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace)
 }

--- a/internal/controller/operator/factory/finalize/vmauth.go
+++ b/internal/controller/operator/factory/finalize/vmauth.go
@@ -13,41 +13,41 @@ import (
 )
 
 // OnVMAuthDelete deletes all vmauth related resources
-func OnVMAuthDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMAuth) error {
+func OnVMAuthDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAuth) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
 
 	// check secret
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.ConfigSecretName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, cr.ConfigSecretName(), cr.Namespace); err != nil {
 		return err
 	}
 
 	// check PDB
-	if crd.Spec.PodDisruptionBudget != nil {
-		if err := finalizePBD(ctx, rclient, crd); err != nil {
+	if cr.Spec.PodDisruptionBudget != nil {
+		if err := finalizePBD(ctx, rclient, cr); err != nil {
 			return err
 		}
 	}
-	if crd.Spec.Ingress != nil {
+	if cr.Spec.Ingress != nil {
 		vmauthIngress := &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crd.PrefixedName(),
-				Namespace: crd.Namespace,
+				Name:      cr.PrefixedName(),
+				Namespace: cr.Namespace,
 			},
 		}
-		if err := removeFinalizeObjByName(ctx, rclient, vmauthIngress, crd.PrefixedName(), crd.Namespace); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, vmauthIngress, cr.PrefixedName(), cr.Namespace); err != nil {
 			return err
 		}
 		if err := SafeDelete(ctx, rclient, vmauthIngress); err != nil {
@@ -56,18 +56,18 @@ func OnVMAuthDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.V
 	}
 
 	// check ingress
-	if err := removeFinalizeObjByName(ctx, rclient, &networkingv1.Ingress{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &networkingv1.Ingress{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
-	if err := removeConfigReloaderRole(ctx, rclient, crd); err != nil {
+	if err := removeConfigReloaderRole(ctx, rclient, cr); err != nil {
 		return err
 	}
 	// remove from self.
-	if err := removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace); err != nil {
 		return err
 	}
 

--- a/internal/controller/operator/factory/finalize/vmcluster.go
+++ b/internal/controller/operator/factory/finalize/vmcluster.go
@@ -16,10 +16,10 @@ import (
 )
 
 // OnVMInsertDelete removes all objects related to vminsert component
-func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMCluster, obj *vmv1beta1.VMInsert) error {
+func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMInsert) error {
 	objMeta := metav1.ObjectMeta{
-		Namespace: crd.Namespace,
-		Name:      crd.GetVMInsertName(),
+		Namespace: cr.Namespace,
+		Name:      cr.GetVMInsertName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -28,8 +28,8 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: crd.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMInsertName()),
+				Namespace: cr.Namespace,
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMInsertName()),
 			},
 		})
 	}
@@ -41,11 +41,11 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMInsertLBName(), Namespace: crd.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
 	}
 
-	if crd.Spec.RequestsLoadBalancer.Enabled && !crd.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMInsertLBName(), Namespace: crd.Namespace}})
+	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -56,10 +56,10 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 }
 
 // OnVMInsertDelete removes all objects related to vminsert component
-func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMCluster, obj *vmv1beta1.VMSelect) error {
+func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMSelect) error {
 	objMeta := metav1.ObjectMeta{
-		Namespace: crd.Namespace,
-		Name:      crd.GetVMSelectName(),
+		Namespace: cr.Namespace,
+		Name:      cr.GetVMSelectName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -68,8 +68,8 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: crd.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMSelectName()),
+				Namespace: cr.Namespace,
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMSelectName()),
 			},
 		})
 	}
@@ -81,10 +81,10 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, false) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMSelectLBName(), Namespace: crd.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
 	}
-	if crd.Spec.RequestsLoadBalancer.Enabled && !crd.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: crd.GetVMSelectLBName(), Namespace: crd.Namespace}})
+	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -95,10 +95,10 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1
 }
 
 // OnVMInsertDelete removes all objects related to vminsert component
-func OnVMStorageDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMCluster, obj *vmv1beta1.VMStorage) error {
+func OnVMStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMStorage) error {
 	objMeta := metav1.ObjectMeta{
-		Namespace: crd.Namespace,
-		Name:      crd.GetVMStorageName(),
+		Namespace: cr.Namespace,
+		Name:      cr.GetVMStorageName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -107,8 +107,8 @@ func OnVMStorageDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 	if obj.ServiceSpec != nil && !obj.ServiceSpec.UseAsDefault {
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: crd.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(crd.GetVMStorageName()),
+				Namespace: cr.Namespace,
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMStorageName()),
 			},
 		})
 	}
@@ -128,35 +128,35 @@ func OnVMStorageDelete(ctx context.Context, rclient client.Client, crd *vmv1beta
 }
 
 // OnVMClusterDelete deletes all vmcluster related resources
-func OnVMClusterDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMCluster) error {
+func OnVMClusterDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster) error {
 	// check deployment
 
-	if crd.Spec.VMInsert != nil {
-		if err := OnVMInsertDelete(ctx, rclient, crd, crd.Spec.VMInsert); err != nil {
+	if cr.Spec.VMInsert != nil {
+		if err := OnVMInsertDelete(ctx, rclient, cr, cr.Spec.VMInsert); err != nil {
 			return fmt.Errorf("cannot remove vminsert component objects: %w", err)
 		}
 	}
 
-	if crd.Spec.VMSelect != nil {
-		if err := OnVMSelectDelete(ctx, rclient, crd, crd.Spec.VMSelect); err != nil {
+	if cr.Spec.VMSelect != nil {
+		if err := OnVMSelectDelete(ctx, rclient, cr, cr.Spec.VMSelect); err != nil {
 			return fmt.Errorf("cannot remove vmselect component objects: %w", err)
 		}
 	}
-	if crd.Spec.VMStorage != nil {
-		if err := OnVMStorageDelete(ctx, rclient, crd, crd.Spec.VMStorage); err != nil {
+	if cr.Spec.VMStorage != nil {
+		if err := OnVMStorageDelete(ctx, rclient, cr, cr.Spec.VMStorage); err != nil {
 			return fmt.Errorf("cannot remove vmstorage component objects: %w", err)
 		}
 	}
 
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
-	if crd.Spec.RequestsLoadBalancer.Enabled {
-		if err := OnVMClusterLoadBalancerDelete(ctx, rclient, crd); err != nil {
+	if cr.Spec.RequestsLoadBalancer.Enabled {
+		if err := OnVMClusterLoadBalancerDelete(ctx, rclient, cr); err != nil {
 			return fmt.Errorf("cannot delete vmcluster loadbalancer components: %w", err)
 		}
 	}
-	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
+	return removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace)
 }
 
 // OnVMClusterLoadBalancerDelete removes vmauth loadbalancer components for vmcluster

--- a/internal/controller/operator/factory/finalize/vmsingle.go
+++ b/internal/controller/operator/factory/finalize/vmsingle.go
@@ -11,31 +11,31 @@ import (
 )
 
 // OnVMSingleDelete deletes all vmsingle related resources
-func OnVMSingleDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMSingle) error {
+func OnVMSingleDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle) error {
 	// check deployment
-	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &appsv1.Deployment{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
 	// check service
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.PrefixedName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.PrefixedName(), cr.Namespace); err != nil {
 		return err
 	}
-	if crd.Spec.Storage != nil {
-		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, crd.PrefixedName(), crd.Namespace, crd.Spec.RemovePvcAfterDelete); err != nil {
+	if cr.Spec.Storage != nil {
+		if err := removeFinalizeObjByNameWithOwnerReference(ctx, rclient, &corev1.PersistentVolumeClaim{}, cr.PrefixedName(), cr.Namespace, cr.Spec.RemovePvcAfterDelete); err != nil {
 			return err
 		}
 	}
-	if crd.Spec.ServiceSpec != nil {
-		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, crd.Spec.ServiceSpec.NameOrDefault(crd.PrefixedName()), crd.Namespace); err != nil {
+	if cr.Spec.ServiceSpec != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &corev1.Service{}, cr.Spec.ServiceSpec.NameOrDefault(cr.PrefixedName()), cr.Namespace); err != nil {
 			return err
 		}
 	}
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.ConfigMap{}, crd.StreamAggrConfigName(), crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.ConfigMap{}, cr.StreamAggrConfigName(), cr.Namespace); err != nil {
 		return err
 	}
-	if err := deleteSA(ctx, rclient, crd); err != nil {
+	if err := deleteSA(ctx, rclient, cr); err != nil {
 		return err
 	}
 
-	return removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace)
+	return removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace)
 }

--- a/internal/controller/operator/factory/finalize/vmuser.go
+++ b/internal/controller/operator/factory/finalize/vmuser.go
@@ -10,12 +10,12 @@ import (
 )
 
 // OnVMUserDelete deletes all vmuser related resources
-func OnVMUserDelete(ctx context.Context, rclient client.Client, crd *vmv1beta1.VMUser) error {
-	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, crd.SecretName(), crd.Namespace); err != nil {
+func OnVMUserDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMUser) error {
+	if err := removeFinalizeObjByName(ctx, rclient, &corev1.Secret{}, cr.SecretName(), cr.Namespace); err != nil {
 		return err
 	}
 
-	if err := removeFinalizeObjByName(ctx, rclient, crd, crd.Name, crd.Namespace); err != nil {
+	if err := removeFinalizeObjByName(ctx, rclient, cr, cr.Name, cr.Namespace); err != nil {
 		return err
 	}
 	return nil

--- a/internal/controller/operator/factory/vmagent/nodescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape_test.go
@@ -17,7 +17,7 @@ import (
 func Test_generateNodeScrapeConfig(t *testing.T) {
 	type args struct {
 		cr              vmv1beta1.VMAgent
-		m               *vmv1beta1.VMNodeScrape
+		sc              *vmv1beta1.VMNodeScrape
 		apiserverConfig *vmv1beta1.APIServerConfig
 		ssCache         *scrapesSecretsCache
 		se              vmv1beta1.VMAgentSecurityEnforcements
@@ -32,7 +32,7 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 			args: args{
 				apiserverConfig: nil,
 				ssCache:         &scrapesSecretsCache{},
-				m: &vmv1beta1.VMNodeScrape{
+				sc: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
 						Namespace: "default",
@@ -79,7 +79,7 @@ relabel_configs:
 						},
 					},
 				},
-				m: &vmv1beta1.VMNodeScrape{
+				sc: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
 						Namespace: "default",
@@ -205,7 +205,7 @@ basic_auth:
 					},
 				},
 				ssCache: &scrapesSecretsCache{},
-				m: &vmv1beta1.VMNodeScrape{
+				sc: &vmv1beta1.VMNodeScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nodes-basic",
 						Namespace: "default",
@@ -247,7 +247,7 @@ relabel_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateNodeScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
+			got := generateNodeScrapeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Errorf("cannot marshal NodeScrapeConfig to yaml,err :%e", err)

--- a/internal/controller/operator/factory/vmagent/podscrape_test.go
+++ b/internal/controller/operator/factory/vmagent/podscrape_test.go
@@ -15,7 +15,7 @@ import (
 func Test_generatePodScrapeConfig(t *testing.T) {
 	type args struct {
 		cr              vmv1beta1.VMAgent
-		m               *vmv1beta1.VMPodScrape
+		sc              *vmv1beta1.VMPodScrape
 		ep              vmv1beta1.PodMetricsEndpoint
 		i               int
 		apiserverConfig *vmv1beta1.APIServerConfig
@@ -30,7 +30,7 @@ func Test_generatePodScrapeConfig(t *testing.T) {
 		{
 			name: "simple test",
 			args: args{
-				m: &vmv1beta1.VMPodScrape{
+				sc: &vmv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-1",
 						Namespace: "default",
@@ -84,7 +84,7 @@ relabel_configs:
 		{
 			name: "disabled running filter",
 			args: args{
-				m: &vmv1beta1.VMPodScrape{
+				sc: &vmv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-1",
 						Namespace: "default",
@@ -140,7 +140,7 @@ relabel_configs:
 						EnableKubernetesAPISelectors: true,
 					},
 				},
-				m: &vmv1beta1.VMPodScrape{
+				sc: &vmv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-1",
 						Namespace: "default",
@@ -212,7 +212,7 @@ relabel_configs:
 						EnableKubernetesAPISelectors: true,
 					},
 				},
-				m: &vmv1beta1.VMPodScrape{
+				sc: &vmv1beta1.VMPodScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-1",
 						Namespace: "default",
@@ -284,7 +284,7 @@ relabel_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generatePodScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.ep, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
+			got := generatePodScrapeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.ep, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Errorf("cannot marshal PodScrapeConfig to yaml,err :%e", err)

--- a/internal/controller/operator/factory/vmagent/probe_test.go
+++ b/internal/controller/operator/factory/vmagent/probe_test.go
@@ -16,8 +16,8 @@ import (
 
 func Test_generateProbeConfig(t *testing.T) {
 	type args struct {
-		crAgent         vmv1beta1.VMAgent
-		cr              *vmv1beta1.VMProbe
+		cr              vmv1beta1.VMAgent
+		sc              *vmv1beta1.VMProbe
 		i               int
 		apiserverConfig *vmv1beta1.APIServerConfig
 		ssCache         *scrapesSecretsCache
@@ -32,7 +32,7 @@ func Test_generateProbeConfig(t *testing.T) {
 			name: "generate static config",
 			args: args{
 				ssCache: &scrapesSecretsCache{},
-				cr: &vmv1beta1.VMProbe{
+				sc: &vmv1beta1.VMProbe{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "static-probe",
@@ -82,7 +82,7 @@ relabel_configs:
 			name: "with ingress discover",
 			args: args{
 				ssCache: &scrapesSecretsCache{},
-				cr: &vmv1beta1.VMProbe{
+				sc: &vmv1beta1.VMProbe{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "probe-ingress",
 						Namespace: "monitor",
@@ -159,7 +159,7 @@ relabel_configs:
 					baSecrets:     map[string]*k8stools.BasicAuthCredentials{},
 					oauth2Secrets: map[string]*k8stools.OAuthCreds{},
 				},
-				cr: &vmv1beta1.VMProbe{
+				sc: &vmv1beta1.VMProbe{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
 						Name:      "static-probe",
@@ -250,12 +250,12 @@ basic_auth:
 			name: "with ingress selectors",
 			args: args{
 				ssCache: &scrapesSecretsCache{},
-				crAgent: vmv1beta1.VMAgent{
+				cr: vmv1beta1.VMAgent{
 					Spec: vmv1beta1.VMAgentSpec{
 						EnableKubernetesAPISelectors: true,
 					},
 				},
-				cr: &vmv1beta1.VMProbe{
+				sc: &vmv1beta1.VMProbe{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "probe-ingress",
 						Namespace: "monitor",
@@ -332,7 +332,7 @@ relabel_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateProbeConfig(context.Background(), &tt.args.crAgent, tt.args.cr, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
+			got := generateProbeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Errorf("cannot decode probe config, it must be in yaml format :%e", err)

--- a/internal/controller/operator/factory/vmagent/scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/scrapeconfig.go
@@ -12,7 +12,7 @@ import (
 
 func generateScrapeConfig(
 	ctx context.Context,
-	vmagentCR *vmv1beta1.VMAgent,
+	cr *vmv1beta1.VMAgent,
 	sc *vmv1beta1.VMScrapeConfig,
 	ssCache *scrapesSecretsCache,
 	se vmv1beta1.VMAgentSecurityEnforcements,
@@ -25,7 +25,7 @@ func generateScrapeConfig(
 		},
 	}
 
-	setScrapeIntervalToWithLimit(ctx, &sc.Spec.EndpointScrapeParams, vmagentCR)
+	setScrapeIntervalToWithLimit(ctx, &sc.Spec.EndpointScrapeParams, cr)
 
 	cfg = addCommonScrapeParamsTo(cfg, sc.Spec.EndpointScrapeParams, se)
 
@@ -33,7 +33,7 @@ func generateScrapeConfig(
 	for _, c := range sc.Spec.RelabelConfigs {
 		relabelings = append(relabelings, generateRelabelConfig(c))
 	}
-	for _, trc := range vmagentCR.Spec.ScrapeConfigRelabelTemplate {
+	for _, trc := range cr.Spec.ScrapeConfigRelabelTemplate {
 		relabelings = append(relabelings, generateRelabelConfig(trc))
 	}
 	// Because of security risks, whenever enforcedNamespaceLabel is set, we want to append it to the

--- a/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
@@ -17,7 +17,7 @@ import (
 func TestGenerateScrapeConfig(t *testing.T) {
 	type args struct {
 		cr      vmv1beta1.VMAgent
-		m       *vmv1beta1.VMScrapeConfig
+		sc      *vmv1beta1.VMScrapeConfig
 		ssCache *scrapesSecretsCache
 		se      vmv1beta1.VMAgentSecurityEnforcements
 	}
@@ -35,7 +35,7 @@ func TestGenerateScrapeConfig(t *testing.T) {
 						MaxScrapeInterval: ptr.To("5m"),
 					},
 				},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "static-1",
 						Namespace: "default",
@@ -93,7 +93,7 @@ static_configs:
 						MaxScrapeInterval: ptr.To("5m"),
 					},
 				},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "file-1",
 						Namespace: "default",
@@ -140,7 +140,7 @@ file_sd_configs:
 			name: "basic httpSDConfig",
 			args: args{
 				cr: vmv1beta1.VMAgent{},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "httpsd-1",
 						Namespace: "default",
@@ -202,7 +202,7 @@ http_sd_configs:
 			name: "basic kubernetesSDConfig",
 			args: args{
 				cr: vmv1beta1.VMAgent{},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "kubernetesSDConfig-1",
 						Namespace: "default",
@@ -265,7 +265,7 @@ kubernetes_sd_configs:
 			name: "mixed",
 			args: args{
 				cr: vmv1beta1.VMAgent{},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "mixconfigs-1",
 						Namespace: "default",
@@ -411,7 +411,7 @@ digitalocean_sd_configs:
 			name: "configs with auth and empty type",
 			args: args{
 				cr: vmv1beta1.VMAgent{},
-				m: &vmv1beta1.VMScrapeConfig{
+				sc: &vmv1beta1.VMScrapeConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sc-auth",
 						Namespace: "default",
@@ -496,7 +496,7 @@ kubernetes_sd_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.ssCache, tt.args.se)
+			got := generateScrapeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/internal/controller/operator/factory/vmagent/servicescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/servicescrape_test.go
@@ -18,7 +18,7 @@ import (
 func Test_generateServiceScrapeConfig(t *testing.T) {
 	type args struct {
 		cr              vmv1beta1.VMAgent
-		m               *vmv1beta1.VMServiceScrape
+		sc              *vmv1beta1.VMServiceScrape
 		ep              vmv1beta1.Endpoint
 		i               int
 		apiserverConfig *vmv1beta1.APIServerConfig
@@ -33,7 +33,7 @@ func Test_generateServiceScrapeConfig(t *testing.T) {
 		{
 			name: "generate simple config",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -150,7 +150,7 @@ bearer_token_file: /var/run/token
 						MaxScrapeInterval: ptr.To("40m"),
 					},
 				},
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -259,7 +259,7 @@ bearer_token_file: /var/run/token
 						MinScrapeInterval: ptr.To("1m"),
 					},
 				},
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -364,7 +364,7 @@ bearer_token_file: /var/run/token
 		{
 			name: "config with discovery role endpointslices",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -465,7 +465,7 @@ bearer_token_file: /var/run/token
 		{
 			name: "config with discovery role services",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -549,7 +549,7 @@ bearer_token_file: /var/run/token
 		{
 			name: "bad discovery role service without port name",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -599,7 +599,7 @@ relabel_configs:
 		{
 			name: "config with tls insecure",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -663,7 +663,7 @@ bearer_token_file: /var/run/token
 		{
 			name: "complete config",
 			args: args{
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -859,7 +859,7 @@ oauth2:
 						},
 					},
 				},
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -968,7 +968,7 @@ bearer_token_file: /var/run/token
 						EnableKubernetesAPISelectors: true,
 					},
 				},
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -1068,7 +1068,7 @@ relabel_configs:
 						EnableKubernetesAPISelectors: true,
 					},
 				},
-				m: &vmv1beta1.VMServiceScrape{
+				sc: &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-scrape",
 						Namespace: "default",
@@ -1130,7 +1130,7 @@ relabel_configs:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateServiceScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.ep, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
+			got := generateServiceScrapeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.ep, tt.args.i, tt.args.apiserverConfig, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Errorf("cannot marshal ServiceScrapeConfig to yaml,err :%e", err)

--- a/internal/controller/operator/factory/vmagent/staticscrape_test.go
+++ b/internal/controller/operator/factory/vmagent/staticscrape_test.go
@@ -17,7 +17,7 @@ import (
 func Test_generateStaticScrapeConfig(t *testing.T) {
 	type args struct {
 		cr      vmv1beta1.VMAgent
-		m       *vmv1beta1.VMStaticScrape
+		sc      *vmv1beta1.VMStaticScrape
 		ep      *vmv1beta1.TargetEndpoint
 		i       int
 		ssCache *scrapesSecretsCache
@@ -32,7 +32,7 @@ func Test_generateStaticScrapeConfig(t *testing.T) {
 			name: "basic cfg",
 			args: args{
 				ssCache: &scrapesSecretsCache{},
-				m: &vmv1beta1.VMStaticScrape{
+				sc: &vmv1beta1.VMStaticScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "static-1",
 						Namespace: "default",
@@ -64,7 +64,7 @@ relabel_configs:
 			name: "basic cfg with overrides",
 			args: args{
 				ssCache: &scrapesSecretsCache{},
-				m: &vmv1beta1.VMStaticScrape{
+				sc: &vmv1beta1.VMStaticScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "static-1",
 						Namespace: "default",
@@ -134,7 +134,7 @@ relabel_configs:
 						},
 					},
 				},
-				m: &vmv1beta1.VMStaticScrape{
+				sc: &vmv1beta1.VMStaticScrape{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "static-1",
 						Namespace: "default",
@@ -309,7 +309,7 @@ oauth2:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateStaticScrapeConfig(context.Background(), &tt.args.cr, tt.args.m, tt.args.ep, tt.args.i, tt.args.ssCache, tt.args.se)
+			got := generateStaticScrapeConfig(context.Background(), &tt.args.cr, tt.args.sc, tt.args.ep, tt.args.i, tt.args.ssCache, tt.args.se)
 			gotBytes, err := yaml.Marshal(got)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
scrape CRs are named either `cr`, `m` or `sc`, renamed them all to `sc`
parent CRs were renamed to `cr`