### PR TITLE
factory/reconcile: reset reason when transitioning into expanding state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): clear `status.reason` when transitioning to `expanding` state. This makes less confusing as resource in `expanding` state is no longer affected by an error displayed in `status.reason`. See [#1426](https://github.com/VictoriaMetrics/operator/issues/1426).
+
 ## [v0.60.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.1)
 
 **Release date:** 24 June 2025

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -200,13 +200,13 @@ func UpdateObjectStatus[T client.Object, ST StatusWithMetadata[STC], STC any](ct
 	newUpdateStatus := actualStatus
 
 	switch actualStatus {
-	case vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusPaused:
+	case vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational:
+		currMeta.Reason = ""
+	case vmv1beta1.UpdateStatusPaused:
 	case vmv1beta1.UpdateStatusFailed:
 		if maybeErr != nil {
 			currMeta.Reason = maybeErr.Error()
 		}
-	case vmv1beta1.UpdateStatusOperational:
-		currMeta.Reason = ""
 	default:
 		panic(fmt.Sprintf("BUG: not expected status=%q", actualStatus))
 	}


### PR DESCRIPTION
Previously, `reason` was only reset when resource was transitioning to `operational` state. That was confusing to the end user as the resource workflow was:
1. Deploy a broken version, observe `updateStatus: failed`, `reaason: {error}`
2. Deploy a fix, observe `updateStatus: expanding`, `reason: {error}` - this is confusing as it is expected that error no longer appears after fix.

See: https://github.com/VictoriaMetrics/operator/issues/1426