### PR TITLE
Fix: conserve custom labels on services

### DIFF
--- a/internal/controller/operator/factory/reconcile/service.go
+++ b/internal/controller/operator/factory/reconcile/service.go
@@ -114,6 +114,11 @@ func reconcileService(ctx context.Context, rclient client.Client, newService, pr
 		prevAnnotations = prevService.Annotations
 	}
 
+	var prevLabels map[string]string
+	if prevService != nil {
+		prevLabels = prevService.Labels
+	}
+
 	rclient.Scheme().Default(newService)
 	isEqual := equality.Semantic.DeepDerivative(newService.Spec, currentService.Spec)
 	if isEqual &&
@@ -125,6 +130,7 @@ func reconcileService(ctx context.Context, rclient client.Client, newService, pr
 
 	vmv1beta1.AddFinalizer(newService, currentService)
 	newService.Annotations = mergeAnnotations(currentService.Annotations, newService.Annotations, prevAnnotations)
+	newService.Labels = mergeAnnotations(currentService.Labels, newService.Labels, prevLabels)
 	cloneSignificantMetadata(newService, currentService)
 
 	logMsg := fmt.Sprintf("updating service %s configuration, is_current_equal=%v, is_prev_equal=%v, is_prev_nil=%v",

--- a/internal/controller/operator/factory/reconcile/service_test.go
+++ b/internal/controller/operator/factory/reconcile/service_test.go
@@ -306,6 +306,46 @@ func Test_reconcileServiceForCRD(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "keep custom labels on svc",
+			args: args{
+				newService: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prefixed-1",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+				ctx: context.TODO(),
+			},
+			predefinedObjects: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prefixed-1",
+						Namespace: "default",
+						Labels:    map[string]string{"custom": "label"},
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+					},
+				},
+			},
+			validate: func(svc *corev1.Service) error {
+				if svc.Name != "prefixed-1" {
+					return fmt.Errorf("unexpected name, got: %v, want: prefixed-1", svc.Name)
+				}
+				l, ok := svc.Labels["custom"]
+				if !ok {
+					return fmt.Errorf("missing 'custom' label on svc")
+				}
+				if l != "label" {
+					return fmt.Errorf("unexpected value of 'custom' label on svc, got: %v, want: 'value'", l)
+				}
+				return nil
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/operator/factory/vmcluster/vmcluster.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster.go
@@ -1579,6 +1579,7 @@ func createOrUpdateVMAuthLBService(ctx context.Context, rclient client.Client, c
 	var prevSvc *corev1.Service
 	if prevCR != nil && prevCR.Spec.RequestsLoadBalancer.Enabled {
 		t.VMCluster = prevCR
+		t.finalLabels = prevCR.FinalLabels(lbls)
 		t.additionalService = prevCR.Spec.RequestsLoadBalancer.Spec.AdditionalServiceSpec
 		prevSvc = build.Service(t, prevCR.Spec.RequestsLoadBalancer.Spec.Port, nil)
 	}


### PR DESCRIPTION
When reconciling k8s services managed by the operator, custom labels, such as those added by mutating webhooks, the user, or third-party controllers are clobbered. Resolves #1533.