### PR TITLE
disable main pipeline for docs changes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+    ignore-paths:
+      - 'docs/**'
+      - '*.md'
+      - '.github/workflows/docs.yaml'
+      - 'codespell/**'
   pull_request:
     branches:
       - master
@@ -13,6 +18,11 @@ on:
       - synchronize
       - ready_for_review
       - converted_to_draft
+    ignore-paths:
+      - 'docs/**'
+      - '*.md'
+      - '.github/workflows/docs.yaml'
+      - 'codespell/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
docs changes to be merged require a not relevant e2e pipeline to be passed, disabling it