### PR TITLE
docs: removed resource kind prefix from operator managed resources in examples

### DIFF
--- a/config/examples/vmagent-full.yaml
+++ b/config/examples/vmagent-full.yaml
@@ -44,7 +44,7 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent-full
+  name: example-full
 spec:
   serviceScrapeNamespaceSelector:
     matchLabels:
@@ -103,7 +103,7 @@ spec:
     name: "vm-agent-global-relabel-config"
     key: "relabel.yaml"
   remoteWrite:
-  - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+  - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
     basicAuth:
       username:
         name: rws-basic-auth
@@ -118,7 +118,7 @@ spec:
       key: "relabel.yaml"
       #      label:
       #        primary: "yes"
-  - url: "http://vmsingle-example-vmsingle.alternative.svc:8429/api/v1/write"
+  - url: "http://vmsingle-example.alternative.svc:8429/api/v1/write"
     #      maxDiskUsagePerURL: 33
     #      sendTimeout: 30s
     #      showURL: true

--- a/config/examples/vmagent-stream-aggr.yaml
+++ b/config/examples/vmagent-stream-aggr.yaml
@@ -15,7 +15,7 @@ spec:
       cpu: "150m"
       memory: "250Mi"
   remoteWrite:
-  - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+  - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
     streamAggrConfig:
       rules:
       - match: '{__name__=~"request_duration_seconds|response_size_bytes"}'

--- a/config/examples/vmagent_istio.yaml
+++ b/config/examples/vmagent_istio.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-istio
+  name: istio
 spec:
   extraArgs:
     remoteWrite.tlsInsecureSkipVerify: "true"
@@ -16,7 +16,7 @@ spec:
       sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-certs/"}]'
       traffic.sidecar.istio.io/includeOutboundIPRanges: ""
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
   selectAllByDefault: true
   extraEnvs:
     - name: POD_IP

--- a/config/examples/vmagent_reloadauth.yaml
+++ b/config/examples/vmagent_reloadauth.yaml
@@ -11,7 +11,7 @@ spec:
     name: reload-key
     key: RELOAD_AUTH_KEY
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example-pvc.default.svc:8429/api/v1/write"
 ---
 apiVersion: v1
 kind: Secret

--- a/config/examples/vmagent_stateful_with_sharding.yaml
+++ b/config/examples/vmagent_stateful_with_sharding.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent-persisted
+  name: example-persisted
 spec:
   selectAllByDefault: true
   scrapeInterval: 30s
@@ -25,4 +25,4 @@ spec:
       cpu: "500m"
       memory: "750Mi"
   remoteWrite:
-  - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+  - url: "http://vmsingle-example.default.svc:8429/api/v1/write"

--- a/config/examples/vmagent_tls.yaml
+++ b/config/examples/vmagent_tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent-tls
+  name: example-tls
 spec:
   selectAllByDefault: true
   replicaCount: 1
@@ -23,7 +23,7 @@ spec:
           certFile: "/etc/vm/secrets/remote-tls/cert"
           keyFile: "/etc/vm/secrets/remote-tls/key"
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example-pvc.default.svc:8429/api/v1/write"
       tlsConfig:
         ca:
           secret:
@@ -36,7 +36,7 @@ spec:
         keySecret:
           name: remote-tls
           key: key
-    - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
       tlsConfig:
         caFile: "/etc/vm/secrets/remote-tls/ca"
         certFile: "/etc/vm/secrets/remote-tls/cert"
@@ -45,7 +45,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: example-scrape-tls
+  name: example-tls
 spec:
   endpoints:
     - port: http
@@ -66,7 +66,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: monitoring
-      app.kubernetes.io/instance: example-vmagent-tls
+      app.kubernetes.io/instance: example-tls
       app.kubernetes.io/name: vmagent
       managed-by: vm-operator
 ---

--- a/config/examples/vmalert-full.yaml
+++ b/config/examples/vmalert-full.yaml
@@ -12,7 +12,7 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: example-vmalert
+  name: example
 spec:
   podMetadata:
     labels:
@@ -30,7 +30,7 @@ spec:
   - name: external.Url
     value: http://some-url
   datasource:
