### PR TITLE
controller/operator/factory: run PollUntilContextTimeout with immediate flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ aliases:
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VMAnomaly to [v1.25.2](https://docs.victoriametrics.com/anomaly-detection/changelog/#v1252) version
 
 * FEATURE: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): support `spec.limit`, `spec.labels`, `spec.query_offset` and `spec.group[*].keep_firing_for` PrometheusRule properties conversion to VMRule. Related issue [#1485](https://github.com/VictoriaMetrics/operator/issues/1485).
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): reduce reconcile latency. See this PR [#1510](https://github.com/VictoriaMetrics/operator/pull/1510) for details. Thanks to the @vrutkovs
 
 * BUGFIX: [config-reloader](https://github.com/VictoriaMetrics/operator/tree/master/cmd/config-reloader): fixed config reloader command line arguments override. Related issue [#1378](https://github.com/VictoriaMetrics/operator/issues/1478).
 * BUGFIX: [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): sort requestsLoadBalancer `Deployment` `args` in order to prevent endless update loop if `extraArgs` are set.

--- a/internal/controller/operator/factory/reconcile/daemonset.go
+++ b/internal/controller/operator/factory/reconcile/daemonset.go
@@ -90,7 +90,7 @@ func DaemonSet(ctx context.Context, rclient client.Client, newDs, prevDs *appsv1
 // waitDeploymentReady waits until deployment's replicaSet rollouts and all new pods is ready
 func waitDaemonSetReady(ctx context.Context, rclient client.Client, ds *appsv1.DaemonSet, deadline time.Duration) error {
 	var isErrDealine bool
-	err := wait.PollUntilContextTimeout(ctx, time.Second, deadline, false, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, deadline, true, func(ctx context.Context) (done bool, err error) {
 		var daemon appsv1.DaemonSet
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: ds.Namespace, Name: ds.Name}, &daemon); err != nil {
 			return false, fmt.Errorf("cannot fetch actual daemonset state: %w", err)

--- a/internal/controller/operator/factory/reconcile/deploy.go
+++ b/internal/controller/operator/factory/reconcile/deploy.go
@@ -95,7 +95,7 @@ func Deployment(ctx context.Context, rclient client.Client, newDeploy, prevDeplo
 // waitDeploymentReady waits until deployment's replicaSet rollouts and all new pods is ready
 func waitDeploymentReady(ctx context.Context, rclient client.Client, dep *appsv1.Deployment, deadline time.Duration) error {
 	var isErrDealine bool
-	err := wait.PollUntilContextTimeout(ctx, time.Second, deadline, false, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, deadline, true, func(ctx context.Context) (done bool, err error) {
 		var actualDeploy appsv1.Deployment
 		if err := rclient.Get(ctx, types.NamespacedName{Namespace: dep.Namespace, Name: dep.Name}, &actualDeploy); err != nil {
 			return false, fmt.Errorf("cannot fetch actual deployment state: %w", err)

--- a/internal/controller/operator/factory/reconcile/deploy_test.go
+++ b/internal/controller/operator/factory/reconcile/deploy_test.go
@@ -42,7 +42,7 @@ func TestDeployOk(t *testing.T) {
 		}
 
 		err := wait.PollUntilContextTimeout(ctx, time.Millisecond*50,
-			waitTimeout, false, func(ctx context.Context) (done bool, err error) {
+			waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 				var createdDep appsv1.Deployment
 				if err := rclient.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, &createdDep); err != nil {
 					if k8serrors.IsNotFound(err) {

--- a/internal/controller/operator/factory/reconcile/deploy_test.go
+++ b/internal/controller/operator/factory/reconcile/deploy_test.go
@@ -29,10 +29,7 @@ func TestDeployOk(t *testing.T) {
 		createErr := make(chan error)
 		go func() {
 			err := Deployment(ctx, rclient, dep, nil, false)
-			select {
-			case createErr <- err:
-			default:
-			}
+			createErr <- err
 		}()
 		reloadDep := func() {
 			t.Helper()

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -39,7 +39,7 @@ type STSOptions struct {
 }
 
 func waitForStatefulSetReady(ctx context.Context, rclient client.Client, newSts *appsv1.StatefulSet) error {
-	err := wait.PollUntilContextTimeout(ctx, podWaitReadyIntervalCheck, appWaitReadyDeadline, false, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, podWaitReadyIntervalCheck, appWaitReadyDeadline, true, func(ctx context.Context) (done bool, err error) {
 		// fast path
 		if newSts.Spec.Replicas == nil {
 			return true, nil
@@ -381,7 +381,7 @@ func PodIsReady(pod *corev1.Pod, minReadySeconds int32) bool {
 
 func waitForPodReady(ctx context.Context, rclient client.Client, nsn types.NamespacedName, desiredRevision string, minReadySeconds int32) error {
 	var pod *corev1.Pod
-	if err := wait.PollUntilContextTimeout(ctx, podWaitReadyIntervalCheck, podWaitReadyTimeout, false, func(_ context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, podWaitReadyIntervalCheck, podWaitReadyTimeout, true, func(_ context.Context) (done bool, err error) {
 		pod = &corev1.Pod{}
 		err = rclient.Get(ctx, nsn, pod)
 		if err != nil {

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -304,7 +304,7 @@ func removeStatefulSetKeepPods(ctx context.Context, rclient client.Client, state
 	nsn := types.NamespacedName{Name: oldStatefulSet.Name, Namespace: oldStatefulSet.Namespace}
 
 	// wait until sts disappears
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, false, func(_ context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(_ context.Context) (done bool, err error) {
 		err = rclient.Get(ctx, nsn, &appsv1.StatefulSet{})
 		if k8serrors.IsNotFound(err) {
 			return true, nil

--- a/internal/controller/operator/factory/reconcile/statefulset_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_test.go
@@ -443,7 +443,7 @@ func TestStatefulsetReconcileOk(t *testing.T) {
 		}
 
 		err := wait.PollUntilContextTimeout(ctx, time.Millisecond*50,
-			waitTimeout, false, func(ctx context.Context) (done bool, err error) {
+			waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 				var createdSts appsv1.StatefulSet
 				if err := rclient.Get(ctx, types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, &createdSts); err != nil {
 					if k8serrors.IsNotFound(err) {

--- a/internal/controller/operator/factory/vlagent/vlagent_test.go
+++ b/internal/controller/operator/factory/vlagent/vlagent_test.go
@@ -49,7 +49,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			err := CreateOrUpdate(ctx, cr, fclient)
 			errC <- err
 		}()
-		err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, false, func(ctx context.Context) (done bool, err error) {
+		err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, true, func(ctx context.Context) (done bool, err error) {
 			var sts appsv1.StatefulSet
 			if err := fclient.Get(ctx, types.NamespacedName{Namespace: "default", Name: fmt.Sprintf("vlagent-%s", cr.Name)}, &sts); err != nil {
 				return false, nil

--- a/internal/controller/operator/factory/vmagent/vmagent_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_test.go
@@ -692,7 +692,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			if tt.statefulsetMode {
 				if tt.cr.Spec.ShardCount != nil {
 					for i := 0; i < *tt.cr.Spec.ShardCount; i++ {
-						err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, false, func(ctx context.Context) (done bool, err error) {
+						err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, true, func(ctx context.Context) (done bool, err error) {
 							var sts appsv1.StatefulSet
 							if err := fclient.Get(ctx, types.NamespacedName{
 								Namespace: "default",
@@ -716,7 +716,7 @@ func TestCreateOrUpdate(t *testing.T) {
 						}
 					}
 				} else {
-					err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, false, func(ctx context.Context) (done bool, err error) {
+					err := wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, time.Second, true, func(ctx context.Context) (done bool, err error) {
 						var sts appsv1.StatefulSet
 						if err := fclient.Get(ctx, types.NamespacedName{Namespace: "default", Name: fmt.Sprintf("vmagent-%s", tt.cr.Name)}, &sts); err != nil {
 							return false, nil


### PR DESCRIPTION
When `immediate` flag is unset, this function waits for `interval` first and only afterward runs the function the first time. This commit changes all function calls to use `immediate` true to make it run sooner.

With [tracing](https://github.com/vrutkovs/operator/tree/tracing) the effects of these flags is most obvious.
Before:
<img width="1545" height="282" alt="image" src="https://github.com/user-attachments/assets/d289e992-b785-46b0-bfea-1b011fb95e14" />
`reconcile.waitDeploymentReady` doesn't do anything for a second and then runs `client.Get`

After:
<img width="1543" height="245" alt="image" src="https://github.com/user-attachments/assets/dd3735d4-dfd7-44df-9e38-765ddf9858bd" />
Now `reconcile.waitDeploymentReady` takes 25 nanoseconds and runs `client.Get` immediately


Unfortunately I didn't get a chance to test this PR properly, as it affects a lot of areas in operators, but I can't think of a reason why would it cause regressions.