### PR TITLE
properly handle reconcile errors

### DIFF
--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -398,6 +398,7 @@ func reconcileAndTrackStatus[T client.Object, ST reconcile.StatusWithMetadata[ST
 		desiredStatus := vmv1beta1.UpdateStatusFailed
 		if reconcile.IsErrorWaitTimeout(err) {
 			desiredStatus = vmv1beta1.UpdateStatusExpanding
+			err = nil
 		}
 		if updateErr := reconcile.UpdateObjectStatus(ctx, c, object, desiredStatus, err); updateErr != nil {
 			resultErr = fmt.Errorf("failed to update object status: %q, origin err: %w", updateErr, err)

--- a/internal/controller/operator/factory/reconcile/deploy.go
+++ b/internal/controller/operator/factory/reconcile/deploy.go
@@ -160,5 +160,7 @@ func reportFirstNotReadyPodOnError(ctx context.Context, rclient client.Client, o
 		}
 		return podStatusesToError(origin, &dp)
 	}
-	return fmt.Errorf("cannot find any pod for selector=%q, check kubernetes events, origin err: %w", selector.String(), origin)
+	return &errWaitReady{
+		origin: fmt.Errorf("cannot find any pod for selector=%q, check kubernetes events, origin err: %w", selector.String(), origin),
+	}
 }

--- a/internal/controller/operator/factory/reconcile/reconcile.go
+++ b/internal/controller/operator/factory/reconcile/reconcile.go
@@ -120,12 +120,11 @@ type errWaitReady struct {
 }
 
 // Error implements errors.Error interface
-func (err *errWaitReady) Error() string {
-	return fmt.Sprintf(": %q",
-		err.origin)
+func (e *errWaitReady) Error() string {
+	return fmt.Sprintf(": %q", e.origin)
 }
 
 // Unwrap implements error.Unwrap interface
-func (err *errWaitReady) Unwrap() error {
-	return err.origin
+func (e *errWaitReady) Unwrap() error {
+	return e.origin
 }

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -90,17 +90,15 @@ func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vlagent.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vlagent.CreateOrUpdate(ctx, instance, r); err != nil {
 			return result, err
 		}
-
 		return result, nil
 	})
-	if err != nil {
-		return
-	}
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -83,14 +83,15 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vlcluster.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vlcluster.CreateOrUpdate(ctx, r, instance); err != nil {
 			return result, fmt.Errorf("failed create or update vlcluster: %w", err)
 		}
-
 		return result, nil
 	})
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -84,14 +84,15 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vlsingle.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vlsingle.CreateOrUpdate(ctx, r, instance); err != nil {
 			return result, fmt.Errorf("failed create or update vlsingle: %w", err)
 		}
-
 		return result, nil
 	})
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -112,17 +112,15 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vmagent.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmagent.CreateOrUpdate(ctx, instance, r); err != nil {
 			return result, err
 		}
-
 		return result, nil
 	})
-	if err != nil {
-		return
-	}
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -93,18 +93,16 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := vmalertmanager.CreateOrUpdateConfig(ctx, r.Client, instance, nil); err != nil {
 			return result, err
 		}
-
 		if err := vmalertmanager.CreateOrUpdateAlertManager(ctx, instance, r); err != nil {
 			return result, err
 		}
-
 		return result, nil
 	})
-	if err != nil {
-		return
+
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	}
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	return
 }
 

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -90,17 +90,15 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vmanomaly.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmanomaly.CreateOrUpdate(ctx, instance, r); err != nil {
 			return result, err
 		}
-
 		return result, nil
 	})
-	if err != nil {
-		return
-	}
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -92,13 +92,12 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		if err := vmauth.CreateOrUpdate(ctx, instance, r); err != nil {
 			return result, fmt.Errorf("cannot create or update vmauth deploy: %w", err)
 		}
-
 		return result, nil
 	})
-	if err != nil {
-		return
+
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	}
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 
 	return
 }

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -73,17 +73,16 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		err = vmcluster.CreateOrUpdate(ctx, instance, r.Client)
-		if err != nil {
+		if err := vmcluster.CreateOrUpdate(ctx, instance, r.Client); err != nil {
 			return result, fmt.Errorf("failed create or update vmcluster: %w", err)
 		}
 		return result, nil
 	})
-	if err != nil {
-		return
+
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	}
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	return
 }
 

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -91,15 +91,15 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vmsingle.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmsingle.CreateOrUpdate(ctx, instance, r); err != nil {
 			return result, fmt.Errorf("failed create or update single: %w", err)
 		}
 		return result, nil
 	})
-	if err != nil {
-		return
+
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 	}
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
 
 	return
 }

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -83,14 +83,15 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vtcluster.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vtcluster.CreateOrUpdate(ctx, r, instance); err != nil {
 			return result, fmt.Errorf("failed create or update vtcluster: %w", err)
 		}
-
 		return result, nil
 	})
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -84,14 +84,15 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err = vtsingle.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vtsingle.CreateOrUpdate(ctx, r, instance); err != nil {
 			return result, fmt.Errorf("failed create or update vtsingle: %w", err)
 		}
-
 		return result, nil
 	})
 
-	result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	if err == nil {
+		result.RequeueAfter = r.BaseConf.ResyncAfterDuration()
+	}
 
 	return
 }


### PR DESCRIPTION
- consistently reconcile across all custom resources
- some controllers do update reconcile result if error is present, which is not allowed
- do not propagate error if it's of type `ErrWaitReady`
- additionally wrap into `ErrWaitReady` error such errors as:
  - `cannot find any pod for selector`
  - `sts wasn't yet removed`