-    url: "http://vmagent-example-vmsingle.default.svc:8429"
+    url: "http://vmagent-example.default.svc:8429"
     basicAuth:
       username:
         name: vmalert-basic-auth
@@ -71,7 +71,7 @@ spec:
     - operator: Exists
       key: name
   remoteWrite:
-    url: "http://vmagent-example-vmsingle.default.svc:8429"
+    url: "http://vmagent-example.default.svc:8429"
     concurrency: 12
     flushInterval: 5m
     maxBatchSize: 20
@@ -84,7 +84,7 @@ spec:
         name: vmalert-basic-auth
         key: password
   remoteRead:
-    url: "http://vmagent-example-vmsingle.default.svc:8429"
+    url: "http://vmagent-example.default.svc:8429"
     lookback: 1h
     basicAuth:
       username:

--- a/config/examples/vmalert.yaml
+++ b/config/examples/vmalert.yaml
@@ -1,13 +1,13 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: example-vmalert
+  name: example
 spec:
   # Add fields here
   replicaCount: 1
   datasource:
-    url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429"
+    url: "http://vmsingle-example-pvc.default.svc:8429"
   notifier:
-    url: "http://vmalertmanager-example-alertmanager.default.svc:9093"
+    url: "http://vmalertmanager-example.default.svc:9093"
   evaluationInterval: "30s"
   selectAllByDefault: true

--- a/config/examples/vmalert_discovery.yaml
+++ b/config/examples/vmalert_discovery.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicaCount: 1
   datasource:
-    url: "http://vmsingle-example-vmsingle-pvc.default.svc:8429"
+    url: "http://vmsingle-example-pvc.default.svc:8429"
   notifiers:
     - selector:
         labelSelector:

--- a/config/examples/vmalertmanager.yaml
+++ b/config/examples/vmalertmanager.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vmalertmanager-example-alertmanager
+  name: vmalertmanager-example
   labels:
     app: vm-operator
 type: Opaque
@@ -23,10 +23,10 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-alertmanager
+  name: example
 spec:
   replicaCount: 2
-  configSecret: vmalertmanager-example-alertmanager
+  configSecret: vmalertmanager-example
   selectAllByDefault: true
   storage:
       volumeClaimTemplate:

--- a/config/examples/vmalertmanager_web_tls.yaml
+++ b/config/examples/vmalertmanager_web_tls.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-alertmanager-web-tls
+  name: example-web-tls
 spec:
   replicaCount: 1
   selectAllByDefault: false

--- a/config/examples/vmalertmanager_with_mtls.yaml
+++ b/config/examples/vmalertmanager_with_mtls.yaml
@@ -149,7 +149,7 @@ spec:
   datasource:
     url: "http://vmsingle-vmcloud-mom.vmcloud.svc:8429"
   remoteWrite:
-     url: "http://vmagent-example-vmsingle-pvc.default.svc:8429"
+     url: "http://vmagent-example-pvc.default.svc:8429"
   evaluationInterval: "5s"
   selectAllByDefault: true
   secrets:

--- a/config/examples/vmcluster.yaml
+++ b/config/examples/vmcluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster-persistent
+  name: example-persistent
 spec:
   retentionPeriod: "4"
   replicationFactor: 2

--- a/config/examples/vmcluster_storage_class_unexpandable.yaml
+++ b/config/examples/vmcluster_storage_class_unexpandable.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster-persistent
+  name: example-persistent
 spec:
   retentionPeriod: "4"
   replicationFactor: 2

--- a/config/examples/vmcluster_with_additional_claim.yaml
+++ b/config/examples/vmcluster_with_additional_claim.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster-persistent
+  name: example-persistent
 spec:
   retentionPeriod: "4"
   replicationFactor: 2

--- a/config/examples/vmcluster_with_backuper.yaml
+++ b/config/examples/vmcluster_with_backuper.yaml
@@ -23,7 +23,7 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster-persistent
+  name: example-persistent
 spec:
   # Add fields here
   retentionPeriod: "4"

