### PR TITLE
internal/controller/operator/factory/vmagent: fix tls config marshalling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly add TLS configuration for scrape configuration. Previously, tls options were applied to the root of scrape configuration, which caused an error at `vmagent` startup. Bug was introduced in v0.60.0 release.
+
 ## [v0.61.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.61.0)
 
 **Release date:** 15 July 2025

--- a/internal/controller/operator/factory/vmagent/servicescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/servicescrape_test.go
@@ -1128,6 +1128,9 @@ bearer_token_file: /var/run/token
 				i: 0,
 				apiserverConfig: &vmv1beta1.APIServerConfig{
 					Host: "default-k8s-host",
+					TLSConfig: &vmv1beta1.TLSConfig{
+						CAFile: "/etc/vmagent-tls/certs/default_k8s_host_ca",
+					},
 				},
 				se: vmv1beta1.VMAgentSecurityEnforcements{
 					OverrideHonorLabels:      false,
@@ -1145,6 +1148,8 @@ kubernetes_sd_configs:
     names:
     - default
   api_server: default-k8s-host
+  tls_config:
+    ca_file: /etc/vmagent-tls/certs/default_k8s_host_ca
   selectors:
   - role: endpoints
     label: dc=prod,env=dev,team=go

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -897,7 +897,7 @@ func generateK8SSDConfig(ac *build.AssetsCache, opts generateK8SSDConfigOptions)
 				return nil, fmt.Errorf("cannot add tls asset for apiServerConfig: %w", err)
 			}
 			if len(cfg) > 0 {
-				k8sSDConfig = append(k8sSDConfig, cfg...)
+				k8sSDConfig = append(k8sSDConfig, yaml.MapItem{Key: "tls_config", Value: cfg})
 			}
 		}
 	}


### PR DESCRIPTION
A config marshalling will not add `tls_config` to store the config for scrape configurations at vmagent since 8df334cc.