### PR TITLE
olm: added absent examples for VLCluster and VLSingle

### DIFF
--- a/config/examples/kustomization.yaml
+++ b/config/examples/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
 - vmstaticscrape.yaml
 - vmscrapeconfig.yaml
 - vlogs.yaml
+- vlsingle.yaml
+- vlcluster.yaml


### PR DESCRIPTION
<img width="807" alt="image" src="https://github.com/user-attachments/assets/a89accc6-e6dc-43ae-a5b2-a0de524f0597" />
