### PR TITLE
defaults: append -cluster and -enterprise image suffixes when it's needed. 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ aliases:
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): added AWS section to VMAgent remoteWrite spec. See [#928](https://github.com/VictoriaMetrics/operator/issues/928).
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): introduce global scrape config for VMAgent. See [#1179](https://github.com/VictoriaMetrics/operator/issues/1179).
 * FEATURE: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): added the `maxUnavailable` field to VMStorage and VMSelect specs to allow customization of rolling update behavior. See [#1457](https://github.com/VictoriaMetrics/operator/issues/1457).
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): fix default versions for all components by removing prerelease parts (`-cluster`, `-enterprise`) and by adding them conditionally depending on presence of license. Suffixes are only added if default version has no prerelease part set, this should keep new version backward compatible.
 
 ## [v0.60.2](https://github.com/VictoriaMetrics/operator/releases/tag/v0.60.2)
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -71,14 +71,14 @@
 | VM_VMSINGLEDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmsingledefault-resource-request-cpu" id="variables-vm-vmsingledefault-resource-request-cpu">#</a> |
 | VM_VMCLUSTERDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmclusterdefault-usedefaultresources" id="variables-vm-vmclusterdefault-usedefaultresources">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_IMAGE: `victoriametrics/vmselect` <a href="#variables-vm-vmclusterdefault-vmselectdefault-image" id="variables-vm-vmclusterdefault-vmselectdefault-image">#</a> |
-| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vmselectdefault-version" id="variables-vm-vmclusterdefault-vmselectdefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmclusterdefault-vmselectdefault-version" id="variables-vm-vmclusterdefault-vmselectdefault-version">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_PORT: `8481` <a href="#variables-vm-vmclusterdefault-vmselectdefault-port" id="variables-vm-vmclusterdefault-vmselectdefault-port">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_MEM: `1000Mi` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-limit-mem" id="variables-vm-vmclusterdefault-vmselectdefault-resource-limit-mem">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vmselectdefault-resource-limit-cpu">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-request-mem" id="variables-vm-vmclusterdefault-vmselectdefault-resource-request-mem">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_RESOURCE_REQUEST_CPU: `100m` <a href="#variables-vm-vmclusterdefault-vmselectdefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vmselectdefault-resource-request-cpu">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_IMAGE: `victoriametrics/vmstorage` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-image" id="variables-vm-vmclusterdefault-vmstoragedefault-image">#</a> |
-| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-version" id="variables-vm-vmclusterdefault-vmstoragedefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-version" id="variables-vm-vmclusterdefault-vmstoragedefault-version">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMINSERTPORT: `8400` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-vminsertport" id="variables-vm-vmclusterdefault-vmstoragedefault-vminsertport">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_VMSELECTPORT: `8401` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-vmselectport" id="variables-vm-vmclusterdefault-vmstoragedefault-vmselectport">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_PORT: `8482` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-port" id="variables-vm-vmclusterdefault-vmstoragedefault-port">#</a> |
@@ -87,7 +87,7 @@
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-request-mem" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-request-mem">#</a> |
 | VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_RESOURCE_REQUEST_CPU: `250m` <a href="#variables-vm-vmclusterdefault-vmstoragedefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vmstoragedefault-resource-request-cpu">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_IMAGE: `victoriametrics/vminsert` <a href="#variables-vm-vmclusterdefault-vminsertdefault-image" id="variables-vm-vmclusterdefault-vminsertdefault-image">#</a> |
-| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_VERSION: `${VM_METRICS_VERSION}-cluster` <a href="#variables-vm-vmclusterdefault-vminsertdefault-version" id="variables-vm-vmclusterdefault-vminsertdefault-version">#</a> |
+| VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmclusterdefault-vminsertdefault-version" id="variables-vm-vmclusterdefault-vminsertdefault-version">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_PORT: `8480` <a href="#variables-vm-vmclusterdefault-vminsertdefault-port" id="variables-vm-vmclusterdefault-vminsertdefault-port">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-limit-mem" id="variables-vm-vmclusterdefault-vminsertdefault-resource-limit-mem">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu">#</a> |
@@ -106,7 +106,7 @@
 | VM_VMALERTMANAGER_RESOURCE_REQUEST_CPU: `30m` <a href="#variables-vm-vmalertmanager-resource-request-cpu" id="variables-vm-vmalertmanager-resource-request-cpu">#</a> |
 | VM_DISABLESELFSERVICESCRAPECREATION: `false` <a href="#variables-vm-disableselfservicescrapecreation" id="variables-vm-disableselfservicescrapecreation">#</a> |
 | VM_VMBACKUP_IMAGE: `victoriametrics/vmbackupmanager` <a href="#variables-vm-vmbackup-image" id="variables-vm-vmbackup-image">#</a> |
