### PR TITLE
factory/vmanomaly/config: fix parsing of data_range for inf values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): use scrape namespace instead of VMAgent one for VMStaticScrape secrets lookup.
 * BUGFIX: [vmanomaly](https://docs.victoriametrics.com/anomaly-detection/): fix marshalling of `.spec.reader.latencyOffset` field. Previously, it was causing an error when trying to create `VManomaly` resource with `latencyOffset`.
+* BUGFIX: [vmanomaly](https://docs.victoriametrics.com/anomaly-detection/): fix parsing of `Inf` value for `data_range` of `.spec.configRawYaml.reader.queries.<query>.data_range`.
 
 ## [v0.60.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.0)
 

--- a/internal/controller/operator/factory/vmanomaly/config/config_test.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config_test.go
@@ -86,6 +86,7 @@ reader:
   queries:
     test:
       expr: vm_metric
+      data_range: [0, inf]
 writer:
   class: vm
   datasource_url: "http://test.com"
@@ -238,6 +239,9 @@ reader:
   queries:
     test:
       expr: vm_metric
+      data_range:
+      - "0"
+      - inf
   tenant_id: "0:1"
   verify_tls: true
   tls_cert_file: /test/monitoring_tls_remote-cert


### PR DESCRIPTION
Treat data_range values as string in order to correctly parse `Inf` values. vmanomaly converts strings to float internally as well.

P.S. this PR targets #1417 and will change target branch automatically once target is merged. This is to make it easier to merge as it will avoid merge conflicts in changelog.