### PR TITLE
upgrade jimmidyson reloader, allow preverve original registry for config reloader if using global registry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ aliases:
 * FEATURE: [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/): added `spec.vlselect.extraStorageNodes` to specify list of additional storage nodes, that are available for select only.
 * FEATURE: [VTCluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): added `spec.vtselect.extraStorageNodes` to specify list of additional storage nodes, that are available for select only.
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): add `scrapeClass` spec definition and `scrapeClassName` reference to the `VMServiceScrape`, `VMPodScrape`, `VMProbe`, `VMScrapeConfig`, `VMStaticScrape` and `VMNodeScrape`. See this issue [#1531](https://github.com/VictoriaMetrics/operator/issues/1531) for details. Thanks to the @endesapt.
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): upgraded jimmidyson/configmap-reload images and added ability for default configreloader images to preserve original registry using `<PREFIX>_PRESERVE_REGISTRY` env variable.
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): properly generate `oauth2` configuration with missing `clientID`. Previously, it could break whole config generation. See this PR [#1563](https://github.com/VictoriaMetrics/operator/pull/1563) for details.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fix an issue where the return value from a couple of controllers was always `nil`. See [#1532](https://github.com/VictoriaMetrics/operator/pull/1532) for details.

--- a/docs/env.md
+++ b/docs/env.md
@@ -45,38 +45,37 @@
 | VM_VTSINGLEDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vtsingledefault-resource-request-cpu" id="variables-vm-vtsingledefault-resource-request-cpu">#</a> |
 | VM_VMALERTDEFAULT_IMAGE: `victoriametrics/vmalert` <a href="#variables-vm-vmalertdefault-image" id="variables-vm-vmalertdefault-image">#</a> |
 | VM_VMALERTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmalertdefault-version" id="variables-vm-vmalertdefault-version">#</a> |
-| VM_VMALERTDEFAULT_CONFIGRELOADIMAGE: `jimmidyson/configmap-reload:v0.3.0` <a href="#variables-vm-vmalertdefault-configreloadimage" id="variables-vm-vmalertdefault-configreloadimage">#</a> |
 | VM_VMALERTDEFAULT_PORT: `8080` <a href="#variables-vm-vmalertdefault-port" id="variables-vm-vmalertdefault-port">#</a> |
 | VM_VMALERTDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmalertdefault-usedefaultresources" id="variables-vm-vmalertdefault-usedefaultresources">#</a> |
 | VM_VMALERTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmalertdefault-resource-limit-mem" id="variables-vm-vmalertdefault-resource-limit-mem">#</a> |
 | VM_VMALERTDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmalertdefault-resource-limit-cpu" id="variables-vm-vmalertdefault-resource-limit-cpu">#</a> |
 | VM_VMALERTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmalertdefault-resource-request-mem" id="variables-vm-vmalertdefault-resource-request-mem">#</a> |
 | VM_VMALERTDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmalertdefault-resource-request-cpu" id="variables-vm-vmalertdefault-resource-request-cpu">#</a> |
+| VM_VMALERTDEFAULT_CONFIGRELOADIMAGE: `ghcr.io/jimmidyson/configmap-reload:v0.15.0` <a href="#variables-vm-vmalertdefault-configreloadimage" id="variables-vm-vmalertdefault-configreloadimage">#</a> |
+| VM_VMALERTDEFAULT_CONFIGRELOADER_PRESERVE_REGISTRY: `true` <a href="#variables-vm-vmalertdefault-configreloader-preserve-registry" id="variables-vm-vmalertdefault-configreloader-preserve-registry">#</a> |
 | VM_VMALERTDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmalertdefault-configreloadercpu" id="variables-vm-vmalertdefault-configreloadercpu">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
 | VM_VMALERTDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmalertdefault-configreloadermemory" id="variables-vm-vmalertdefault-configreloadermemory">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_VMSERVICESCRAPEDEFAULT_ENFORCEENDPOINTSLICES: `false` <a href="#variables-vm-vmservicescrapedefault-enforceendpointslices" id="variables-vm-vmservicescrapedefault-enforceendpointslices">#</a><br>Use endpointslices instead of endpoints as discovery role for vmservicescrape when generate scrape config for vmagent. |
 | VM_VMAGENTDEFAULT_IMAGE: `victoriametrics/vmagent` <a href="#variables-vm-vmagentdefault-image" id="variables-vm-vmagentdefault-image">#</a> |
 | VM_VMAGENTDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmagentdefault-version" id="variables-vm-vmagentdefault-version">#</a> |
-| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmagentdefault-configreloadimage" id="variables-vm-vmagentdefault-configreloadimage">#</a> |
 | VM_VMAGENTDEFAULT_PORT: `8429` <a href="#variables-vm-vmagentdefault-port" id="variables-vm-vmagentdefault-port">#</a> |
 | VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmagentdefault-usedefaultresources" id="variables-vm-vmagentdefault-usedefaultresources">#</a> |
 | VM_VMAGENTDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmagentdefault-resource-limit-mem" id="variables-vm-vmagentdefault-resource-limit-mem">#</a> |
 | VM_VMAGENTDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmagentdefault-resource-limit-cpu" id="variables-vm-vmagentdefault-resource-limit-cpu">#</a> |
 | VM_VMAGENTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmagentdefault-resource-request-mem" id="variables-vm-vmagentdefault-resource-request-mem">#</a> |
 | VM_VMAGENTDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmagentdefault-resource-request-cpu" id="variables-vm-vmagentdefault-resource-request-cpu">#</a> |
-| VM_VMAGENTDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmagentdefault-configreloadercpu" id="variables-vm-vmagentdefault-configreloadercpu">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMAGENTDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmagentdefault-configreloadermemory" id="variables-vm-vmagentdefault-configreloadermemory">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
+| VM_VMAGENTDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmagentdefault-configreloadimage" id="variables-vm-vmagentdefault-configreloadimage">#</a> |
+| VM_VMAGENTDEFAULT_CONFIGRELOADER_PRESERVE_REGISTRY: `false` <a href="#variables-vm-vmagentdefault-configreloader-preserve-registry" id="variables-vm-vmagentdefault-configreloader-preserve-registry">#</a> |
+| VM_VMAGENTDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmagentdefault-configreloadercpu" id="variables-vm-vmagentdefault-configreloadercpu">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMAGENTDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmagentdefault-configreloadermemory" id="variables-vm-vmagentdefault-configreloadermemory">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_VMANOMALYDEFAULT_IMAGE: `victoriametrics/vmanomaly` <a href="#variables-vm-vmanomalydefault-image" id="variables-vm-vmanomalydefault-image">#</a> |
 | VM_VMANOMALYDEFAULT_VERSION: `${VM_ANOMALY_VERSION}` <a href="#variables-vm-vmanomalydefault-version" id="variables-vm-vmanomalydefault-version">#</a> |
-| VM_VMANOMALYDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmanomalydefault-configreloadimage" id="variables-vm-vmanomalydefault-configreloadimage">#</a> |
 | VM_VMANOMALYDEFAULT_PORT: `8490` <a href="#variables-vm-vmanomalydefault-port" id="variables-vm-vmanomalydefault-port">#</a> |
 | VM_VMANOMALYDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmanomalydefault-usedefaultresources" id="variables-vm-vmanomalydefault-usedefaultresources">#</a> |
 | VM_VMANOMALYDEFAULT_RESOURCE_LIMIT_MEM: `500Mi` <a href="#variables-vm-vmanomalydefault-resource-limit-mem" id="variables-vm-vmanomalydefault-resource-limit-mem">#</a> |
 | VM_VMANOMALYDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmanomalydefault-resource-limit-cpu" id="variables-vm-vmanomalydefault-resource-limit-cpu">#</a> |
 | VM_VMANOMALYDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmanomalydefault-resource-request-mem" id="variables-vm-vmanomalydefault-resource-request-mem">#</a> |
 | VM_VMANOMALYDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmanomalydefault-resource-request-cpu" id="variables-vm-vmanomalydefault-resource-request-cpu">#</a> |
-| VM_VMANOMALYDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmanomalydefault-configreloadercpu" id="variables-vm-vmanomalydefault-configreloadercpu">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMANOMALYDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmanomalydefault-configreloadermemory" id="variables-vm-vmanomalydefault-configreloadermemory">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_VMSINGLEDEFAULT_IMAGE: `victoriametrics/victoria-metrics` <a href="#variables-vm-vmsingledefault-image" id="variables-vm-vmsingledefault-image">#</a> |
 | VM_VMSINGLEDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmsingledefault-version" id="variables-vm-vmsingledefault-version">#</a> |
 | VM_VMSINGLEDEFAULT_PORT: `8429` <a href="#variables-vm-vmsingledefault-port" id="variables-vm-vmsingledefault-port">#</a> |
@@ -109,9 +108,6 @@
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_LIMIT_CPU: `500m` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu" id="variables-vm-vmclusterdefault-vminsertdefault-resource-limit-cpu">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_MEM: `200Mi` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-request-mem" id="variables-vm-vmclusterdefault-vminsertdefault-resource-request-mem">#</a> |
 | VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmclusterdefault-vminsertdefault-resource-request-cpu" id="variables-vm-vmclusterdefault-vminsertdefault-resource-request-cpu">#</a> |
-| VM_VMALERTMANAGER_CONFIGRELOADERIMAGE: `jimmidyson/configmap-reload:v0.3.0` <a href="#variables-vm-vmalertmanager-configreloaderimage" id="variables-vm-vmalertmanager-configreloaderimage">#</a> |
-| VM_VMALERTMANAGER_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmalertmanager-configreloadercpu" id="variables-vm-vmalertmanager-configreloadercpu">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
-| VM_VMALERTMANAGER_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmalertmanager-configreloadermemory" id="variables-vm-vmalertmanager-configreloadermemory">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE: `prom/alertmanager` <a href="#variables-vm-vmalertmanager-alertmanagerdefaultbaseimage" id="variables-vm-vmalertmanager-alertmanagerdefaultbaseimage">#</a> |
 | VM_VMALERTMANAGER_ALERTMANAGERVERSION: `v0.28.1` <a href="#variables-vm-vmalertmanager-alertmanagerversion" id="variables-vm-vmalertmanager-alertmanagerversion">#</a> |
 | VM_VMALERTMANAGER_LOCALHOST: `127.0.0.1` <a href="#variables-vm-vmalertmanager-localhost" id="variables-vm-vmalertmanager-localhost">#</a> |
@@ -120,6 +116,10 @@
 | VM_VMALERTMANAGER_RESOURCE_LIMIT_CPU: `100m` <a href="#variables-vm-vmalertmanager-resource-limit-cpu" id="variables-vm-vmalertmanager-resource-limit-cpu">#</a> |
 | VM_VMALERTMANAGER_RESOURCE_REQUEST_MEM: `56Mi` <a href="#variables-vm-vmalertmanager-resource-request-mem" id="variables-vm-vmalertmanager-resource-request-mem">#</a> |
 | VM_VMALERTMANAGER_RESOURCE_REQUEST_CPU: `30m` <a href="#variables-vm-vmalertmanager-resource-request-cpu" id="variables-vm-vmalertmanager-resource-request-cpu">#</a> |
+| VM_VMALERTMANAGER_CONFIGRELOADIMAGE: `ghcr.io/jimmidyson/configmap-reload:v0.15.0` <a href="#variables-vm-vmalertmanager-configreloadimage" id="variables-vm-vmalertmanager-configreloadimage">#</a> |
+| VM_VMALERTMANAGER_CONFIGRELOADER_PRESERVE_REGISTRY: `true` <a href="#variables-vm-vmalertmanager-configreloader-preserve-registry" id="variables-vm-vmalertmanager-configreloader-preserve-registry">#</a> |
+| VM_VMALERTMANAGER_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmalertmanager-configreloadercpu" id="variables-vm-vmalertmanager-configreloadercpu">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
+| VM_VMALERTMANAGER_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmalertmanager-configreloadermemory" id="variables-vm-vmalertmanager-configreloadermemory">#</a><br>Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_DISABLESELFSERVICESCRAPECREATION: `false` <a href="#variables-vm-disableselfservicescrapecreation" id="variables-vm-disableselfservicescrapecreation">#</a> |
 | VM_VMBACKUP_IMAGE: `victoriametrics/vmbackupmanager` <a href="#variables-vm-vmbackup-image" id="variables-vm-vmbackup-image">#</a> |
 | VM_VMBACKUP_VERSION: `${VM_METRICS_VERSION}-enterprise` <a href="#variables-vm-vmbackup-version" id="variables-vm-vmbackup-version">#</a> |
@@ -131,13 +131,14 @@
 | VM_VMBACKUP_RESOURCE_REQUEST_CPU: `150m` <a href="#variables-vm-vmbackup-resource-request-cpu" id="variables-vm-vmbackup-resource-request-cpu">#</a> |
 | VM_VMAUTHDEFAULT_IMAGE: `victoriametrics/vmauth` <a href="#variables-vm-vmauthdefault-image" id="variables-vm-vmauthdefault-image">#</a> |
 | VM_VMAUTHDEFAULT_VERSION: `${VM_METRICS_VERSION}` <a href="#variables-vm-vmauthdefault-version" id="variables-vm-vmauthdefault-version">#</a> |
-| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmauthdefault-configreloadimage" id="variables-vm-vmauthdefault-configreloadimage">#</a> |
 | VM_VMAUTHDEFAULT_PORT: `8427` <a href="#variables-vm-vmauthdefault-port" id="variables-vm-vmauthdefault-port">#</a> |
 | VM_VMAUTHDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vmauthdefault-usedefaultresources" id="variables-vm-vmauthdefault-usedefaultresources">#</a> |
 | VM_VMAUTHDEFAULT_RESOURCE_LIMIT_MEM: `300Mi` <a href="#variables-vm-vmauthdefault-resource-limit-mem" id="variables-vm-vmauthdefault-resource-limit-mem">#</a> |
 | VM_VMAUTHDEFAULT_RESOURCE_LIMIT_CPU: `200m` <a href="#variables-vm-vmauthdefault-resource-limit-cpu" id="variables-vm-vmauthdefault-resource-limit-cpu">#</a> |
 | VM_VMAUTHDEFAULT_RESOURCE_REQUEST_MEM: `100Mi` <a href="#variables-vm-vmauthdefault-resource-request-mem" id="variables-vm-vmauthdefault-resource-request-mem">#</a> |
 | VM_VMAUTHDEFAULT_RESOURCE_REQUEST_CPU: `50m` <a href="#variables-vm-vmauthdefault-resource-request-cpu" id="variables-vm-vmauthdefault-resource-request-cpu">#</a> |
+| VM_VMAUTHDEFAULT_CONFIGRELOADIMAGE: `quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1` <a href="#variables-vm-vmauthdefault-configreloadimage" id="variables-vm-vmauthdefault-configreloadimage">#</a> |
+| VM_VMAUTHDEFAULT_CONFIGRELOADER_PRESERVE_REGISTRY: `false` <a href="#variables-vm-vmauthdefault-configreloader-preserve-registry" id="variables-vm-vmauthdefault-configreloader-preserve-registry">#</a> |
 | VM_VMAUTHDEFAULT_CONFIGRELOADERCPU: `10m` <a href="#variables-vm-vmauthdefault-configreloadercpu" id="variables-vm-vmauthdefault-configreloadercpu">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead |
 | VM_VMAUTHDEFAULT_CONFIGRELOADERMEMORY: `25Mi` <a href="#variables-vm-vmauthdefault-configreloadermemory" id="variables-vm-vmauthdefault-configreloadermemory">#</a><br>Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead |
 | VM_VLCLUSTERDEFAULT_USEDEFAULTRESOURCES: `true` <a href="#variables-vm-vlclusterdefault-usedefaultresources" id="variables-vm-vlclusterdefault-usedefaultresources">#</a> |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,21 +67,24 @@ var WatchNamespaceEnvVar = "WATCH_NAMESPACE"
 type ApplicationDefaults struct {
 	Image               string
 	Version             string
-	ConfigReloadImage   string
 	Port                string
 	UseDefaultResources bool
 	Resource            struct {
 		Limit struct {
 			Mem string
-			Cpu string
+			CPU string
 		}
 		Request struct {
 			Mem string
-			Cpu string
+			CPU string
 		}
 	}
-	ConfigReloaderCPU    string
-	ConfigReloaderMemory string
+	ConfigReloader struct {
+		Image            string
+		PreserveRegistry bool
+		CPU              string
+		Mem              string
+	}
 }
 
 // Resource is useful for generic resource building
@@ -89,11 +92,11 @@ type ApplicationDefaults struct {
 type Resource struct {
 	Limit struct {
 		Mem string
-		Cpu string
+		CPU string
 	}
 	Request struct {
 		Mem string
-		Cpu string
+		CPU string
 	}
 }
 
@@ -128,103 +131,118 @@ type BaseOperatorConf struct {
 	VLogsDefault struct {
 		Image               string `default:"victoriametrics/victoria-logs"`
 		Version             string `env:",expand" default:"${VM_LOGS_VERSION}"`
-		ConfigReloadImage   string `env:"-"`
 		Port                string `default:"9428"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"1500Mi"`
-				Cpu string `default:"1200m"`
+				CPU string `default:"1200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"150m"`
+				CPU string `default:"150m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		ConfigReloaderCPU    string `env:"-"`
-		ConfigReloaderMemory string `env:"-"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VLOGSDEFAULT_"`
 
 	VLAgentDefault struct {
 		Image               string `default:"victoriametrics/vlagent"`
 		Version             string `env:",expand" default:"${VM_LOGS_VERSION}"`
-		ConfigReloadImage   string `env:"-"`
 		Port                string `default:"9429"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"200m"`
+				CPU string `default:"200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"200Mi"`
-				Cpu string `default:"50m"`
+				CPU string `default:"50m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		ConfigReloaderCPU    string `env:"-"`
-		ConfigReloaderMemory string `env:"-"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VLAGENTDEFAULT_"`
 
 	VLSingleDefault struct {
 		Image               string `default:"victoriametrics/victoria-logs"`
 		Version             string `env:",expand" default:"${VM_LOGS_VERSION}"`
-		ConfigReloadImage   string `env:"-"`
 		Port                string `default:"9428"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"1500Mi"`
-				Cpu string `default:"1200m"`
+				CPU string `default:"1200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"150m"`
+				CPU string `default:"150m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		ConfigReloaderCPU    string `env:"-"`
-		ConfigReloaderMemory string `env:"-"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VLSINGLEDEFAULT_"`
 
 	VTSingleDefault struct {
 		Image               string `default:"victoriametrics/victoria-traces"`
 		Version             string `env:",expand" default:"${VM_TRACES_VERSION}"`
-		ConfigReloadImage   string `env:"-"`
 		Port                string `default:"10428"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"1500Mi"`
-				Cpu string `default:"1200m"`
+				CPU string `default:"1200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"150m"`
+				CPU string `default:"150m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		ConfigReloaderCPU    string `env:"-"`
-		ConfigReloaderMemory string `env:"-"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VTSINGLEDEFAULT_"`
 
 	VMAlertDefault struct {
 		Image               string `default:"victoriametrics/vmalert"`
 		Version             string `env:",expand" default:"${VM_METRICS_VERSION}"`
-		ConfigReloadImage   string `default:"jimmidyson/configmap-reload:v0.3.0" env:"CONFIGRELOADIMAGE"`
 		Port                string `default:"8080"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"200m"`
+				CPU string `default:"200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"200Mi"`
-				Cpu string `default:"50m"`
+				CPU string `default:"50m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead
-		ConfigReloaderCPU string `default:"10m" env:"CONFIGRELOADERCPU"`
-		// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
-		ConfigReloaderMemory string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		ConfigReloader struct {
+			Image            string `default:"ghcr.io/jimmidyson/configmap-reload:v0.15.0" env:"CONFIGRELOADIMAGE"`
+			PreserveRegistry bool   `default:"true" env:"CONFIGRELOADER_PRESERVE_REGISTRY"`
+			// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead
+			CPU string `default:"10m" env:"CONFIGRELOADERCPU"`
+			// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
+			Mem string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		} `prefix:""`
 	} `prefix:"VMALERTDEFAULT_"`
 
 	VMServiceScrapeDefault struct {
@@ -236,65 +254,72 @@ type BaseOperatorConf struct {
 	VMAgentDefault struct {
 		Image               string `default:"victoriametrics/vmagent"`
 		Version             string `env:",expand" default:"${VM_METRICS_VERSION}"`
-		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1" env:"CONFIGRELOADIMAGE"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"200m"`
+				CPU string `default:"200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"200Mi"`
-				Cpu string `default:"50m"`
+				CPU string `default:"50m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead
-		ConfigReloaderCPU string `default:"10m" env:"CONFIGRELOADERCPU"`
-		// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
-		ConfigReloaderMemory string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		ConfigReloader struct {
+			Image            string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1" env:"CONFIGRELOADIMAGE"`
+			PreserveRegistry bool   `default:"false" env:"CONFIGRELOADER_PRESERVE_REGISTRY"`
+			// Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead
+			CPU string `default:"10m" env:"CONFIGRELOADERCPU"`
+			// Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
+			Mem string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		} `prefix:""`
 	} `prefix:"VMAGENTDEFAULT_"`
 
 	VMAnomalyDefault struct {
 		Image               string `default:"victoriametrics/vmanomaly"`
 		Version             string `env:",expand" default:"${VM_ANOMALY_VERSION}"`
-		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1" env:"CONFIGRELOADIMAGE"`
 		Port                string `default:"8490"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"200m"`
+				CPU string `default:"200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"200Mi"`
-				Cpu string `default:"50m"`
+				CPU string `default:"50m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead
-		ConfigReloaderCPU string `default:"10m" env:"CONFIGRELOADERCPU"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
-		ConfigReloaderMemory string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VMANOMALYDEFAULT_"`
 
 	VMSingleDefault struct {
 		Image               string `default:"victoriametrics/victoria-metrics"`
 		Version             string `env:",expand" default:"${VM_METRICS_VERSION}"`
-		ConfigReloadImage   string `env:"-"`
 		Port                string `default:"8429"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"1500Mi"`
-				Cpu string `default:"1200m"`
+				CPU string `default:"1200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"150m"`
+				CPU string `default:"150m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		ConfigReloaderCPU    string `env:"-"`
-		ConfigReloaderMemory string `env:"-"`
+		ConfigReloader struct {
+			Image            string `env:"-"`
+			PreserveRegistry bool   `env:"-"`
+			CPU              string `env:"-"`
+			Mem              string `env:"-"`
+		}
 	} `prefix:"VMSINGLEDEFAULT_"`
 
 	VMClusterDefault struct {
@@ -306,11 +331,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"1000Mi"`
-					Cpu string `default:"500m"`
+					CPU string `default:"500m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"500Mi"`
-					Cpu string `default:"100m"`
+					CPU string `default:"100m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VMSELECTDEFAULT_"`
@@ -323,11 +348,11 @@ type BaseOperatorConf struct {
 			Resource     struct {
 				Limit struct {
 					Mem string `default:"1500Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"500Mi"`
-					Cpu string `default:"250m"`
+					CPU string `default:"250m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VMSTORAGEDEFAULT_"`
@@ -338,22 +363,17 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"500Mi"`
-					Cpu string `default:"500m"`
+					CPU string `default:"500m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"200Mi"`
-					Cpu string `default:"150m"`
+					CPU string `default:"150m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VMINSERTDEFAULT_"`
 	} `prefix:"VMCLUSTERDEFAULT_"`
 
 	VMAlertManager struct {
-		ConfigReloaderImage string `default:"jimmidyson/configmap-reload:v0.3.0" env:"CONFIGRELOADERIMAGE"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead
-		ConfigReloaderCPU string `default:"10m" env:"CONFIGRELOADERCPU"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
-		ConfigReloaderMemory         string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
 		AlertmanagerDefaultBaseImage string `default:"prom/alertmanager" env:"ALERTMANAGERDEFAULTBASEIMAGE"`
 		AlertManagerVersion          string `default:"v0.28.1" env:"ALERTMANAGERVERSION"`
 		LocalHost                    string `default:"127.0.0.1" env:"LOCALHOST"`
@@ -361,13 +381,21 @@ type BaseOperatorConf struct {
 		Resource                     struct {
 			Limit struct {
 				Mem string `default:"256Mi"`
-				Cpu string `default:"100m"`
+				CPU string `default:"100m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"56Mi"`
-				Cpu string `default:"30m"`
+				CPU string `default:"30m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
+		ConfigReloader struct {
+			Image            string `default:"ghcr.io/jimmidyson/configmap-reload:v0.15.0" env:"CONFIGRELOADIMAGE"`
+			PreserveRegistry bool   `default:"true" env:"CONFIGRELOADER_PRESERVE_REGISTRY"`
+			// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_CPU instead
+			CPU string `default:"10m" env:"CONFIGRELOADERCPU"`
+			// Deprecated:: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
+			Mem string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		} `prefix:""`
 	} `prefix:"VMALERTMANAGER_"`
 
 	DisableSelfServiceScrapeCreation bool `default:"false" env:"DISABLESELFSERVICESCRAPECREATION"`
@@ -379,34 +407,37 @@ type BaseOperatorConf struct {
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"500Mi"`
-				Cpu string `default:"500m"`
+				CPU string `default:"500m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"200Mi"`
-				Cpu string `default:"150m"`
+				CPU string `default:"150m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
 	} `prefix:"VMBACKUP_"`
 	VMAuthDefault struct {
 		Image               string `default:"victoriametrics/vmauth"`
 		Version             string `env:",expand" default:"${VM_METRICS_VERSION}"`
-		ConfigReloadImage   string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1" env:"CONFIGRELOADIMAGE"`
 		Port                string `default:"8427"`
 		UseDefaultResources bool   `default:"true" env:"USEDEFAULTRESOURCES"`
 		Resource            struct {
 			Limit struct {
 				Mem string `default:"300Mi"`
-				Cpu string `default:"200m"`
+				CPU string `default:"200m"`
 			} `prefix:"LIMIT_"`
 			Request struct {
 				Mem string `default:"100Mi"`
-				Cpu string `default:"50m"`
+				CPU string `default:"50m"`
 			} `prefix:"REQUEST_"`
 		} `prefix:"RESOURCE_"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead
-		ConfigReloaderCPU string `default:"10m" env:"CONFIGRELOADERCPU"`
-		// Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
-		ConfigReloaderMemory string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		ConfigReloader struct {
+			Image            string `default:"quay.io/prometheus-operator/prometheus-config-reloader:v0.82.1" env:"CONFIGRELOADIMAGE"`
+			PreserveRegistry bool   `default:"false" env:"CONFIGRELOADER_PRESERVE_REGISTRY"`
+			// Deprecated: use VM_CONFIG_RELOADER_REQUEST_CPU instead
+			CPU string `default:"10m" env:"CONFIGRELOADERCPU"`
+			// Deprecated: use VM_CONFIG_RELOADER_REQUEST_MEMORY instead
+			Mem string `default:"25Mi" env:"CONFIGRELOADERMEMORY"`
+		} `prefix:""`
 	} `prefix:"VMAUTHDEFAULT_"`
 
 	VLClusterDefault struct {
@@ -418,11 +449,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"1024Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"256Mi"`
-					Cpu string `default:"100m"`
+					CPU string `default:"100m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VLSELECTDEFAULT_"`
@@ -433,11 +464,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"2048Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"512Mi"`
-					Cpu string `default:"200m"`
+					CPU string `default:"200m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VLSTORAGEDEFAULT_"`
@@ -448,11 +479,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"1024Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"256Mi"`
-					Cpu string `default:"100m"`
+					CPU string `default:"100m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"VLINSERTDEFAULT_"`
@@ -467,11 +498,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"1024Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"256Mi"`
-					Cpu string `default:"100m"`
+					CPU string `default:"100m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"SELECT_"`
@@ -482,11 +513,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"2048Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"512Mi"`
-					Cpu string `default:"200m"`
+					CPU string `default:"200m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"STORAGE_"`
@@ -497,11 +528,11 @@ type BaseOperatorConf struct {
 			Resource struct {
 				Limit struct {
 					Mem string `default:"1024Mi"`
-					Cpu string `default:"1000m"`
+					CPU string `default:"1000m"`
 				} `prefix:"LIMIT_"`
 				Request struct {
 					Mem string `default:"256Mi"`
-					Cpu string `default:"100m"`
+					CPU string `default:"100m"`
 				} `prefix:"REQUEST_"`
 			} `prefix:"RESOURCE_"`
 		} `prefix:"INSERT_"`
@@ -612,8 +643,8 @@ func (boc BaseOperatorConf) Validate() error {
 				return fmt.Errorf("cannot parse resource request memory for %q, err :%w", name, err)
 			}
 		}
-		if res.Request.Cpu != UnLimitedResource {
-			if _, err := resource.ParseQuantity(res.Request.Cpu); err != nil {
+		if res.Request.CPU != UnLimitedResource {
+			if _, err := resource.ParseQuantity(res.Request.CPU); err != nil {
 				return fmt.Errorf("cannot parse resource request cpu for %q, err :%w", name, err)
 			}
 		}
@@ -622,8 +653,8 @@ func (boc BaseOperatorConf) Validate() error {
 				return fmt.Errorf("cannot parse resource limit memory for %q, err :%w", name, err)
 			}
 		}
-		if res.Limit.Cpu != UnLimitedResource {
-			if _, err := resource.ParseQuantity(res.Limit.Cpu); err != nil {
+		if res.Limit.CPU != UnLimitedResource {
+			if _, err := resource.ParseQuantity(res.Limit.CPU); err != nil {
 				return fmt.Errorf("cannot parse resource limit cpu for %q, err :%w", name, err)
 			}
 		}

--- a/internal/controller/operator/factory/build/container.go
+++ b/internal/controller/operator/factory/build/container.go
@@ -134,11 +134,11 @@ func Resources(crdResources corev1.ResourceRequirements, defaultResources config
 	}
 
 	if !cpuResourceIsSet && useDefault {
-		if defaultResources.Request.Cpu != config.UnLimitedResource {
-			crdResources.Requests[corev1.ResourceCPU] = resource.MustParse(defaultResources.Request.Cpu)
+		if defaultResources.Request.CPU != config.UnLimitedResource {
+			crdResources.Requests[corev1.ResourceCPU] = resource.MustParse(defaultResources.Request.CPU)
 		}
-		if defaultResources.Limit.Cpu != config.UnLimitedResource {
-			crdResources.Limits[corev1.ResourceCPU] = resource.MustParse(defaultResources.Limit.Cpu)
+		if defaultResources.Limit.CPU != config.UnLimitedResource {
+			crdResources.Limits[corev1.ResourceCPU] = resource.MustParse(defaultResources.Limit.CPU)
 		}
 	}
 	if !memResourceIsSet && useDefault {
@@ -209,10 +209,12 @@ func formatContainerImage(globalRepo string, containerImage string) string {
 		globalRepo += "/"
 	}
 	// operator has built-in images hosted at quay, check for it.
-	if !strings.HasPrefix(containerImage, "quay.io/") {
-		return globalRepo + containerImage
+	for _, registry := range []string{"docker.io/", "quay.io/", "ghcr.io/"} {
+		if strings.HasPrefix(containerImage, registry) {
+			return globalRepo + containerImage[len(registry):]
+		}
 	}
-	return globalRepo + containerImage[len("quay.io/"):]
+	return globalRepo + containerImage
 }
 
 // AppendInsertPorts conditionally adds ingestPorts to the given ports slice


### PR DESCRIPTION
- upgraded jimmidyson config reloader, new versions are present on ghcr.io
- jimmidyson has no correspondent image on quay.io, which causes errors for alertmanager e2e tests. added preserveregistry config reloader option to preserve original registry if global one is set