### PR TITLE
run e2e in parallel

### DIFF
--- a/.github/workflows/close-pr.yaml
+++ b/.github/workflows/close-pr.yaml
@@ -1,5 +1,8 @@
 name: Close PR
 
+permissions:
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/crds.yaml
+++ b/.github/workflows/crds.yaml
@@ -1,5 +1,9 @@
 name: Update CRDs for chart repo
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   release:
     types: [published]

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,9 @@ on:
       - 'README.md'
       - '.github/workflows/docs.yaml'
 
+permissions:
+  contents: write
+
 jobs:
   update-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      checks: write
     steps:
       - name: Free space
         run: |
@@ -97,6 +98,11 @@ jobs:
             echo "there is no docker secret, just build"
             make build
           fi
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: success() || failure()
+        with:
+          report_paths: 'report.xml'
       - name: Prepare binary cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,16 +88,6 @@ jobs:
           git diff --exit-code
           make test
           TAG=${TAG} make test-e2e
-          if [ -n '${{secrets.REPO_KEY}}' ]; then
-            echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
-            if [ -n '${{secrets.QUAY_ACCESSKEY}}' ]; then
-              echo ${{secrets.QUAY_ACCESSKEY}} | docker login quay.io --username '${{secrets.QUAY_USER}}' --password-stdin
-            fi
-            make publish
-          else
-            echo "there is no docker secret, just build"
-            make build
-          fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: success() || failure()

--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -1,5 +1,9 @@
 name: Publish OperatorHub release
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/sandbox.yaml
+++ b/.github/workflows/sandbox.yaml
@@ -7,6 +7,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update:
     name: Update version on sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Temporary Build Files
 .DS_Store
 Dockerfile.cross
+report.xml
 .idea
 /bin/
 /build*

--- a/Makefile
+++ b/Makefile
@@ -136,10 +136,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: load-kind ginkgo
-	$(GINKGO_BIN) -timeout=30m ./test/e2e/
-	$(GINKGO_BIN) -procs=1 -timeout=20m ./test/e2e/childobjects/
-	$(GINKGO_BIN) -procs=$(E2E_TESTS_CONCURRENCY) -timeout=20m ./test/e2e/watchnamespace/
-	$(GINKGO_BIN) -procs=$(E2E_TESTS_CONCURRENCY) -timeout=20m ./test/e2e/deploy/
+	$(GINKGO_BIN) \
+		-procs=$(E2E_TESTS_CONCURRENCY) \
+		-timeout=30m \
+		-junit-report=report.xml ./test/e2e/...
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/test/e2e/childobjects/vmalertmanagerconfig_test.go
+++ b/test/e2e/childobjects/vmalertmanagerconfig_test.go
@@ -1,6 +1,7 @@
 package childobjects
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,7 +17,7 @@ import (
 
 //nolint:dupl,lll
 var _ = Describe("test vmalertmanagerconfig Controller", func() {
-	namespace := "default"
+	namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 	ctx := context.Background()
 	type opts struct {
 		ams    []*vmv1beta1.VMAlertmanager

--- a/test/e2e/childobjects/vmrule_test.go
+++ b/test/e2e/childobjects/vmrule_test.go
@@ -1,6 +1,7 @@
 package childobjects
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,7 +17,7 @@ import (
 
 //nolint:dupl,lll
 var _ = Describe("test vmrule Controller", func() {
-	namespace := "default"
+	namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 	ctx := context.Background()
 	type opts struct {
 		alerts []*vmv1beta1.VMAlert

--- a/test/e2e/childobjects/vmuser_test.go
+++ b/test/e2e/childobjects/vmuser_test.go
@@ -1,6 +1,8 @@
 package childobjects
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
@@ -16,7 +18,7 @@ import (
 
 //nolint:dupl,lll
 var _ = Describe("test vmuser Controller", func() {
-	namespace := "default"
+	namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 	ctx := context.Background()
 	type opts struct {
 		vmauths []*vmv1beta1.VMAuth

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -24,7 +24,7 @@ var _ = Describe("test vlsingle Controller", Label("vl", "cluster"), func() {
 
 	Context("e2e vlcluster", func() {
 		var ctx context.Context
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vlsingle_test.go
+++ b/test/e2e/vlsingle_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,7 +25,7 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single"), func() {
 
 	Context("e2e vlsingle", func() {
 		var ctx context.Context
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("test vmagent Controller", Label("vm", "agent"), func() {
 	ctx := context.Background()
 	Context("e2e vmagent", func() {
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmalert_test.go
+++ b/test/e2e/vmalert_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
@@ -20,7 +22,7 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 	ctx := context.Background()
 
 	Context("e2e vmalert", func() {
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmalertmanager_test.go
+++ b/test/e2e/vmalertmanager_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
@@ -36,7 +38,7 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 
 	Context("e2e vmalertmanager", func() {
 		ctx := context.Background()
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmanomaly_test.go
+++ b/test/e2e/vmanomaly_test.go
@@ -62,7 +62,7 @@ var (
 //nolint:dupl,lll
 var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise"), Ordered, func() {
 	ctx := context.Background()
-	namespace := "default"
+	namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 	anomalyDatasourceURL := fmt.Sprintf("http://vmsingle-anomaly.%s.svc:8428", namespace)
 	anomalySingle := vmv1beta1.VMSingle{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,7 +110,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 
 	})
 	Context("e2e vmanomaly", func() {
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmauth_test.go
+++ b/test/e2e/vmauth_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
@@ -23,7 +25,7 @@ import (
 var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 	Context("e2e ", func() {
 		var ctx context.Context
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -21,7 +21,7 @@ import (
 
 //nolint:dupl,lll
 var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
-	namespace := "default"
+	namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 	var ctx context.Context
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,

--- a/test/e2e/vmsingle_test.go
+++ b/test/e2e/vmsingle_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,12 +24,13 @@ var _ = Describe("test  vmsingle Controller", Label("vm", "single"), func() {
 
 	Context("e2e vmsingle", func() {
 		var ctx context.Context
-		namespace := "default"
+		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
 		namespacedName := types.NamespacedName{
 			Namespace: namespace,
 		}
 		BeforeEach(func() {
 			ctx = context.Background()
+
 		})
 		AfterEach(func() {
 			Expect(finalize.SafeDelete(ctx, k8sClient, &vmv1beta1.VMSingle{


### PR DESCRIPTION
- run e2e tests in paralllel
- removed operator images build and publishing for non-release builds, since it takes lots of CI time
- added permissions to all CI jobs, which are suggested by github
- CI time reduced from about 40 mins to up to 15 mins
- added JUnit test report