### PR TITLE
reconcile: properly check deployment and statefulset ready status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 
 **Release date:** 30 October 2025
 
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): properly check `StatefulSet` ready status for `rollingUpdateStrategy: RollingUpdate`. See this issue [#1579](https://github.com/VictoriaMetrics/operator/issues/1579) for details.
 * BUGFIX: [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/): fix `-storageNode` argument generation for vlinsert. Bug was introduced in [ff722eb](https://github.com/VictoriaMetrics/operator/commit/ff722eb3ba4e72765548b4353b5f370b42d143f7).
 
 ## [v0.64.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.64.0)

--- a/internal/controller/operator/factory/reconcile/deploy.go
+++ b/internal/controller/operator/factory/reconcile/deploy.go
@@ -102,7 +102,10 @@ func waitDeploymentReady(ctx context.Context, rclient client.Client, dep *appsv1
 		// (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment)
 		// this function uses the deployment readiness detection algorithm from `kubectl rollout status` command
 		// (https://github.com/kubernetes/kubectl/blob/6e4fe32a45fdcbf61e5c30ebdc511d75e7242432/pkg/polymorphichelpers/rollout_status.go#L76)
-		if actualDeploy.Generation > actualDeploy.Status.ObservedGeneration {
+		if actualDeploy.Generation > actualDeploy.Status.ObservedGeneration ||
+			// special case to prevent possible race condition between updated object and local cache
+			// See this issue https://github.com/VictoriaMetrics/operator/issues/1579
+			dep.Generation > actualDeploy.Generation {
 			// Waiting for deployment spec update to be observed by controller...
 			return false, nil
 		}


### PR DESCRIPTION
 Previously, due to race condition between local client cache and actual
 Kubernetes api-server, operator may incorrectly track ready status for
 Deployment and StatefulSet.

 client.Update(object) call increments `Generation` field of the update
object if there was any change. While, client.Get(object) may not yet have this change.

 So this commit explicitly checks if updateObject.Generation is greater
 than getObject.Generation, to prevent such case.

Fixes https://github.com/VictoriaMetrics/operator/issues/1579