### PR TITLE
Revert "use existing github action for runner cleanup"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,10 +36,20 @@ jobs:
       security-events: write
       checks: write
     steps:
-      - uses: mathio/gha-cleanup@v1
-        with:
-          remove-browsers: true
-          verbose: true
+      - name: Free space
+        run: |
+          # cleanup up space to free additional ~20GiB of memory
+          # which are lacking for multiplaform images build
+          formatByteCount() { echo $(numfmt --to=iec-i --suffix=B --padding=7 $1'000'); }
+          getAvailableSpace() { echo $(df -a $1 | awk 'NR > 1 {avail+=$4} END {print avail}'); }
+          BEFORE=$(getAvailableSpace)
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          AFTER=$(getAvailableSpace)
+          SAVED=$((AFTER-BEFORE))
+          echo "Saved $(formatByteCount $SAVED)"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Restore binaries from cache


### PR DESCRIPTION
 New github action takes x3 more time - previous action took ~4 minutes, new one up to 16 minutes. It's significantly slowly. 

Reverts VictoriaMetrics/operator#1565