--- a/config/examples/vmpodscrape-full.yaml
+++ b/config/examples/vmpodscrape-full.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
-  name: example-pod-scrape
+  name: example
 spec:
   jobLabel: job
   podTargetLabels: ["app"]

--- a/config/examples/vmpodscrape.yaml
+++ b/config/examples/vmpodscrape.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
-  name: example-pod-scrape
+  name: example
 spec:
   podMetricsEndpoints:
   - port: metrics

--- a/config/examples/vmprobe.yaml
+++ b/config/examples/vmprobe.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMProbe
 metadata:
-  name: probe-agent
+  name: agent
 spec:
   jobName: static-probe
   vmProberSpec:
@@ -11,5 +11,5 @@ spec:
   targets:
     staticConfig:
       targets:
-      - vmagent-example-vmagent.default.svc:8429/health
+      - vmagent-example.default.svc:8429/health
   interval: 2s

--- a/config/examples/vmrule.yaml
+++ b/config/examples/vmrule.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  name: example-vmrule
+  name: example
 spec:
   groups:
   - name: kafka

--- a/config/examples/vmservicescrape-full.yaml
+++ b/config/examples/vmservicescrape-full.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: example-scrape
+  name: example
 spec:
   discoveryRole: "endpoints"
   jobLabel: job

--- a/config/examples/vmsingle.yaml
+++ b/config/examples/vmsingle.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle
+  name: example
 spec:
   # Add fields here
   retentionPeriod: "1"

--- a/config/examples/vmsingle_with_backuper.yaml
+++ b/config/examples/vmsingle_with_backuper.yaml
@@ -14,7 +14,7 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle
+  name: example
 spec:
   # Add fields here
   retentionPeriod: "1"

--- a/config/examples/vmsingle_with_pvc.yaml
+++ b/config/examples/vmsingle_with_pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle-pvc
+  name: example-pvc
 spec:
   # Add fields here
   retentionPeriod: "1"

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
     apiVersion: v1
     kind: Secret
     metadata:
-      name: vmalertmanager-example-alertmanager
+      name: vmalertmanager-example
 - patch: |-
     $patch: delete
     kind: ClusterRoleBinding

--- a/config/samples/operator_v1beta1_vmprobe.yaml
+++ b/config/samples/operator_v1beta1_vmprobe.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: vm-operator
     app.kubernetes.io/managed-by: kustomize
-  name: probe-agent
+  name: agent
 spec:
   jobName: static-probe
   vmProberSpec:
@@ -14,5 +14,5 @@ spec:
   targets:
     staticConfig:
       targets:
-      - vmagent-example-vmagent.default.svc:8429/health
+      - vmagent-example.default.svc:8429/health
   interval: 2s

--- a/config/samples/operator_v1beta1_vmscrapeconfig.yaml
+++ b/config/samples/operator_v1beta1_vmscrapeconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: vm-operator
     app.kubernetes.io/managed-by: kustomize
-  name: example-scrape-consul
+  name: example-consul
   annotations:
     scrape: annotation
 spec:

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -55,7 +55,7 @@ Usage example:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: vmsingle-example-extraargs
+  name: example-extraargs
 spec:
   retentionPeriod: "1"
   extraArgs:
