### PR TITLE
k8stools/selectors: properly apply namespace selectors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly add TLS configuration for scrape configuration. Previously, tls options were applied to the root of scrape configuration, which caused an error at `vmagent` startup. Bug was introduced in v0.60.0 release.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmalert](https://docs.victoriametrics.com/operator/resources/vmalert/), [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth/) and [vmalertmanager](https://docs.victoriametrics.com/operator/resources/vmalertmanager/): reduce Kubernetes API-server and operator resource usage for objects discovery with `NamespaceSelector: {}`. See this [1468](https://github.com/VictoriaMetrics/operator/issues/1468) issue for details.
 
 ## [v0.61.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.61.0)
 

--- a/internal/controller/operator/factory/k8stools/selectors_test.go
+++ b/internal/controller/operator/factory/k8stools/selectors_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,10 +21,17 @@ func Test_discoverNamespaces(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "select 1 ns",
+			name:         "no match",
 			selectorOpts: &SelectorOpts{},
 			predefinedNs: []runtime.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}}},
-			want:         []string{"ns1"},
+			want:         []string{},
+			wantErr:      false,
+		},
+		{
+			name:         "match everything(empty slice)",
+			selectorOpts: &SelectorOpts{SelectAll: true},
+			predefinedNs: []runtime.Object{&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}}},
+			want:         []string{},
 			wantErr:      false,
 		},
 		{
@@ -33,13 +42,46 @@ func Test_discoverNamespaces(t *testing.T) {
 						"name": "kube-system",
 					},
 				},
-				SelectAll: true,
 			},
 			predefinedNs: []runtime.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"name": "kube-system"}}},
 			},
 			want:    []string{"kube-system"},
+			wantErr: false,
+		},
+		{
+			name: "no match with ns selector",
+			selectorOpts: &SelectorOpts{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"name": "kube-system",
+					},
+				},
+			},
+			predefinedNs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: map[string]string{"name": "default"}}},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "match for object NS only",
+			selectorOpts: &SelectorOpts{
+				DefaultNamespace: "default",
+				ObjectSelector: &metav1.LabelSelector{
+
+					MatchLabels: map[string]string{
+						"name": "kube-system",
+					},
+				},
+			},
+			predefinedNs: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: map[string]string{"name": "default-1"}}},
+			},
+			want:    []string{"default"},
 			wantErr: false,
 		},
 	}
