### PR TITLE
fixed anomaly e2e test, update shards concurrently

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,8 @@ aliases:
 ## tip
 
 * SECURITY: upgrade Go builder from Go1.24.3 to Go1.24.4. See [the list of issues addressed in Go1.24.4](https://github.com/golang/go/issues?q=milestone%3AGo1.24.4+label%3ACherryPickApproved).
-* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): fixed typo in VMAnomaly shard creation
+* FEATURE: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): create VMAnomaly shards concurrently
+* BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fixed typo in VMAnomaly shard creation
 
 ## [v0.60.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.0)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 ## tip
 
 * SECURITY: upgrade Go builder from Go1.24.3 to Go1.24.4. See [the list of issues addressed in Go1.24.4](https://github.com/golang/go/issues?q=milestone%3AGo1.24.4+label%3ACherryPickApproved).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): fixed typo in VMAnomaly shard creation
 
 ## [v0.60.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.0)
 

--- a/internal/controller/operator/factory/vmanomaly/statefulset.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset.go
@@ -223,16 +223,16 @@ func createOrUpdateShardedStatefulSet(ctx context.Context, rclient client.Client
 		shardMutator(cr, shardedDeploy, shardNum)
 		if prevStatefulSet != nil {
 			prevShardedObject = prevStatefulSet.DeepCopyObject().(*appsv1.StatefulSet)
-			shardMutator(cr, prevShardedObject, shardNum)
+			shardMutator(prevCR, prevShardedObject, shardNum)
 		}
 		placeholders := map[string]string{shardNumPlaceholder: strconv.Itoa(shardNum)}
-		var prevStatefulSet *appsv1.StatefulSet
+		var prevDeploy *appsv1.StatefulSet
 		shardedDeploy, err = k8stools.RenderPlaceholders(shardedDeploy, placeholders)
 		if err != nil {
 			return fmt.Errorf("cannot fill placeholders for StatefulSet in sharded %T: %w", cr, err)
 		}
 		if prevShardedObject != nil {
-			prevStatefulSet, err = k8stools.RenderPlaceholders(prevStatefulSet, placeholders)
+			prevDeploy, err = k8stools.RenderPlaceholders(prevDeploy, placeholders)
 			if err != nil {
 				return fmt.Errorf("cannot fill placeholders for prev StatefulSet in sharded %T: %w", cr, err)
 			}
@@ -245,7 +245,7 @@ func createOrUpdateShardedStatefulSet(ctx context.Context, rclient client.Client
 				return selectorLabels
 			},
 		}
-		if err := reconcile.HandleSTSUpdate(ctx, rclient, statefulSetOpts, shardedDeploy, prevStatefulSet); err != nil {
+		if err := reconcile.HandleSTSUpdate(ctx, rclient, statefulSetOpts, shardedDeploy, prevDeploy); err != nil {
 			return err
 		}
 		statefulSetNames[shardedDeploy.Name] = struct{}{}

--- a/test/e2e/vmanomaly_test.go
+++ b/test/e2e/vmanomaly_test.go
@@ -63,6 +63,14 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 			Name:      "anomaly",
 			Namespace: namespace,
 		},
+		Spec: vmv1beta1.VMSingleSpec{
+			CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+				ReplicaCount: ptr.To[int32](1),
+			},
+			CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
+				UseDefaultResources: ptr.To(false),
+			},
+		},
 	}
 	licenseKey := os.Getenv("LICENSE_KEY")
 	BeforeAll(func() {
@@ -430,7 +438,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 					verify: func(cr *vmv1.VMAnomaly) {
 						Eventually(func() string {
 							return expectPodCount(k8sClient, 3, namespace, cr.SelectorLabels())
-						}, eventualDeploymentAppReadyTimeout, 1).Should(BeEmpty())
+						}, eventualStatefulsetAppReadyTimeout, 1).Should(BeEmpty())
 					},
 				},
 			),


### PR DESCRIPTION
- fixed typo shard creation. previously newly created shard was immediately recreated
- disabled default resource configuration for VMSingle in VMAnomaly E2E tests, default limits for VMSingle for some reason are set for config reloader limits, which trigger infinite VMSingle recreation
- use statefulset timeouts in anomaly tests instead of deployment ones
- update shards concurrently