@@ -73,7 +73,7 @@ Usage example:
 ```yaml
 kind: VMSingle
 metadata:
-  name: vmsingle-example-extraenvs
+  name: example-extraenvs
 spec:
   retentionPeriod: "1"
   extraEnvs:

--- a/docs/resources/vlsingle.md
+++ b/docs/resources/vlsingle.md
@@ -47,7 +47,7 @@ To set `VLSingle` version add `spec.image.tag` name from [releases](https://gith
 apiVersion: operator.victoriametrics.com/v1
 kind: VLSingle
 metadata:
-  name: example-vlogs
+  name: example
 spec:
   image:
     repository: victoriametrics/victoria-logs
@@ -62,7 +62,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1
 kind: VLSingle
 metadata:
-  name: example-vlogs
+  name: example
 spec:
   image:
     repository: victoriametrics/victoria-logs

--- a/docs/resources/vmagent.md
+++ b/docs/resources/vmagent.md
@@ -102,7 +102,7 @@ Here are some examples of `VMAgent` configuration with selectors:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-select-all
+  name: select-all
 spec:
   # ...
   selectAllByDefault: true
@@ -113,7 +113,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-select-ns
+  name: select-ns
 spec:
   # ...
   serviceScrapeNamespaceSelector: 
@@ -152,7 +152,7 @@ You can do it with `extraArgs` on [`VMSingle`](https://docs.victoriametrics.com/
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: vmsingle-example
+  name: example
 spec:
   # ...
   extraArgs:
@@ -166,7 +166,7 @@ For [`VMCluster`](https://docs.victoriametrics.com/operator/resources/vmcluster)
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-example
+  name: example
 spec:
   # ...
   vmselect:
@@ -189,7 +189,7 @@ For instance, let's create `VMAgent` with 2 replicas:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-ha-example
+  name: ha-example
 spec:
   # ...
   selectAllByDefault: true
@@ -219,7 +219,7 @@ Example of configuration for `StatefulMode`:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-ha-example
+  name: ha-example
 spec:
   # ...
   selectAllByDefault: true
@@ -253,7 +253,7 @@ Example usage (it is a complete example of `VMAgent` with high availability feat
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-ha-example
+  name: ha-example
 spec:
   # ...
   selectAllByDefault: true
@@ -321,7 +321,7 @@ See example below
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-example
+  name: example
 spec:
   # ...
   selectAllByDefault: true
@@ -360,7 +360,7 @@ After that, you need to specify the secret's name and key in VMAgent CRD in `add
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-example
+  name: example
 spec:
   # ...
   selectAllByDefault: true
@@ -431,7 +431,7 @@ and key `target-1-relabel.yaml` to one of remoteWrite target for relabeling only
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-example
+  name: example
 spec:
   # ...
   selectAllByDefault: true
@@ -439,8 +439,8 @@ spec:
    name: "vmagent-relabel"
    key: "global-relabel.yaml"
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle-persisted.default.svc:8429/api/v1/write"
-    - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example-persisted.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
       urlRelabelConfig:
         name: "vmagent-relabel"
         key: "target-1-relabel.yaml"
@@ -452,7 +452,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-example
+  name: example
 spec:
   # ...
   selectAllByDefault: true
@@ -468,8 +468,8 @@ spec:
    - action: drop
      source_labels: [aaa]
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle-persisted.default.svc:8429/api/v1/write"
-    - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example-persisted.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
       inlineUrlRelabelConfig:
        - action: keep_if_equal
          source_labels: [foo, bar]
@@ -511,7 +511,7 @@ data:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent
+  name: example
 spec:
   # ...
   selectAllByDefault: true
@@ -522,8 +522,8 @@ spec:
    name: "vmagent-relabel"
    key: "global-relabel.yaml"
   remoteWrite:
-    - url: "http://vmsingle-example-vmsingle-persisted.default.svc:8429/api/v1/write"
-    - url: "http://vmsingle-example-vmsingle.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example-persisted.default.svc:8429/api/v1/write"
+    - url: "http://vmsingle-example.default.svc:8429/api/v1/write"
       urlRelabelConfig:
         name: "vmagent-relabel"
         key: "target-1-relabel.yaml"