-| VM_VMBACKUP_VERSION: `${VM_METRICS_VERSION}-enterprise` <a href="#variables-vm-vmbackup-version" id="variables-vm-vmbackup-version">#</a> |
+| VM_VMBACKUP_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmbackup-version" id="variables-vm-vmbackup-version">#</a> |
 | VM_VMBACKUP_PORT: `8300` <a href="#variables-vm-vmbackup-port" id="variables-vm-vmbackup-port">#</a> |
 | VM_VMBACKUP_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmbackup-usedefaultresources" id="variables-vm-vmbackup-usedefaultresources">#</a> |
 | VM_VMBACKUP_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmbackup-resource-limit-mem" id="variables-vm-vmbackup-resource-limit-mem">#</a> |

--- a/docs/resources/vmagent.md
+++ b/docs/resources/vmagent.md
@@ -664,9 +664,7 @@ Also, you can specify requests without limits - in this case default values for 
 VMAgent supports feature [Kafka integration](https://docs.victoriametrics.com/vmagent#kafka-integration)
 from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/enterprise#victoriametrics-enterprise).
 
-For using Enterprise version of [vmagent](https://docs.victoriametrics.com/vmagent) you need to:
- - specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref).
- - change version of `vmagent` to version with `-enterprise` suffix using [Version management](#version-management).
+For using Enterprise version of [vmagent](https://docs.victoriametrics.com/vmagent) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` container image suffix will be added automatically.
 
 After that you can pass [Kafka integration](https://docs.victoriametrics.com/vmagent#kafka-integration)
 flags to `VMAgent` with [extraArgs](./#extra-arguments).
@@ -686,8 +684,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   extraArgs:
     # using enterprise features: reading metrics from kafka
     # more details about kafka integration you can read on https://docs.victoriametrics.com/vmagent#kafka-integration
@@ -715,8 +711,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   # using enterprise features: writing metrics to Kafka
   # more details about kafka integration you can read on https://docs.victoriametrics.com/vmagent/#kafka-integration
   remoteWrite:

--- a/docs/resources/vmalert.md
+++ b/docs/resources/vmalert.md
@@ -304,9 +304,7 @@ VMAlert supports features [Reading rules from object storage](https://docs.victo
 and [Multitenancy](https://docs.victoriametrics.com/vmalert#multitenancy)
 from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/enterprise#victoriametrics-enterprise).
 
-For using Enterprise version of [vmalert](https://docs.victoriametrics.com/vmalert) you need to
- - specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref).
- - change version of `vmalert` to version with `-enterprise` suffix using [Version management](#version-management).
+For using Enterprise version of [vmalert](https://docs.victoriametrics.com/vmalert) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
 
 ### Reading rules from object storage
 
@@ -328,8 +326,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   extraArgs:
     # using enterprise features: Reading rules from object storage
     # more details about reading rules from object storage you can read on https://docs.victoriametrics.com/vmalert#reading-rules-from-object-storage
@@ -359,8 +355,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   extraArgs:
     # using enterprise features: Multitenancy
     # more details about multitenancy you can read on https://docs.victoriametrics.com/vmalert#multitenancy

--- a/docs/resources/vmauth.md
+++ b/docs/resources/vmauth.md
@@ -207,7 +207,7 @@ Also, you can specify requests without limits - in this case default values for 
 Custom resource `VMAuth` supports feature [IP filters](https://docs.victoriametrics.com/vmauth#ip-filters)
 from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/enterprise#victoriametrics-enterprise).
 
-For using Enterprise version of [vmauth](https://docs.victoriametrics.com/vmauth) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
+For using Enterprise version of [vmauth](https://docs.victoriametrics.com/vmauth) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` container image suffix will be added automatically.
 
 ### IP Filters
 

--- a/docs/resources/vmauth.md
+++ b/docs/resources/vmauth.md
@@ -207,9 +207,7 @@ Also, you can specify requests without limits - in this case default values for 
 Custom resource `VMAuth` supports feature [IP filters](https://docs.victoriametrics.com/vmauth#ip-filters)
 from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/enterprise#victoriametrics-enterprise).
 
-For using Enterprise version of [vmauth](https://docs.victoriametrics.com/vmauth) you need to:
- - specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref).
- - change version of `vmauth` to version with `-enterprise` suffix using [Version management](#version-management).
+For using Enterprise version of [vmauth](https://docs.victoriametrics.com/vmauth) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
 
 ### IP Filters
 
@@ -229,8 +227,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   # using enterprise features: ip filters for vmauth
   # more details about ip filters you can read in https://docs.victoriametrics.com/vmauth#ip-filters
   ip_filters:

--- a/docs/resources/vmcluster.md
+++ b/docs/resources/vmcluster.md
@@ -221,7 +221,7 @@ spec:
       pullPolicy: Always
 ```
 
-or for all cluster components all together using `clusterVersion` property that expects version without `-cluster` suffix, which will be optionally added to cluster components.
+or for all cluster components all together using `clusterVersion` property, that expects version without `-cluster` suffix, which will be optionally added to cluster components.
 
 ```yaml
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -229,7 +229,7 @@ kind: VMCluster
 metadata:
   name: example
 spec:
-  clusterVersion: v1.110.13-cluster
+  clusterVersion: v1.110.13
 ```
 
 Also, you can specify `imagePullSecrets` if you are pulling images from private repo, 

--- a/docs/resources/vmcluster.md
+++ b/docs/resources/vmcluster.md
@@ -221,7 +221,7 @@ spec:
       pullPolicy: Always
 ```
 
-or for all cluster components all together, using `clusterVersion` property:
+or for all cluster components all together using `clusterVersion` property that expects version without `-cluster` suffix, which will be optionally added to cluster components.
 
 ```yaml
 apiVersion: operator.victoriametrics.com/v1beta1
@@ -346,9 +346,7 @@ from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/enterprise#vi
 VMCluster doesn't support yet feature 
 [Automatic discovery for vmstorage nodes](https://docs.victoriametrics.com/Cluster-VictoriaMetrics#automatic-vmstorage-discovery).
 
-For using Enterprise version of [vmcluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics) you need to:
- - specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref).
- - change version of `vmcluster` to version with `-enterprise-cluster` suffix using [Version management](#version-management).
+For using Enterprise version of [vmcluster](https://docs.victoriametrics.com/Cluster-VictoriaMetrics) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
 
 ### Downsampling
 
@@ -368,7 +366,7 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  clusterVersion: v1.110.13-enterprise-cluster
+  clusterVersion: v1.110.13
   vmselect:
     # enabling enterprise features for vmselect
     extraArgs:
@@ -403,7 +401,7 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  clusterVersion: v1.110.13-enterprise-cluster
+  clusterVersion: v1.110.13
   vmstorage:
     extraArgs:
       # using enterprise features: Retention filters
@@ -431,7 +429,7 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  clusterVersion: v1.110.13-enterprise-cluster
+  clusterVersion: v1.110.13
 
   # ...other fields...
 ```
@@ -458,7 +456,7 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  clusterVersion: v1.110.13-enterprise-cluster
+  clusterVersion: v1.110.13
   vmselect:
     extraArgs:
       # using enterprise features: mTLS protection

--- a/docs/resources/vmsingle.md
+++ b/docs/resources/vmsingle.md
@@ -121,9 +121,7 @@ VMSingle supports features from [VictoriaMetrics Enterprise](https://docs.victor
 - [Multiple retentions / Retention filters](https://docs.victoriametrics.com/#retention-filters)
 - [Backup automation](https://docs.victoriametrics.com/vmbackupmanager)
 
-For using Enterprise version of [vmsingle](https://docs.victoriametrics.com/) you need to:
- - specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref).
- - change version of `vmsingle` to version with `-enterprise` suffix using [Version management](#version-management).
+For using Enterprise version of [vmsingle](https://docs.victoriametrics.com/) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
 
 ### Downsampling
 
@@ -143,8 +141,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   extraArgs:
     # using enterprise features: Downsampling
     # more details about downsampling you can read on https://docs.victoriametrics.com/#downsampling
@@ -168,8 +164,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   extraArgs:
     # using enterprise features: Retention filters
     # more details about retention filters you can read on https://docs.victoriametrics.com/#retention-filters
@@ -199,8 +193,6 @@ spec:
     keyRef:
       name: k8s-secret-that-contains-license
       key: key-in-a-secret-that-contains-license
-  image:
-    tag: v1.110.13-enterprise
   vmBackup:
     # using enterprise features: Backup automation
     # more details about backup automation you can read on https://docs.victoriametrics.com/vmbackupmanager/
@@ -261,8 +253,6 @@ Steps:
         keyRef:
           name: k8s-secret-that-contains-license
           key: key-in-a-secret-that-contains-license
-      image:
-        tag: v1.110.13-enterprise
       vmBackup:
         # using enterprise features: Backup automation
         # more details about backup automation you can read https://docs.victoriametrics.com/vmbackupmanager/

--- a/docs/resources/vmsingle.md
+++ b/docs/resources/vmsingle.md
@@ -121,7 +121,7 @@ VMSingle supports features from [VictoriaMetrics Enterprise](https://docs.victor
 - [Multiple retentions / Retention filters](https://docs.victoriametrics.com/#retention-filters)
 - [Backup automation](https://docs.victoriametrics.com/vmbackupmanager)
 
-For using Enterprise version of [vmsingle](https://docs.victoriametrics.com/) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` and `-enterprise-cluster` container image suffices will be added automatically.
+For using Enterprise version of [vmsingle](https://docs.victoriametrics.com/) you need to specify license at [`spec.license.key`](https://docs.victoriametrics.com/operator/api/#license-key) or at [`spec.license.keyRef`](https://docs.victoriametrics.com/operator/api/#license-keyref) and respective `-enterprise` container image suffix will be added automatically.
 
 ### Downsampling
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,7 +256,7 @@ type BaseOperatorConf struct {
 		UseDefaultResources bool `default:"true" env:"USEDEFAULTRESOURCES"`
 		VMSelectDefault     struct {
 			Image    string `default:"victoriametrics/vmselect"`
-			Version  string `env:",expand" default:"${VM_METRICS_VERSION}-cluster"`
+			Version  string `env:",expand" default:"${VM_METRICS_VERSION}"`
 			Port     string `default:"8481"`
 			Resource struct {
 				Limit struct {
@@ -271,7 +271,7 @@ type BaseOperatorConf struct {
 		} `prefix:"VMSELECTDEFAULT_"`
 		VMStorageDefault struct {
 			Image        string `default:"victoriametrics/vmstorage"`
-			Version      string `env:",expand" default:"${VM_METRICS_VERSION}-cluster"`
+			Version      string `env:",expand" default:"${VM_METRICS_VERSION}"`
 			VMInsertPort string `default:"8400" env:"VMINSERTPORT"`
 			VMSelectPort string `default:"8401" env:"VMSELECTPORT"`
 			Port         string `default:"8482"`
@@ -288,7 +288,7 @@ type BaseOperatorConf struct {
 		} `prefix:"VMSTORAGEDEFAULT_"`
 		VMInsertDefault struct {
 			Image    string `default:"victoriametrics/vminsert"`
-			Version  string `env:",expand" default:"${VM_METRICS_VERSION}-cluster"`
+			Version  string `env:",expand" default:"${VM_METRICS_VERSION}"`
 			Port     string `default:"8480"`
 			Resource struct {
 				Limit struct {
@@ -328,7 +328,7 @@ type BaseOperatorConf struct {
 	DisableSelfServiceScrapeCreation bool `default:"false" env:"DISABLESELFSERVICESCRAPECREATION"`
 	VMBackup                         struct {
 		Image               string `default:"victoriametrics/vmbackupmanager"`
-		Version             string `env:",expand" default:"${VM_METRICS_VERSION}-enterprise"`
+		Version             string `env:",expand" default:"${VM_METRICS_VERSION}"`
 		Port                string `default:"8300"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {

--- a/internal/controller/operator/factory/vlcluster/vmauth_lb.go
+++ b/internal/controller/operator/factory/vlcluster/vmauth_lb.go
@@ -125,13 +125,13 @@ func buildVMauthLBDeployment(cr *vmv1.VLCluster) (*appsv1.Deployment, error) {
 		},
 	}
 	volumes = append(volumes, spec.Volumes...)
-	vmounts := []corev1.VolumeMount{
+	vmMounts := []corev1.VolumeMount{
 		{
 			MountPath: "/opt/vmauth-config/",
 			Name:      configMountName,
 		},
 	}
-	vmounts = append(vmounts, spec.VolumeMounts...)
+	vmMounts = append(vmMounts, spec.VolumeMounts...)
 
 	args := []string{
 		"-auth.config=/opt/vmauth-config/config.yaml",
@@ -166,7 +166,7 @@ func buildVMauthLBDeployment(cr *vmv1.VLCluster) (*appsv1.Deployment, error) {
 		Resources:       spec.Resources,
 		Image:           fmt.Sprintf("%s:%s", spec.Image.Repository, spec.Image.Tag),
 		ImagePullPolicy: spec.Image.PullPolicy,
-		VolumeMounts:    vmounts,
+		VolumeMounts:    vmMounts,
 	}
 	vmauthLBCnt = build.Probe(vmauthLBCnt, &spec)
 	containers := []corev1.Container{


### PR DESCRIPTION
- removed `-cluster` and `-enterprise` suffixes from default versions and append them in defaults when it's needed
- removed impact of vlcluster cluster version on lb image, since it's versioning differs

related issue #1365
