### PR TITLE
e2e: use custom timeouts for anomaly, change e2e registry to quay.io

### DIFF
--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -126,6 +126,8 @@ func InitOperatorProcess() {
 		Expect(cfg).ToNot(BeNil())
 
 		// operator settings
+		Expect(os.Setenv("VM_CONTAINERREGISTRY", "quay.io")).To(Succeed())
+		Expect(os.Setenv("VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE", "prometheus/alertmanager")).To(Succeed())
 		Expect(os.Setenv("VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES", "true")).To(Succeed())
 		Expect(os.Setenv("VM_PODWAITREADYTIMEOUT", "20s")).To(Succeed())
 		Expect(os.Setenv("VM_PODWAITREADYINTERVALCHECK", "1s")).To(Succeed())

--- a/test/e2e/vmanomaly_test.go
+++ b/test/e2e/vmanomaly_test.go
@@ -225,7 +225,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				func(cr *vmv1.VMAnomaly) {
 					Eventually(func() string {
 						return expectPodCount(k8sClient, 1, namespace, cr.SelectorLabels())
-					}, eventualDeploymentPodTimeout, 1).Should(BeEmpty())
+					}, anomalyReadyTimeout, 1).Should(BeEmpty())
 					Expect(finalize.SafeDelete(
 						ctx,
 						k8sClient,
@@ -272,7 +272,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				}, nil, func(cr *vmv1.VMAnomaly) {
 					Eventually(func() string {
 						return expectPodCount(k8sClient, 1, namespace, cr.SelectorLabels())
-					}, eventualDeploymentPodTimeout, 1).Should(BeEmpty())
+					}, anomalyReadyTimeout, 1).Should(BeEmpty())
 					var dep appsv1.StatefulSet
 					Expect(k8sClient.Get(ctx, types.NamespacedName{
 						Name: cr.PrefixedName(), Namespace: namespace,


### PR DESCRIPTION
- e2e tests are hitting rate limit on hub.docker.io from time to time, switching to quay.io
- use already defined anomaly specific timeouts on cases that are failing frequently enough