@@ -56,4 +98,307 @@ func Test_discoverNamespaces(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVisitSelected(t *testing.T) {
+	type opts struct {
+		so                *SelectorOpts
+		watchNamespaces   []string
+		wantPods          []corev1.Pod
+		predefinedObjects []runtime.Object
+	}
+
+	podFromNameNs := func(name string, namespace string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+	ignoreDiffOpts := cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
+
+	f := func(opts opts) {
+		if len(opts.watchNamespaces) > 0 {
+			origin := getWatchNamespaces
+			getWatchNamespaces = func() []string {
+				return opts.watchNamespaces
+			}
+			defer func() {
+				getWatchNamespaces = origin
+			}()
+		}
+		t.Helper()
+		ctx := context.Background()
+		fclient := GetTestClientWithObjects(opts.predefinedObjects)
+		var gotPods []corev1.Pod
+		err := VisitSelected(ctx, fclient, opts.so, func(pl *corev1.PodList) {
+			gotPods = append(gotPods, pl.Items...)
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if d := cmp.Diff(opts.wantPods, gotPods, ignoreDiffOpts); len(d) > 0 {
+			t.Fatalf("unexpected diff: %s", d)
+		}
+	}
+	// empty objects
+	o := opts{
+		so: &SelectorOpts{
+			DefaultNamespace: "default",
+		},
+	}
+	f(o)
+
+	// all objects at single namespace
+	o = opts{
+		so: &SelectorOpts{
+			ObjectSelector:   &metav1.LabelSelector{},
+			DefaultNamespace: "default",
+		},
+		wantPods: []corev1.Pod{
+			*podFromNameNs("pod-1", "default"),
+			*podFromNameNs("pod-2", "default"),
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-2"}},
+		},
+	}
+	f(o)
+
+	// all objects at any namespace
+	o = opts{
+		so: &SelectorOpts{
+			SelectAll:        true,
+			DefaultNamespace: "default",
+		},
+		wantPods: []corev1.Pod{
+			*podFromNameNs("pod-1", "default"),
+			*podFromNameNs("pod-2", "default"),
+			*podFromNameNs("pod-3", "default-1"),
+			*podFromNameNs("pod-3", "default-2"),
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-2"}},
+		},
+	}
+	f(o)
+
+	// all objects at any namespace with non-nil selectors
+	o = opts{
+		so: &SelectorOpts{
+			ObjectSelector:    &metav1.LabelSelector{},
+			NamespaceSelector: &metav1.LabelSelector{},
+			DefaultNamespace:  "default",
+		},
+		wantPods: []corev1.Pod{
+			*podFromNameNs("pod-1", "default"),
+			*podFromNameNs("pod-2", "default"),
+			*podFromNameNs("pod-3", "default-1"),
+			*podFromNameNs("pod-3", "default-2"),
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-2"}},
+		},
+	}
+	f(o)
+
+	// objects matched selectors at single namespace
+	o = opts{
+		so: &SelectorOpts{
+			ObjectSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod", "v": "v1"},
+			},
+			DefaultNamespace: "default-5",
+		},
+		wantPods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar"}}},
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-5"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-2"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// all objects at multiple namespaces matched selectors
+	o = opts{
+		so: &SelectorOpts{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "env", "foo": "bar"}},
+			DefaultNamespace:  "default-5",
+		},
+		wantPods: []corev1.Pod{
+			*podFromNameNs("pod-3", "default-1"),
+			*podFromNameNs("pod-1", "default-3"),
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default-3"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// objects matched selectors at multiple namespaces matched selectors
+	o = opts{
+		so: &SelectorOpts{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "env", "foo": "bar"}},
+			ObjectSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod", "v": "v1"},
+			},
+			DefaultNamespace: "default-5",
+		},
+		wantPods: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-1", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar", "baz": "bar"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-5", Namespace: "default-3", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar"}}},
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-0", "default-3"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-4", "default-1"),
+			podFromNameNs("pod-6", "default-2"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-1", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar", "baz": "bar"}}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-5", Namespace: "default-3", Labels: map[string]string{"env": "prod", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// match nothing due to namespace selectors mismatch
+	o = opts{
+		so: &SelectorOpts{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "prod", "bar": "baz"}},
+			DefaultNamespace:  "default-5",
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default-3"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "d", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// match nothing due to object selectors mismatch
+	o = opts{
+		so: &SelectorOpts{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "env", "foo": "bar"}},
+			ObjectSelector:    &metav1.LabelSelector{MatchLabels: map[string]string{"bar": "baz"}},
+			DefaultNamespace:  "default-5",
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default-3"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "default-2"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "d", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// watch namespace is set for single ns
+	o = opts{
+		watchNamespaces: []string{"dev"},
+		so: &SelectorOpts{
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "env", "foo": "bar"}},
+			ObjectSelector:    &metav1.LabelSelector{},
+			DefaultNamespace:  "dev",
+		},
+		wantPods: []corev1.Pod{
+			*podFromNameNs("pod-3", "dev"),
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default-3"),
+			podFromNameNs("pod-2", "default"),
+			podFromNameNs("pod-3", "default-1"),
+			podFromNameNs("pod-3", "dev"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default-5", Labels: map[string]string{"env": "d", "v": "v1", "foo": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dev"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
+	// watch namespace is set for multiple namespace with object selector
+	o = opts{
+		watchNamespaces: []string{"dev", "prod"},
+		so: &SelectorOpts{
+			ObjectSelector:   &metav1.LabelSelector{MatchLabels: map[string]string{"dev": "env", "foo": "bar"}},
+			DefaultNamespace: "dev",
+		},
+		wantPods: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "dev", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-5", Namespace: "prod", Labels: map[string]string{"dev": "env", "foo": "bar", "baz": "bar"}}},
+		},
+		predefinedObjects: []runtime.Object{
+			podFromNameNs("pod-1", "default-3"),
+			podFromNameNs("pod-2", "dev"),
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "dev", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-5", Namespace: "prod", Labels: map[string]string{"dev": "env", "foo": "bar", "baz": "bar"}}},
+
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dev"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "prod"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-1", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-3", Labels: map[string]string{"dev": "env", "foo": "bar"}}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default-5"}},
+		},
+	}
+	f(o)
+
 }


### PR DESCRIPTION
 Previously, operator performed namespace discovery on defined, but
empty namespaceSelector. Also operator treat empty response for namespaceSelector ( such as non-namespace matched for given selectors) as cluster wide request. Which is not correct.

 This commit fixes both issues and adds corresponding tests for
selectors.

Fixes https://github.com/VictoriaMetrics/operator/issues/1468