### PR TITLE
vmanomaly: support ui preset mode

### DIFF
--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -218,8 +218,6 @@ type VMAnomalyMonitoringSpec struct {
 // VMAnomalyMonitoringPullSpec defines pull monitoring configuration
 // which is enabled by default and served at POD_IP:8490/metrics
 type VMAnomalyMonitoringPullSpec struct {
-	// Addr changes listen addr, default is 0.0.0.0
-	Addr string `json:"addr,omitempty" yaml:"addr,omitempty"`
 	// Port defines a port for metrics scrape
 	Port string `json:"port"`
 }
@@ -365,7 +363,7 @@ func (cr *VMAnomaly) GetServiceScrape() *vmv1beta1.VMServiceScrapeSpec {
 	return cr.Spec.ServiceScrapeSpec
 }
 
-// Port returns port for accessing anomaly
+// Port returns port for accessing anomaly UI
 func (cr *VMAnomaly) Port() string {
 	return cr.Spec.Port
 }

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -21123,9 +21123,6 @@ spec:
                       VMAnomalyMonitoringPullSpec defines pull monitoring configuration
                       which is enabled by default and served at POD_IP:8490/metrics
                     properties:
-                      addr:
-                        description: Addr changes listen addr, default is 0.0.0.0
-                        type: string
                       port:
                         description: Port defines a port for metrics scrape
                         type: string

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ aliases:
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.126.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.126.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.35.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.35.0).
 
+* FEATURE: [vmanomaly](https://docs.victoriametrics.com/anomaly-detection/): support ui preset mode, support `vlogs` reader type. See [#1532](https://github.com/VictoriaMetrics/operator/issues/1538).
+
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fix an issue where the return value from a couple of controllers was always `nil`. See [#1532](https://github.com/VictoriaMetrics/operator/pull/1532) for details.
 
 ## [v0.63.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.63.0)

--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -281,7 +281,7 @@ func addVMAnomalyDefaults(objI any) {
 	if cr.Spec.Monitoring == nil {
 		cr.Spec.Monitoring = &vmv1.VMAnomalyMonitoringSpec{
 			Pull: &vmv1.VMAnomalyMonitoringPullSpec{
-				Port: cr.Port(),
+				Port: "8080",
 			},
 		}
 	}

--- a/internal/controller/operator/factory/vmanomaly/config/monitoring.go
+++ b/internal/controller/operator/factory/vmanomaly/config/monitoring.go
@@ -1,7 +1,7 @@
 package config
 
 type monitoring struct {
-	Pull *pullMonitoring `yaml:"pull,omitempty"`
+	Pull *server         `yaml:"pull,omitempty"`
 	Push *pushMonitoring `yaml:"push,omitempty"`
 }
 
@@ -9,7 +9,7 @@ func (m *monitoring) validate() error {
 	return nil
 }
 
-type pullMonitoring struct {
+type server struct {
 	Addr string `yaml:"addr,omitempty"`
 	Port string `yaml:"port,omitempty"`
 }

--- a/internal/controller/operator/factory/vmanomaly/config/readers.go
+++ b/internal/controller/operator/factory/vmanomaly/config/readers.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -22,7 +24,10 @@ type reader struct {
 }
 
 func (r *reader) validate() error {
-	if r.Class != "reader.vm.VmReader" && r.Class != "vm" && r.Class != "reader.synthetic.SyntheticVmReader" && r.Class != "synthetic_vm" {
+	if strings.ToLower(r.Class) == "noop" {
+		return nil
+	}
+	if !slices.Contains([]string{"reader.vm.VmReader", "vm", "reader.synthetic.SyntheticVmReader", "synthetic_vm", "vlogs", "reader.vlogs.VLogsReader"}, r.Class) {
 		return fmt.Errorf("anomaly reader class=%q is not supported", r.Class)
 	}
 	if len(r.Queries) == 0 {

--- a/internal/controller/operator/factory/vmanomaly/config/schedulers.go
+++ b/internal/controller/operator/factory/vmanomaly/config/schedulers.go
@@ -45,6 +45,14 @@ func (s *scheduler) MarshalYAML() (any, error) {
 	return s.validatable, nil
 }
 
+type noopScheduler struct {
+	Class string `yaml:"class"`
+}
+
+func (s *noopScheduler) validate() error {
+	return nil
+}
+
 type periodicScheduler struct {
 	Class      string        `yaml:"class"`
 	FitEvery   *duration     `yaml:"fit_every,omitempty"`

--- a/internal/controller/operator/factory/vmanomaly/config/writers.go
+++ b/internal/controller/operator/factory/vmanomaly/config/writers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -14,7 +15,10 @@ type writer struct {
 }
 
 func (w *writer) validate() error {
-	if w.Class != "writer.vm.VmReader" && w.Class != "vm" {
+	if strings.ToLower(w.Class) == "noop" {
+		return nil
+	}
+	if !slices.Contains([]string{"writer.vm.VmWriter", "vm"}, w.Class) {
 		return fmt.Errorf("anomaly writer class=%q is not supported", w.Class)
 	}
 	if w.MetricFormat != nil {

--- a/internal/controller/operator/factory/vmanomaly/pod.go
+++ b/internal/controller/operator/factory/vmanomaly/pod.go
@@ -40,10 +40,20 @@ func newPodSpec(cr *vmv1.VMAnomaly, ac *build.AssetsCache) (*corev1.PodSpec, err
 		args = append(args, fmt.Sprintf("--loggerLevel=%s", strings.ToUpper(cr.Spec.LogLevel)))
 	}
 
+	monitoringPort, err := strconv.ParseInt(cr.Spec.Monitoring.Pull.Port, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reconcile vmanomaly: failed to parse monitoring port: %w", err)
+	}
+
 	ports := []corev1.ContainerPort{
 		{
 			Name:          "http",
 			ContainerPort: int32(port),
+			Protocol:      corev1.ProtocolTCP,
+		},
+		{
+			Name:          "monitoring-http",
+			ContainerPort: int32(monitoringPort),
 			Protocol:      corev1.ProtocolTCP,
 		},
 	}


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1538
allow providing empty reader, writer, models and schedulers sections, when spec.configRawYaml.preset is equal to ui