### PR TITLE
fix: fixed vmstaticscrape endpoint auth secrets namespace

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): use scrape namespace instead of VMAgent one for VMStaticScrape secrets lookup.
+
 ## [v0.60.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.0)
 
 * FEATURE: [operator](https://docs.victoriametrics.com/operator/api): introduce new resource `VMAnomaly`. See [1136](https://github.com/VictoriaMetrics/operator/issues/1136) issue for details.

--- a/internal/controller/operator/factory/vmagent/staticscrape.go
+++ b/internal/controller/operator/factory/vmagent/staticscrape.go
@@ -73,5 +73,5 @@ func generateStaticScrapeConfig(
 	} else {
 		cfg = append(cfg, c...)
 	}
-	return addEndpointAuthTo(cfg, &ep.EndpointAuth, cr.Namespace, ac)
+	return addEndpointAuthTo(cfg, &ep.EndpointAuth, sc.Namespace, ac)
 }


### PR DESCRIPTION
use VMStaticScrape namespace instead of VMAgent namespace for endpoint auth creds lookup