@@ -592,7 +592,7 @@ To set `VMAgent` version add `spec.image.tag` name from [releases](https://githu
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent
+  name: example
 spec:
   image:
     repository: victoriametrics/vmagent
@@ -607,7 +607,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent
+  name: example
 spec:
   image:
     repository: victoriametrics/vmagent
@@ -626,7 +626,7 @@ You can specify resources for each `VMAgent` resource in the `spec` section of t
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-resources-example
+  name: resources-example
 spec:
     # ...
     resources:
@@ -682,7 +682,7 @@ Here are complete example for [Reading metrics from Kafka](https://docs.victoria
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -713,7 +713,7 @@ Here are complete example for [Writing metrics to Kafka](https://docs.victoriame
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -763,7 +763,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: vmagent-example
+  name: example
 spec:
   selectAllByDefault: true
   replicaCount: 1

--- a/docs/resources/vmalert.md
+++ b/docs/resources/vmalert.md
@@ -89,7 +89,7 @@ Here are some examples of `VMAlert` configuration with selectors:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: vmalert-select-all
+  name: select-all
 spec:
   # ...
   selectAllByDefault: true
@@ -100,7 +100,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: vmalert-select-ns
+  name: select-ns
 spec:
   # ...
   ruleNamespaceSelector: 
@@ -120,7 +120,7 @@ You have to specify all pod fqdns  at `VMAlert.spec.notifiers.[url]`. Or you can
     apiVersion: v1
     kind: Secret
     metadata:
-      name: vmalertmanager-example-alertmanager
+      name: vmalertmanager-example
       labels:
         app: vm-operator
     type: Opaque
@@ -151,7 +151,7 @@ You have to specify all pod fqdns  at `VMAlert.spec.notifiers.[url]`. Or you can
        usage: dedicated
     spec:
       replicaCount: 2
-      configSecret: vmalertmanager-example-alertmanager
+      configSecret: vmalertmanager-example
       configSelector: {}
       configNamespaceSelector: {}
       # ...
@@ -231,7 +231,7 @@ To set `VMAlert` version add `spec.image.tag` name from [releases](https://githu
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: example-vmalert
+  name: example
 spec:
   image:
     repository: victoriametrics/vmalert
@@ -246,7 +246,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: example-vmalert
+  name: example
 spec:
   image:
     repository: victoriametrics/vmalert
@@ -265,7 +265,7 @@ You can specify resources for each `VMAlert` resource in the `spec` section of t
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: vmalert-resources-example
+  name: resources-example
 spec:
     # ...
     resources:
@@ -324,7 +324,7 @@ Here are complete example for [Reading rules from object storage](https://docs.v
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: vmalert-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -357,7 +357,7 @@ in [VMRule](https://docs.victoriametrics.com/operator/resources/vmrule#enterpris
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: vmalert-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -380,7 +380,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  name: vmrule-ent-example
+  name: ent-example
 spec:
   groups:
     - name: vmalert-1
@@ -405,13 +405,13 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlert
 metadata:
-  name: example-vmalert
+  name: example
 spec:
   replicaCount: 1
   datasource:
-    url: "http://vmsingle-example-vmsingle-persisted.default.svc:8429"
+    url: "http://vmsingle-example-persisted.default.svc:8429"
   notifier:
-    url: "http://vmalertmanager-example-alertmanager.default.svc:9093"
+    url: "http://vmalertmanager-example.default.svc:9093"
   evaluationInterval: "30s"
   selectAllByDefault: true
 ```

--- a/docs/resources/vmalertmanager.md
+++ b/docs/resources/vmalertmanager.md
@@ -74,7 +74,7 @@ stringData:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-alertmanager
+  name: example
 spec:
   replicaCount: 2
   configSecret: alertmanager-config
@@ -89,7 +89,7 @@ You can define configuration at `spec.configRawYaml` section of `VMAlertmanager`
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-alertmanager
+  name: example
 spec:
   replicaCount: 2
   configRawYaml: |
@@ -191,7 +191,7 @@ spec:
   apiVersion: operator.victoriametrics.com/v1beta1
   kind: VMAlertmanager
   metadata:
-    name: example-alertmanager
+    name: example
   spec:
     replicaCount: 2
     templates:
@@ -240,7 +240,7 @@ To set `VMAlertmanager` version add `spec.image.tag` name from [releases](https:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-vmalertmanager
+  name: example
 spec:
   image:
     repository: prom/alertmanager
@@ -255,7 +255,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: example-vmalertmanager
+  name: example
 spec:
   image:
     repository: prom/alertmanager
@@ -274,7 +274,7 @@ You can specify resources for each `VMAlertManager` resource in the `spec` secti
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertManager
 metadata:
-  name: vmalertmanager-resources-example
+  name: resources-example
 spec:
     # ...
     resources:
@@ -313,7 +313,7 @@ Also, you can specify requests without limits - in this case default values for 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAlertmanager
 metadata:
-  name: vmalertmanager-example
+  name: example
 spec:
   replicaCount: 1
   configRawYaml: |

--- a/docs/resources/vmalertmanagerconfig.md
+++ b/docs/resources/vmalertmanagerconfig.md
@@ -55,7 +55,7 @@ spec:
       - alertname="pd"
       receiver: pagerduty
 status:
-  lastErrorParentAlertmanagerName: default/example-alertmanager
+  lastErrorParentAlertmanagerName: default/example
   lastSyncError: 'receiver at idx=2 is invalid: at idx=0 pagerduty_configs one of
     ''routing_key'' or ''service_key'' must be configured'
   lastSyncErrorTimestamp: 1722950290

--- a/docs/resources/vmauth.md
+++ b/docs/resources/vmauth.md
@@ -71,7 +71,7 @@ Here are some examples of `VMAuth` configuration with selectors:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-select-all
+  name: select-all
 spec:
   # ...
   selectAllByDefault: true
@@ -82,7 +82,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-select-ns
+  name: select-ns
 spec:
   # ...
   userNamespaceSelector: 
@@ -100,7 +100,7 @@ For instance:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-unauthorized-example
+  name: unauthorized-example
 spec:
   unauthorizedUserAccessSpec:
     - src_paths: ["/metrics"]
@@ -121,7 +121,7 @@ The `VMAuth` resource is stateless, so it can be scaled horizontally by increasi
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-example
+  name: example
 spec:
     replicaCount: 3
     # ...
@@ -135,7 +135,7 @@ To set `VMAuth` version add `spec.image.tag` name from [releases](https://github
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: example-vmauth
+  name: example
 spec:
   image:
     repository: victoriametrics/vmauth
@@ -150,7 +150,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: example-vmauth
+  name: example
 spec:
   image:
     repository: victoriametrics/vmauth
@@ -169,7 +169,7 @@ You can specify resources for each `VMAuth` resource in the `spec` section of th
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-resources-example
+  name: resources-example
 spec:
     # ...
     resources:
@@ -225,7 +225,7 @@ Here are complete example with described above:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAuth
 metadata:
-  name: vmauth-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -262,7 +262,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMUser
 metadata:
-  name: vmuser-ent-example
+  name: ent-example
 spec:
   username: simple-user
   password: simple-password

--- a/docs/resources/vmcluster.md
+++ b/docs/resources/vmcluster.md
@@ -124,7 +124,7 @@ Here is an example of a `VMCluster` resource with HA features:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster-persistent
+  name: example-persistent
 spec:
   replicationFactor: 2       
   vmstorage:
@@ -199,7 +199,7 @@ For `VMCluster` you can specify tag name from [releases](https://github.com/Vict
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster
+  name: example
 spec:
   vmstorage:
     replicaCount: 2
@@ -228,7 +228,7 @@ but `imagePullSecrets` is global setting for all `VMCluster` specification:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: example-vmcluster
+  name: example
 spec:
   vmstorage:
     replicaCount: 2
@@ -261,7 +261,7 @@ You can specify resources for each component of `VMCluster` resource in the `spe
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-resources-example
+  name: resources-example
 spec:
     # ...
     vmstorage:
@@ -353,7 +353,7 @@ Here are complete example for [Downsampling](https://docs.victoriametrics.com/Cl
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-ent-example
+  name: ent-example
 spec:
   
   vmselect:
@@ -400,7 +400,7 @@ Here are complete example for [Retention filters](https://docs.victoriametrics.c
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-ent-example
+  name: ent-example
 spec:
   
   vmstorage:
@@ -432,7 +432,7 @@ and operator will automatically create
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-ent-example
+  name: ent-example
 spec:
   
   vmselect:
@@ -486,7 +486,7 @@ Here are complete example for [mTLS protection](https://docs.victoriametrics.com
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-ent-example
+  name: ent-example
 spec:
   
   vmselect:
@@ -635,7 +635,7 @@ Here is a complete example for backup configuration:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-ent-example
+  name: ent-example
 spec:
   vmstorage:
     vmBackup:
@@ -687,7 +687,7 @@ Also see VMCluster example spec [here](https://github.com/VictoriaMetrics/operat
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMCluster
 metadata:
-  name: vmcluster-example-minimal
+  name: example-minimal
 spec:
   # ...
   retentionPeriod: "1"
@@ -704,7 +704,7 @@ spec:
 ```yaml
 kind: VMCluster
 metadata:
-  name: vmcluster-example-persistent
+  name: example-persistent
 spec:
   # ...
   retentionPeriod: "4"

--- a/docs/resources/vmpodscrape.md
+++ b/docs/resources/vmpodscrape.md
@@ -39,7 +39,7 @@ To discover targets in all namespaces the `namespaceSelector` has to have value 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
-  name: example-pod-scrape
+  name: example
 spec:
   namespaceSelector:
     any: true
@@ -67,7 +67,7 @@ More details about migration from prometheus-operator you can read in [this doc]
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
-  name: example-pod-scrape
+  name: example
 spec:
   podMetricsEndpoints:
     - port: web

--- a/docs/resources/vmprobe.md
+++ b/docs/resources/vmprobe.md
@@ -45,7 +45,7 @@ More details about migration from prometheus-operator you can read in [this doc]
 
 ### Static targets
 
-It will probe `VMAgent` with url - `vmagent-example-vmagent.default.svc:9115/health` with blackbox url:
+It will probe `VMAgent` with url - `vmagent-example.default.svc:9115/health` with blackbox url:
 `prometheus-blackbox-exporter.default.svc:9115` and module `http_2xx` 
 (it was specified at [blackbox configmap](#blackbox-exporter)).
 
@@ -53,7 +53,7 @@ It will probe `VMAgent` with url - `vmagent-example-vmagent.default.svc:9115/hea
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMProbe
 metadata:
-  name: vmprobe-static-example
+  name: static-example
 spec:
   jobName: static-probe
   vmProberSpec:
@@ -63,7 +63,7 @@ spec:
   targets:
    staticConfig: 
       targets:
-      -  vmagent-example-vmagent.default.svc:8429/health
+      -  vmagent-example.default.svc:8429/health
   interval: 2s 
 ```
 
@@ -75,7 +75,7 @@ After adding target to `VMAgent` configuration it starts probing itself throw bl
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMProbe
 metadata:
-  name: vmprobe-ingress-example
+  name: ingress-example
 spec:
   vmProberSpec:
      # by default scheme http, and path is /probe
@@ -187,7 +187,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle-persisted
+  name: example-persisted
 spec:
   retentionPeriod: "1"
   removePvcAfterDelete: true
@@ -212,14 +212,14 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: vmsingle-example-vmsingle-persisted
+              serviceName: vmsingle-example-persisted
               servicePort: 8428
             path: /
     - host: vmsingle2.example.com
       http:
         paths:
           - backend:
-              serviceName: vmsingle-example-vmsingle-persisted
+              serviceName: vmsingle-example-persisted
               servicePort: 8428
             path: /
 ```
@@ -230,10 +230,10 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-   name: example-vmagent
+   name: example
 spec:
    selectAllByDefault: true
    replicaCount: 1
    remoteWrite:
-     - url: "http://vmsingle-example-vmsingle-persisted.default.svc:8429/api/v1/write"
+     - url: "http://vmsingle-example-persisted.default.svc:8429/api/v1/write"
 ```

--- a/docs/resources/vmrule.md
+++ b/docs/resources/vmrule.md
@@ -50,7 +50,7 @@ After that you can add `tenant` field for groups in `VMRule`:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  name: vmrule-ent-example
+  name: ent-example
 spec:
   groups:
     - name: vmalert-1
@@ -77,7 +77,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  name: vmrule-alerting-example
+  name: alerting-example
 spec:
   groups:
     - name: vmalert
@@ -99,7 +99,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
-  name: vmrule-recording-example
+  name: recording-example
 spec:
   groups:
     - name: vmrule_recording_groupname

--- a/docs/resources/vmservicescrape.md
+++ b/docs/resources/vmservicescrape.md
@@ -50,7 +50,7 @@ To discover targets in all namespaces the `namespaceSelector` has to have value 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: example-service-scrape
+  name: example
 spec:
   namespaceSelector:
     any: true
@@ -78,7 +78,7 @@ More details about migration from prometheus-operator you can read in [this doc]
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: example-service-scrape
+  name: example
   labels:
     team: frontend
 spec:

--- a/docs/resources/vmsingle.md
+++ b/docs/resources/vmsingle.md
@@ -46,7 +46,7 @@ To set `VMSingle` version add `spec.image.tag` name from [releases](https://gith
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle
+  name: example
 spec:
   image:
     repository: victoriametrics/victoria-metrics
@@ -61,7 +61,7 @@ Also, you can specify `imagePullSecrets` if you are pulling images from private 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle
+  name: example
 spec:
   image:
     repository: victoriametrics/victoria-metrics
@@ -80,7 +80,7 @@ You can specify resources for each `VMSingle` resource in the `spec` section of 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: vmsingle-resources-example
+  name: resources-example
 spec:
     # ...
     resources:
@@ -139,7 +139,7 @@ Here are complete example for [Downsampling](https://github.com/VictoriaMetrics/
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: vmsingle-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -166,7 +166,7 @@ The same method is used to enable retention filters - here are complete example 
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: vmsingle-ent-example
+  name: ent-example
 spec:
   # enabling enterprise features
   image:
@@ -199,7 +199,7 @@ Here is a complete example for backup configuration:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
-  name: example-vmsingle
+  name: example
 spec:
 
   vmBackup:
@@ -260,7 +260,7 @@ Steps:
     apiVersion: operator.victoriametrics.com/v1beta1
     kind: VMSingle
     metadata:
-      name: example-vmsingle
+      name: vmsingle
     spec:
     
       vmBackup:
@@ -314,7 +314,7 @@ Advantages of using `VMBackupmanager` include:
 ```yaml
 kind: VMSingle
 metadata:
-  name: vmsingle-example
+  name: example
 spec:
   retentionPeriod: "12"
   removePvcAfterDelete: true

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,7 +51,7 @@ Default psp:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: vmagent-example-vmagent
+  name: vmagent-example
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
@@ -150,7 +150,7 @@ following [Kubernetes doc](https://kubernetes.io/docs/tasks/configure-pod-contai
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent
+  name: example
   namespace: default
 spec:
   remoteWrite:
@@ -166,7 +166,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: vmagent-example-vmagent-0
+  name: vmagent-example-0
   namespace: default
 spec:
   containers:
@@ -188,7 +188,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
-  hostname: vmagent-example-vmagent-0
+  hostname: vmagent-example-0
   initContainers:
   - args:
 ...
@@ -199,8 +199,8 @@ spec:
       name: kube-api-access-q44gh
       readOnly: true
 
-  serviceAccount: vmagent-example-vmagent
-  serviceAccountName: vmagent-example-vmagent
+  serviceAccount: vmagent-example
+  serviceAccountName: vmagent-example
   volumes:
 ...
   - emptyDir: {}
@@ -231,7 +231,7 @@ spec:
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
-  name: example-vmagent
+  name: example
   namespace: default
 spec:
   disableAutomountServiceAccountToken: true
@@ -248,7 +248,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: vmagent-example-vmagent-0
+  name: vmagent-example-0
   namespace: default
 spec:
   automountServiceAccountToken: false
@@ -273,7 +273,7 @@ spec:
       readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
-  hostname: vmagent-example-vmagent-0
+  hostname: vmagent-example-0
   initContainers:
   - args:
     name: config-init
@@ -282,8 +282,8 @@ spec:
       name: config
     - mountPath: /etc/vmagent/config_out
       name: config-out
-  serviceAccount: vmagent-example-vmagent
-  serviceAccountName: vmagent-example-vmagent
+  serviceAccount: vmagent-example
+  serviceAccountName: vmagent-example
   volumes:
 ...
   - name: kube-api-access


### PR DESCRIPTION
removed CR names prefixes and suffixes, which are duplicate ones that are already added by operator to all managed resources