### PR TITLE
allow pods eviction

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,6 +89,7 @@ rules:
 - apiGroups:
   - policy
   resources:
+  - pods
   - poddisruptionbudgets
   - poddisruptionbudgets/finalizers
   verbs:


### PR DESCRIPTION
given below permissions are needed for eviction
```
- apiGroups: ["policy"]
  resources: ["pods"]
  verbs: ["evict"]
```
related issue https://github.com/VictoriaMetrics/operator/issues/1483