### PR TITLE
unify vm/vt/vl cluster interface

### DIFF
--- a/api/operator/v1/vlcluster_types.go
+++ b/api/operator/v1/vlcluster_types.go
@@ -603,28 +603,28 @@ func (cr *VLCluster) GetVMAuthLBName() string {
 	return fmt.Sprintf("vlclusterlb-%s", cr.Name)
 }
 
-// GetVLSelectLBName returns headless proxy service name for select component
-func (cr *VLCluster) GetVLSelectLBName() string {
+// GetSelectLBName returns headless proxy service name for select component
+func (cr *VLCluster) GetSelectLBName() string {
 	return prefixedName(cr.Name, "vlselectint")
 }
 
-// GetVLInsertLBName returns headless proxy service name for insert component
-func (cr *VLCluster) GetVLInsertLBName() string {
+// GetInsertLBName returns headless proxy service name for insert component
+func (cr *VLCluster) GetInsertLBName() string {
 	return prefixedName(cr.Name, "vlinsertint")
 }
 
-// GetVLInsertName returns insert component name
-func (cr *VLCluster) GetVLInsertName() string {
+// GetInsertName returns insert component name
+func (cr *VLCluster) GetInsertName() string {
 	return prefixedName(cr.Name, "vlinsert")
 }
 
 // GetLVSelectName returns select component name
-func (cr *VLCluster) GetVLSelectName() string {
+func (cr *VLCluster) GetSelectName() string {
 	return prefixedName(cr.Name, "vlselect")
 }
 
-// GetVLStorageName returns select component name
-func (cr *VLCluster) GetVLStorageName() string {
+// GetStorageName returns select component name
+func (cr *VLCluster) GetStorageName() string {
 	return prefixedName(cr.Name, "vlstorage")
 }
 
@@ -635,8 +635,8 @@ func (cr *VLCluster) Validate() error {
 	}
 	if cr.Spec.VLSelect != nil {
 		vms := cr.Spec.VLSelect
-		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetVLSelectName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVLSelectName())
+		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetSelectName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetSelectName())
 		}
 		if vms.HPA != nil {
 			if err := vms.HPA.Validate(); err != nil {
@@ -646,8 +646,8 @@ func (cr *VLCluster) Validate() error {
 	}
 	if cr.Spec.VLInsert != nil {
 		vli := cr.Spec.VLInsert
-		if vli.ServiceSpec != nil && vli.ServiceSpec.Name == cr.GetVLInsertName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVLInsertName())
+		if vli.ServiceSpec != nil && vli.ServiceSpec.Name == cr.GetInsertName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetInsertName())
 		}
 		if vli.HPA != nil {
 			if err := vli.HPA.Validate(); err != nil {
@@ -657,8 +657,8 @@ func (cr *VLCluster) Validate() error {
 	}
 	if cr.Spec.VLStorage != nil {
 		vls := cr.Spec.VLStorage
-		if vls.ServiceSpec != nil && vls.ServiceSpec.Name == cr.GetVLStorageName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVLStorageName())
+		if vls.ServiceSpec != nil && vls.ServiceSpec.Name == cr.GetStorageName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetStorageName())
 		}
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled {
@@ -671,8 +671,8 @@ func (cr *VLCluster) Validate() error {
 	return nil
 }
 
-// VLSelectSelectorLabels returns selector labels for select cluster component
-func (cr *VLCluster) VLSelectSelectorLabels() map[string]string {
+// GetSelectSelectorLabels returns selector labels for select cluster component
+func (cr *VLCluster) GetSelectSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vlselect",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -681,17 +681,17 @@ func (cr *VLCluster) VLSelectSelectorLabels() map[string]string {
 	}
 }
 
-// VLSelectPodLabels returns pod labels for select cluster component
-func (cr *VLCluster) VLSelectPodLabels() map[string]string {
-	selectorLabels := cr.VLSelectSelectorLabels()
+// GetSelectPodLabels returns pod labels for select cluster component
+func (cr *VLCluster) GetSelectPodLabels() map[string]string {
+	selectorLabels := cr.GetSelectSelectorLabels()
 	if cr.Spec.VLSelect == nil || cr.Spec.VLSelect.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.VLSelect.PodMetadata.Labels, selectorLabels)
 }
 
-// VLInsertSelectorLabels returns selector labels for insert cluster component
-func (cr *VLCluster) VLInsertSelectorLabels() map[string]string {
+// GetInsertSelectorLabels returns selector labels for insert cluster component
+func (cr *VLCluster) GetInsertSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vlinsert",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -700,17 +700,17 @@ func (cr *VLCluster) VLInsertSelectorLabels() map[string]string {
 	}
 }
 
-// VLInsertPodLabels returns pod labels for vlinsert cluster component
-func (cr *VLCluster) VLInsertPodLabels() map[string]string {
-	selectorLabels := cr.VLInsertSelectorLabels()
+// GetInsertPodLabels returns pod labels for vlinsert cluster component
+func (cr *VLCluster) GetInsertPodLabels() map[string]string {
+	selectorLabels := cr.GetInsertSelectorLabels()
 	if cr.Spec.VLInsert == nil || cr.Spec.VLInsert.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.VLInsert.PodMetadata.Labels, selectorLabels)
 }
 
-// VLStorageSelectorLabels returns pod labels for vlstorage cluster component
-func (cr *VLCluster) VLStorageSelectorLabels() map[string]string {
+// GetStorageSelectorLabels returns pod labels for vlstorage cluster component
+func (cr *VLCluster) GetStorageSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vlstorage",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -719,9 +719,9 @@ func (cr *VLCluster) VLStorageSelectorLabels() map[string]string {
 	}
 }
 
-// VLStoragePodLabels returns pod labels for the vmstorage cluster component
-func (cr *VLCluster) VLStoragePodLabels() map[string]string {
-	selectorLabels := cr.VLStorageSelectorLabels()
+// GetStoragePodLabels returns pod labels for the vmstorage cluster component
+func (cr *VLCluster) GetStoragePodLabels() map[string]string {
+	selectorLabels := cr.GetStorageSelectorLabels()
 	if cr.Spec.VLStorage == nil || cr.Spec.VLStorage.PodMetadata == nil {
 		return selectorLabels
 	}
@@ -768,24 +768,24 @@ func (cr *VLCluster) FinalLabels(selectorLabels map[string]string) map[string]st
 	return labels.Merge(cr.Spec.ManagedMetadata.Labels, baseLabels)
 }
 
-// VLSelectPodAnnotations returns pod annotations for select cluster component
-func (cr *VLCluster) VLSelectPodAnnotations() map[string]string {
+// GetSelectPodAnnotations returns pod annotations for select cluster component
+func (cr *VLCluster) GetSelectPodAnnotations() map[string]string {
 	if cr.Spec.VLSelect == nil || cr.Spec.VLSelect.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.VLSelect.PodMetadata.Annotations
 }
 
-// VLInsertPodAnnotations returns pod annotations for insert cluster component
-func (cr *VLCluster) VLInsertPodAnnotations() map[string]string {
+// GetInsertPodAnnotations returns pod annotations for insert cluster component
+func (cr *VLCluster) GetInsertPodAnnotations() map[string]string {
 	if cr.Spec.VLInsert == nil || cr.Spec.VLInsert.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.VLInsert.PodMetadata.Annotations
 }
 
-// VLStoragePodAnnotations returns pod annotations for storage cluster component
-func (cr *VLCluster) VLStoragePodAnnotations() map[string]string {
+// GetStoragePodAnnotations returns pod annotations for storage cluster component
+func (cr *VLCluster) GetStoragePodAnnotations() map[string]string {
 	if cr.Spec.VLStorage == nil || cr.Spec.VLStorage.PodMetadata == nil {
 		return make(map[string]string)
 	}
@@ -867,7 +867,7 @@ func (cr *VLCluster) SelectURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLSelect.ExtraArgs), cr.GetVLSelectName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLSelect.ExtraArgs), cr.GetSelectName(), cr.Namespace, port)
 }
 
 // InsertURL returns url to access VLInsert component
@@ -886,7 +886,7 @@ func (cr *VLCluster) InsertURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLInsert.ExtraArgs), cr.GetVLInsertName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLInsert.ExtraArgs), cr.GetInsertName(), cr.Namespace, port)
 }
 
 // StorageURL returns url to access VLStorage component
@@ -905,7 +905,7 @@ func (cr *VLCluster) StorageURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLStorage.ExtraArgs), cr.GetVLStorageName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.VLStorage.ExtraArgs), cr.GetStorageName(), cr.Namespace, port)
 }
 
 // +kubebuilder:object:root=true

--- a/api/operator/v1/vtcluster_types.go
+++ b/api/operator/v1/vtcluster_types.go
@@ -486,8 +486,8 @@ func (cr *VTCluster) AsOwner() []metav1.OwnerReference {
 	}
 }
 
-// VMAuthLBSelectorLabels defines selector labels for vmauth balancer
-func (cr *VTCluster) VMAuthLBSelectorLabels() map[string]string {
+// GetVMAuthLBSelectorLabels defines selector labels for vmauth balancer
+func (cr *VTCluster) GetVMAuthLBSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vtclusterlb-vmauth-balancer",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -496,17 +496,17 @@ func (cr *VTCluster) VMAuthLBSelectorLabels() map[string]string {
 	}
 }
 
-// VMAuthLBPodLabels returns pod labels for vtclusterlb-vmauth-balancer cluster component
-func (cr *VTCluster) VMAuthLBPodLabels() map[string]string {
-	selectorLabels := cr.VMAuthLBSelectorLabels()
+// GetVMAuthLBPodLabels returns pod labels for vtclusterlb-vmauth-balancer cluster component
+func (cr *VTCluster) GetVMAuthLBPodLabels() map[string]string {
+	selectorLabels := cr.GetVMAuthLBSelectorLabels()
 	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.RequestsLoadBalancer.Spec.PodMetadata.Labels, selectorLabels)
 }
 
-// VMAuthLBPodAnnotations returns pod annotations for vmstorage cluster component
-func (cr *VTCluster) VMAuthLBPodAnnotations() map[string]string {
+// GetVMAuthLBPodAnnotations returns pod annotations for vmstorage cluster component
+func (cr *VTCluster) GetVMAuthLBPodAnnotations() map[string]string {
 	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
 		return make(map[string]string)
 	}
@@ -518,28 +518,28 @@ func (cr *VTCluster) GetVMAuthLBName() string {
 	return fmt.Sprintf("vtclusterlb-%s", cr.Name)
 }
 
-// GetVTSelectLBName returns headless proxy service name for select component
-func (cr *VTCluster) GetVTSelectLBName() string {
+// GetSelectLBName returns headless proxy service name for select component
+func (cr *VTCluster) GetSelectLBName() string {
 	return prefixedName(cr.Name, "vtselectint")
 }
 
-// GetVTInsertLBName returns headless proxy service name for insert component
-func (cr *VTCluster) GetVTInsertLBName() string {
+// GetInsertLBName returns headless proxy service name for insert component
+func (cr *VTCluster) GetInsertLBName() string {
 	return prefixedName(cr.Name, "vtinsertint")
 }
 
-// GetVTInsertName returns insert component name
-func (cr *VTCluster) GetVTInsertName() string {
+// GetInsertName returns insert component name
+func (cr *VTCluster) GetInsertName() string {
 	return prefixedName(cr.Name, "vtinsert")
 }
 
 // GetLVSelectName returns select component name
-func (cr *VTCluster) GetVTSelectName() string {
+func (cr *VTCluster) GetSelectName() string {
 	return prefixedName(cr.Name, "vtselect")
 }
 
-// GetVTStorageName returns select component name
-func (cr *VTCluster) GetVTStorageName() string {
+// GetStorageName returns select component name
+func (cr *VTCluster) GetStorageName() string {
 	return prefixedName(cr.Name, "vtstorage")
 }
 
@@ -550,8 +550,8 @@ func (cr *VTCluster) Validate() error {
 	}
 	if cr.Spec.Select != nil {
 		vms := cr.Spec.Select
-		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetVTSelectName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVTSelectName())
+		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetSelectName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetSelectName())
 		}
 		if vms.HPA != nil {
 			if err := vms.HPA.Validate(); err != nil {
@@ -561,8 +561,8 @@ func (cr *VTCluster) Validate() error {
 	}
 	if cr.Spec.Insert != nil {
 		vti := cr.Spec.Insert
-		if vti.ServiceSpec != nil && vti.ServiceSpec.Name == cr.GetVTInsertName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVTInsertName())
+		if vti.ServiceSpec != nil && vti.ServiceSpec.Name == cr.GetInsertName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetInsertName())
 		}
 		if vti.HPA != nil {
 			if err := vti.HPA.Validate(); err != nil {
@@ -572,8 +572,8 @@ func (cr *VTCluster) Validate() error {
 	}
 	if cr.Spec.Storage != nil {
 		vts := cr.Spec.Storage
-		if vts.ServiceSpec != nil && vts.ServiceSpec.Name == cr.GetVTStorageName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVTStorageName())
+		if vts.ServiceSpec != nil && vts.ServiceSpec.Name == cr.GetStorageName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetStorageName())
 		}
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled {
@@ -586,8 +586,8 @@ func (cr *VTCluster) Validate() error {
 	return nil
 }
 
-// VTSelectSelectorLabels returns selector labels for select cluster component
-func (cr *VTCluster) VTSelectSelectorLabels() map[string]string {
+// GetSelectSelectorLabels returns selector labels for select cluster component
+func (cr *VTCluster) GetSelectSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vtselect",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -596,17 +596,17 @@ func (cr *VTCluster) VTSelectSelectorLabels() map[string]string {
 	}
 }
 
-// VTSelectPodLabels returns pod labels for select cluster component
-func (cr *VTCluster) VTSelectPodLabels() map[string]string {
-	selectorLabels := cr.VTSelectSelectorLabels()
+// GetSelectPodLabels returns pod labels for select cluster component
+func (cr *VTCluster) GetSelectPodLabels() map[string]string {
+	selectorLabels := cr.GetSelectSelectorLabels()
 	if cr.Spec.Select == nil || cr.Spec.Select.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.Select.PodMetadata.Labels, selectorLabels)
 }
 
-// VTInsertSelectorLabels returns selector labels for insert cluster component
-func (cr *VTCluster) VTInsertSelectorLabels() map[string]string {
+// GetInsertSelectorLabels returns selector labels for insert cluster component
+func (cr *VTCluster) GetInsertSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vtinsert",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -615,17 +615,17 @@ func (cr *VTCluster) VTInsertSelectorLabels() map[string]string {
 	}
 }
 
-// VTInsertPodLabels returns pod labels for vtinsert cluster component
-func (cr *VTCluster) VTInsertPodLabels() map[string]string {
-	selectorLabels := cr.VTInsertSelectorLabels()
+// GetInsertPodLabels returns pod labels for vtinsert cluster component
+func (cr *VTCluster) GetInsertPodLabels() map[string]string {
+	selectorLabels := cr.GetInsertSelectorLabels()
 	if cr.Spec.Insert == nil || cr.Spec.Insert.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.Insert.PodMetadata.Labels, selectorLabels)
 }
 
-// VTStorageSelectorLabels  returns pod labels for vtstorage cluster component
-func (cr *VTCluster) VTStorageSelectorLabels() map[string]string {
+// GetStorageSelectorLabels  returns pod labels for vtstorage cluster component
+func (cr *VTCluster) GetStorageSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vtstorage",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -634,9 +634,9 @@ func (cr *VTCluster) VTStorageSelectorLabels() map[string]string {
 	}
 }
 
-// VTStoragePodLabels returns pod labels for the vmstorage cluster component
-func (cr *VTCluster) VTStoragePodLabels() map[string]string {
-	selectorLabels := cr.VTStorageSelectorLabels()
+// GetStoragePodLabels returns pod labels for the vmstorage cluster component
+func (cr *VTCluster) GetStoragePodLabels() map[string]string {
+	selectorLabels := cr.GetStorageSelectorLabels()
 	if cr.Spec.Storage == nil || cr.Spec.Storage.PodMetadata == nil {
 		return selectorLabels
 	}
@@ -683,24 +683,24 @@ func (cr *VTCluster) FinalLabels(selectorLabels map[string]string) map[string]st
 	return labels.Merge(cr.Spec.ManagedMetadata.Labels, baseLabels)
 }
 
-// VTSelectPodAnnotations returns pod annotations for select cluster component
-func (cr *VTCluster) VTSelectPodAnnotations() map[string]string {
+// GetSelectPodAnnotations returns pod annotations for select cluster component
+func (cr *VTCluster) GetSelectPodAnnotations() map[string]string {
 	if cr.Spec.Select == nil || cr.Spec.Select.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.Select.PodMetadata.Annotations
 }
 
-// VTInsertPodAnnotations returns pod annotations for insert cluster component
-func (cr *VTCluster) VTInsertPodAnnotations() map[string]string {
+// GetInsertPodAnnotations returns pod annotations for insert cluster component
+func (cr *VTCluster) GetInsertPodAnnotations() map[string]string {
 	if cr.Spec.Insert == nil || cr.Spec.Insert.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.Insert.PodMetadata.Annotations
 }
 
-// VTStoragePodAnnotations returns pod annotations for storage cluster component
-func (cr *VTCluster) VTStoragePodAnnotations() map[string]string {
+// GetStoragePodAnnotations returns pod annotations for storage cluster component
+func (cr *VTCluster) GetStoragePodAnnotations() map[string]string {
 	if cr.Spec.Storage == nil || cr.Spec.Storage.PodMetadata == nil {
 		return make(map[string]string)
 	}
@@ -782,7 +782,7 @@ func (cr *VTCluster) SelectURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Select.ExtraArgs), cr.GetVTSelectName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Select.ExtraArgs), cr.GetSelectName(), cr.Namespace, port)
 }
 
 // InsertURL returns url to access VTInsert component
@@ -801,7 +801,7 @@ func (cr *VTCluster) InsertURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Insert.ExtraArgs), cr.GetVTInsertName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Insert.ExtraArgs), cr.GetInsertName(), cr.Namespace, port)
 }
 
 // StorageURL returns url to access VTStorage component
@@ -820,7 +820,7 @@ func (cr *VTCluster) StorageURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Storage.ExtraArgs), cr.GetVTStorageName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", vmv1beta1.HTTPProtoFromFlags(cr.Spec.Storage.ExtraArgs), cr.GetStorageName(), cr.Namespace, port)
 }
 
 // +kubebuilder:object:root=true

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -85,8 +85,8 @@ type VMClusterSpec struct {
 	ManagedMetadata *ManagedObjectsMetadata `json:"managedMetadata,omitempty"`
 }
 
-// VMAuthLBSelectorLabels defines selector labels for vmauth balancer
-func (cr *VMCluster) VMAuthLBSelectorLabels() map[string]string {
+// GetVMAuthLBSelectorLabels defines selector labels for vmauth balancer
+func (cr *VMCluster) GetVMAuthLBSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vmclusterlb-vmauth-balancer",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -95,17 +95,17 @@ func (cr *VMCluster) VMAuthLBSelectorLabels() map[string]string {
 	}
 }
 
-// VMAuthLBPodLabels returns pod labels for vmclusterlb-vmauth-balancer cluster component
-func (cr *VMCluster) VMAuthLBPodLabels() map[string]string {
-	selectorLabels := cr.VMAuthLBSelectorLabels()
+// GetVMAuthLBPodLabels returns pod labels for vmclusterlb-vmauth-balancer cluster component
+func (cr *VMCluster) GetVMAuthLBPodLabels() map[string]string {
+	selectorLabels := cr.GetVMAuthLBSelectorLabels()
 	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.RequestsLoadBalancer.Spec.PodMetadata.Labels, selectorLabels)
 }
 
-// VMAuthLBPodAnnotations returns pod annotations for vmstorage cluster component
-func (cr *VMCluster) VMAuthLBPodAnnotations() map[string]string {
+// GetVMAuthLBPodAnnotations returns pod annotations for vmstorage cluster component
+func (cr *VMCluster) GetVMAuthLBPodAnnotations() map[string]string {
 	if cr.Spec.RequestsLoadBalancer.Spec.PodMetadata == nil {
 		return make(map[string]string)
 	}
@@ -289,8 +289,8 @@ type VMSelect struct {
 	CommonApplicationDeploymentParams `json:",inline"`
 }
 
-// GetVMSelectLBName returns headless proxy service name for select component
-func (cr *VMCluster) GetVMSelectLBName() string {
+// GetSelectLBName returns headless proxy service name for select component
+func (cr *VMCluster) GetSelectLBName() string {
 	return prefixedName(cr.Name, "vmselectinternal")
 }
 
@@ -359,8 +359,8 @@ type VMInsert struct {
 	CommonApplicationDeploymentParams `json:",inline"`
 }
 
-// GetVMInsertLBName returns headless proxy service name for insert component
-func (cr *VMCluster) GetVMInsertLBName() string {
+// GetInsertLBName returns headless proxy service name for insert component
+func (cr *VMCluster) GetInsertLBName() string {
 	return prefixedName(cr.Name, "vminsertinternal")
 }
 
@@ -384,17 +384,17 @@ func (*VMInsert) ProbeNeedLiveness() bool {
 	return true
 }
 
-// GetVMInsertName returns vminsert component name
-func (cr *VMCluster) GetVMInsertName() string {
+// GetInsertName returns vminsert component name
+func (cr *VMCluster) GetInsertName() string {
 	return prefixedName(cr.Name, "vminsert")
 }
 
 // GetInsertName returns select component name
-func (cr *VMCluster) GetVMSelectName() string {
+func (cr *VMCluster) GetSelectName() string {
 	return prefixedName(cr.Name, "vmselect")
 }
 
-func (cr *VMCluster) GetVMStorageName() string {
+func (cr *VMCluster) GetStorageName() string {
 	return prefixedName(cr.Name, "vmstorage")
 }
 
@@ -603,8 +603,8 @@ func (cr *VMCluster) Validate() error {
 	}
 	if cr.Spec.VMSelect != nil {
 		vms := cr.Spec.VMSelect
-		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetVMSelectName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVMSelectName())
+		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetSelectName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetSelectName())
 		}
 		if vms.HPA != nil {
 			if err := vms.HPA.Validate(); err != nil {
@@ -619,8 +619,8 @@ func (cr *VMCluster) Validate() error {
 	}
 	if cr.Spec.VMInsert != nil {
 		vmi := cr.Spec.VMInsert
-		if vmi.ServiceSpec != nil && vmi.ServiceSpec.Name == cr.GetVMInsertName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVMInsertName())
+		if vmi.ServiceSpec != nil && vmi.ServiceSpec.Name == cr.GetInsertName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetInsertName())
 		}
 		if vmi.HPA != nil {
 			if err := vmi.HPA.Validate(); err != nil {
@@ -630,8 +630,8 @@ func (cr *VMCluster) Validate() error {
 	}
 	if cr.Spec.VMStorage != nil {
 		vms := cr.Spec.VMStorage
-		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetVMStorageName() {
-			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetVMStorageName())
+		if vms.ServiceSpec != nil && vms.ServiceSpec.Name == cr.GetStorageName() {
+			return fmt.Errorf(".serviceSpec.Name cannot be equal to prefixed name=%q", cr.GetStorageName())
 		}
 		if cr.Spec.VMStorage.VMBackup != nil {
 			if err := cr.Spec.VMStorage.VMBackup.validate(cr.Spec.License); err != nil {
@@ -654,8 +654,8 @@ func (cr *VMCluster) Validate() error {
 	return nil
 }
 
-// VMSelectSelectorLabels returns selector labels for vmselect cluster component
-func (cr *VMCluster) VMSelectSelectorLabels() map[string]string {
+// GetSelectSelectorLabels returns selector labels for vmselect cluster component
+func (cr *VMCluster) GetSelectSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vmselect",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -664,17 +664,17 @@ func (cr *VMCluster) VMSelectSelectorLabels() map[string]string {
 	}
 }
 
-// VMSelectPodLabels returns pod labels for vmselect cluster component
-func (cr *VMCluster) VMSelectPodLabels() map[string]string {
-	selectorLabels := cr.VMSelectSelectorLabels()
+// GetSelectPodLabels returns pod labels for vmselect cluster component
+func (cr *VMCluster) GetSelectPodLabels() map[string]string {
+	selectorLabels := cr.GetSelectSelectorLabels()
 	if cr.Spec.VMSelect == nil || cr.Spec.VMSelect.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.VMSelect.PodMetadata.Labels, selectorLabels)
 }
 
-// VMInsertSelectorLabels returns selector labels for vminsert cluster component
-func (cr *VMCluster) VMInsertSelectorLabels() map[string]string {
+// GetInsertSelectorLabels returns selector labels for vminsert cluster component
+func (cr *VMCluster) GetInsertSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vminsert",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -683,17 +683,17 @@ func (cr *VMCluster) VMInsertSelectorLabels() map[string]string {
 	}
 }
 
-// VMInsertPodLabels returns pod labels for vminsert cluster component
-func (cr *VMCluster) VMInsertPodLabels() map[string]string {
-	selectorLabels := cr.VMInsertSelectorLabels()
+// GetInsertPodLabels returns pod labels for vminsert cluster component
+func (cr *VMCluster) GetInsertPodLabels() map[string]string {
+	selectorLabels := cr.GetInsertSelectorLabels()
 	if cr.Spec.VMInsert == nil || cr.Spec.VMInsert.PodMetadata == nil {
 		return selectorLabels
 	}
 	return labels.Merge(cr.Spec.VMInsert.PodMetadata.Labels, selectorLabels)
 }
 
-// VMStorageSelectorLabels  returns pod labels for vmstorage cluster component
-func (cr *VMCluster) VMStorageSelectorLabels() map[string]string {
+// GetStorageSelectorLabels  returns pod labels for vmstorage cluster component
+func (cr *VMCluster) GetStorageSelectorLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":      "vmstorage",
 		"app.kubernetes.io/instance":  cr.Name,
@@ -702,9 +702,9 @@ func (cr *VMCluster) VMStorageSelectorLabels() map[string]string {
 	}
 }
 
-// VMStoragePodLabels returns pod labels for the vmstorage cluster component
-func (cr *VMCluster) VMStoragePodLabels() map[string]string {
-	selectorLabels := cr.VMStorageSelectorLabels()
+// GetStoragePodLabels returns pod labels for the vmstorage cluster component
+func (cr *VMCluster) GetStoragePodLabels() map[string]string {
+	selectorLabels := cr.GetStorageSelectorLabels()
 	if cr.Spec.VMStorage == nil || cr.Spec.VMStorage.PodMetadata == nil {
 		return selectorLabels
 	}
@@ -759,24 +759,24 @@ func (cr *VMCluster) FinalLabels(selectorLabels map[string]string) map[string]st
 	return labels.Merge(result, baseLabels)
 }
 
-// VMSelectPodAnnotations returns pod annotations for vmselect cluster component
-func (cr *VMCluster) VMSelectPodAnnotations() map[string]string {
+// GetSelectPodAnnotations returns pod annotations for vmselect cluster component
+func (cr *VMCluster) GetSelectPodAnnotations() map[string]string {
 	if cr.Spec.VMSelect == nil || cr.Spec.VMSelect.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.VMSelect.PodMetadata.Annotations
 }
 
-// VMInsertPodAnnotations returns pod annotations for vminsert cluster component
-func (cr *VMCluster) VMInsertPodAnnotations() map[string]string {
+// GetInsertPodAnnotations returns pod annotations for vminsert cluster component
+func (cr *VMCluster) GetInsertPodAnnotations() map[string]string {
 	if cr.Spec.VMInsert == nil || cr.Spec.VMInsert.PodMetadata == nil {
 		return make(map[string]string)
 	}
 	return cr.Spec.VMInsert.PodMetadata.Annotations
 }
 
-// VMStoragePodAnnotations returns pod annotations for vmstorage cluster component
-func (cr *VMCluster) VMStoragePodAnnotations() map[string]string {
+// GetStoragePodAnnotations returns pod annotations for vmstorage cluster component
+func (cr *VMCluster) GetStoragePodAnnotations() map[string]string {
 	if cr.Spec.VMStorage == nil || cr.Spec.VMStorage.PodMetadata == nil {
 		return make(map[string]string)
 	}
@@ -937,7 +937,7 @@ func (cr *VMCluster) SelectURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMSelect.ExtraArgs), cr.GetVMSelectName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMSelect.ExtraArgs), cr.GetSelectName(), cr.Namespace, port)
 }
 
 // InsertURL returns url to access VMInsert component
@@ -956,7 +956,7 @@ func (cr *VMCluster) InsertURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMInsert.ExtraArgs), cr.GetVMInsertName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMInsert.ExtraArgs), cr.GetInsertName(), cr.Namespace, port)
 }
 
 // StorageURL returns url to access VMStorage component
@@ -975,7 +975,7 @@ func (cr *VMCluster) StorageURL() string {
 			}
 		}
 	}
-	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMStorage.ExtraArgs), cr.GetVMStorageName(), cr.Namespace, port)
+	return fmt.Sprintf("%s://%s.%s.svc:%s", HTTPProtoFromFlags(cr.Spec.VMStorage.ExtraArgs), cr.GetStorageName(), cr.Namespace, port)
 }
 
 func (cr *VMSelect) Probe() *EmbeddedProbes {

--- a/internal/controller/operator/factory/finalize/vlcluster.go
+++ b/internal/controller/operator/factory/finalize/vlcluster.go
@@ -51,7 +51,7 @@ func OnVLClusterDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCl
 func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCluster, obj *vmv1.VLInsert) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVLInsertName(),
+		Name:      cr.GetInsertName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -61,7 +61,7 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLInsertName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetInsertName()),
 			},
 		})
 	}
@@ -73,11 +73,11 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -91,7 +91,7 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCluster, obj *vmv1.VLSelect) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVLSelectName(),
+		Name:      cr.GetSelectName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -101,7 +101,7 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLSelectName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetSelectName()),
 			},
 		})
 	}
@@ -113,10 +113,10 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -130,7 +130,7 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 func OnVLStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCluster, obj *vmv1.VLStorage) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVLStorageName(),
+		Name:      cr.GetStorageName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -140,7 +140,7 @@ func OnVLStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCl
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVLStorageName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetStorageName()),
 			},
 		})
 	}
@@ -181,20 +181,20 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 	if cr.Spec.VLSelect != nil {
 		if !ptr.Deref(cr.Spec.VLSelect.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVLSelectLBName(),
+			Name:      cr.GetSelectLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}
 	if cr.Spec.VLInsert != nil {
 		if !ptr.Deref(cr.Spec.VLInsert.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVLInsertLBName(),
+			Name:      cr.GetInsertLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}

--- a/internal/controller/operator/factory/finalize/vmcluster.go
+++ b/internal/controller/operator/factory/finalize/vmcluster.go
@@ -19,7 +19,7 @@ import (
 func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMInsert) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVMInsertName(),
+		Name:      cr.GetInsertName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -29,7 +29,7 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMInsertName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetInsertName()),
 			},
 		})
 	}
@@ -41,11 +41,11 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -59,7 +59,7 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMSelect) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVMSelectName(),
+		Name:      cr.GetSelectName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -69,7 +69,7 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMSelectName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetSelectName()),
 			},
 		})
 	}
@@ -81,10 +81,10 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -98,7 +98,7 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 func OnVMStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster, obj *vmv1beta1.VMStorage) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVMStorageName(),
+		Name:      cr.GetStorageName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -108,7 +108,7 @@ func OnVMStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVMStorageName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetStorageName()),
 			},
 		})
 	}
@@ -181,20 +181,20 @@ func OnVMClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 	if cr.Spec.VMSelect != nil {
 		if !ptr.Deref(cr.Spec.VMSelect.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMSelectLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVMSelectLBName(),
+			Name:      cr.GetSelectLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}
 	if cr.Spec.VMInsert != nil {
 		if !ptr.Deref(cr.Spec.VMInsert.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVMInsertLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVMInsertLBName(),
+			Name:      cr.GetInsertLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}

--- a/internal/controller/operator/factory/finalize/vtcluster.go
+++ b/internal/controller/operator/factory/finalize/vtcluster.go
@@ -52,7 +52,7 @@ func OnVTClusterDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCl
 func OnVTInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCluster, obj *vmv1.VTInsert) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVTInsertName(),
+		Name:      cr.GetInsertName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -62,7 +62,7 @@ func OnVTInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVTInsertName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetInsertName()),
 			},
 		})
 	}
@@ -74,11 +74,11 @@ func OnVTInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTInsertLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -92,7 +92,7 @@ func OnVTInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 func OnVTSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCluster, obj *vmv1.VTSelect) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVTSelectName(),
+		Name:      cr.GetSelectName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
@@ -102,7 +102,7 @@ func OnVTSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVTSelectName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetSelectName()),
 			},
 		})
 	}
@@ -114,10 +114,10 @@ func OnVTSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 	}
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
-		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
-		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTSelectLBName(), Namespace: cr.Namespace}})
+		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 	}
 	for _, objToRemove := range objsToRemove {
 		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
@@ -131,7 +131,7 @@ func OnVTSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 func OnVTStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCluster, obj *vmv1.VTStorage) error {
 	objMeta := metav1.ObjectMeta{
 		Namespace: cr.Namespace,
-		Name:      cr.GetVTStorageName(),
+		Name:      cr.GetStorageName(),
 	}
 	objsToRemove := []client.Object{
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
@@ -141,7 +141,7 @@ func OnVTStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCl
 		objsToRemove = append(objsToRemove, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: cr.Namespace,
-				Name:      obj.ServiceSpec.NameOrDefault(cr.GetVTStorageName()),
+				Name:      obj.ServiceSpec.NameOrDefault(cr.GetStorageName()),
 			},
 		})
 	}
@@ -182,20 +182,20 @@ func OnVTClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 	if cr.Spec.Select != nil {
 		if !ptr.Deref(cr.Spec.Select.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTSelectLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVTSelectLBName(),
+			Name:      cr.GetSelectLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}
 	if cr.Spec.Insert != nil {
 		if !ptr.Deref(cr.Spec.Insert.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 			objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{
-				ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTInsertLBName(), Namespace: cr.Namespace}})
+				ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace}})
 		}
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetVTInsertLBName(),
+			Name:      cr.GetInsertLBName(),
 			Namespace: cr.Namespace,
 		}})
 	}

--- a/internal/controller/operator/factory/vlcluster/vlcluster.go
+++ b/internal/controller/operator/factory/vlcluster/vlcluster.go
@@ -87,7 +87,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				return fmt.Errorf("cannot remove storage from prev state: %w", err)
 			}
 		} else {
-			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetVLStorageName()}
+			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetStorageName()}
 			if vmst.PodDisruptionBudget == nil && prevSt.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev storage: %w", err)
@@ -99,7 +99,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevSt.ServiceSpec, vmst.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVLStorageName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetStorageName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove storage additional service: %w", err)
 			}
 		}
@@ -112,7 +112,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			}
 		} else {
 			commonObjMeta := metav1.ObjectMeta{
-				Namespace: cr.Namespace, Name: cr.GetVLSelectName()}
+				Namespace: cr.Namespace, Name: cr.GetSelectName()}
 			if vmse.PodDisruptionBudget == nil && prevSe.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev select: %w", err)
@@ -129,7 +129,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevSe.ServiceSpec, vmse.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVLSelectName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetSelectName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove select additional service: %w", err)
 			}
 		}
@@ -139,7 +139,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			// remove service scrape because service was renamed
 			if !ptr.Deref(cr.Spec.VLSelect.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb select svc: %w", err)
 				}
@@ -149,14 +149,14 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 		// transit to the k8s service balancing mode
 		if prevLB.Enabled && !prevLB.DisableSelectBalancing && (!newLB.Enabled || newLB.DisableSelectBalancing) {
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.GetVLSelectLBName(),
+				Name:      cr.GetSelectLBName(),
 				Namespace: cr.Namespace,
 			}}); err != nil {
 				return fmt.Errorf("cannot remove select lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.VLSelect.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLSelectLBName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb select svc: %w", err)
 				}
@@ -171,7 +171,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			}
 		} else {
 
-			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetVLInsertName()}
+			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetInsertName()}
 			if vmis.PodDisruptionBudget == nil && prevIs.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev insert: %w", err)
@@ -188,7 +188,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevIs.ServiceSpec, vmis.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVLInsertName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetInsertName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove insert additional service: %w", err)
 			}
 		}
@@ -198,7 +198,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			// remove service scrape because service was renamed
 			if !ptr.Deref(cr.Spec.VLInsert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb insert svc: %w", err)
 				}
@@ -208,14 +208,14 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 		// transit to the k8s service balancing mode
 		if prevLB.Enabled && !prevLB.DisableInsertBalancing && (!newLB.Enabled || newLB.DisableInsertBalancing) {
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.GetVLInsertLBName(),
+				Name:      cr.GetInsertLBName(),
 				Namespace: cr.Namespace,
 			}}); err != nil {
 				return fmt.Errorf("cannot remove insert lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.VLInsert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVLInsertLBName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb insert svc: %w", err)
 				}

--- a/internal/controller/operator/factory/vlcluster/vlcluster_test.go
+++ b/internal/controller/operator/factory/vlcluster/vlcluster_test.go
@@ -59,7 +59,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if cr.Spec.VLStorage != nil {
 			var vlst appsv1.StatefulSet
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetVLStorageName(), Namespace: cr.Namespace}, &vlst); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetStorageName(), Namespace: cr.Namespace}, &vlst); err != nil {
 					return err
 				}
 				vlst.Status.ReadyReplicas = *cr.Spec.VLStorage.ReplicaCount
@@ -74,7 +74,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if cr.Spec.VLSelect != nil {
 			var vls appsv1.Deployment
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetVLSelectName(), Namespace: cr.Namespace}, &vls); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: cr.Namespace}, &vls); err != nil {
 					return err
 				}
 				vls.Status.Conditions = append(vls.Status.Conditions, appsv1.DeploymentCondition{
@@ -95,7 +95,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if cr.Spec.VLInsert != nil {
 			var vli appsv1.Deployment
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetVLInsertName(), Namespace: cr.Namespace}, &vli); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: cr.GetInsertName(), Namespace: cr.Namespace}, &vli); err != nil {
 					return err
 				}
 				vli.Status.Conditions = append(vli.Status.Conditions, appsv1.DeploymentCondition{
@@ -179,29 +179,29 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		// check insert
 		var dep appsv1.Deployment
-		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVLInsertName(), Namespace: cr.Namespace}, &dep))
+		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetInsertName(), Namespace: cr.Namespace}, &dep))
 		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 		cnt := dep.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:9481", "-internalselect.disable=true", "-storageNode=vlstorage-base-0.vlstorage-base.default:9491,vlstorage-base-1.vlstorage-base.default:9491"})
 		assert.Nil(t, dep.Annotations)
-		assert.Equal(t, dep.Labels, cr.FinalLabels(cr.VLInsertSelectorLabels()))
+		assert.Equal(t, dep.Labels, cr.FinalLabels(cr.GetInsertSelectorLabels()))
 
 		// check select
-		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVLSelectName(), Namespace: cr.Namespace}, &dep))
+		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: cr.Namespace}, &dep))
 		assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 		cnt = dep.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:9471", "-internalinsert.disable=true", "-storageNode=vlstorage-base-0.vlstorage-base.default:9491,vlstorage-base-1.vlstorage-base.default:9491"})
 		assert.Nil(t, dep.Annotations)
-		assert.Equal(t, dep.Labels, cr.FinalLabels(cr.VLSelectSelectorLabels()))
+		assert.Equal(t, dep.Labels, cr.FinalLabels(cr.GetSelectSelectorLabels()))
 
 		// check storage
 		var sts appsv1.StatefulSet
-		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVLStorageName(), Namespace: cr.Namespace}, &sts))
+		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetStorageName(), Namespace: cr.Namespace}, &sts))
 		assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
 		cnt = sts.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:9491", "-storageDataPath=/vlstorage-data"})
 		assert.Nil(t, sts.Annotations)
-		assert.Equal(t, sts.Labels, cr.FinalLabels(cr.VLStorageSelectorLabels()))
+		assert.Equal(t, sts.Labels, cr.FinalLabels(cr.GetStorageSelectorLabels()))
 
 		return nil
 	}
@@ -229,7 +229,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		// check storage
 		var sts appsv1.StatefulSet
-		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVLStorageName(), Namespace: cr.Namespace}, &sts))
+		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetStorageName(), Namespace: cr.Namespace}, &sts))
 		assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
 		cnt := sts.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, cnt.Args, []string{"-futureRetention=2d", "-httpListenAddr=:9491", "-retention.maxDiskSpaceUsageBytes=5GB", "-retentionPeriod=1w", "-storageDataPath=/vlstorage-data"})
@@ -268,7 +268,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		// check select
 		var d appsv1.Deployment
-		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVLSelectName(), Namespace: cr.Namespace}, &d))
+		assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: cr.Namespace}, &d))
 		assert.Len(t, d.Spec.Template.Spec.Containers, 1)
 		cnt := d.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, cnt.Args, []string{

--- a/internal/controller/operator/factory/vlcluster/vmauth_lb.go
+++ b/internal/controller/operator/factory/vlcluster/vmauth_lb.go
@@ -87,9 +87,9 @@ func buildVMauthLBSecret(cr *vmv1.VLCluster) *corev1.Secret {
 		}
 	}
 	insertURL := fmt.Sprintf("%s://%s.%s:%s",
-		insertProto, cr.GetVLInsertLBName(), targetHostSuffix, insertPort)
+		insertProto, cr.GetInsertLBName(), targetHostSuffix, insertPort)
 	selectURL := fmt.Sprintf("%s://%s.%s:%s",
-		selectProto, cr.GetVLSelectLBName(), targetHostSuffix, selectPort)
+		selectProto, cr.GetSelectLBName(), targetHostSuffix, selectPort)
 
 	lbScrt := &corev1.Secret{
 		ObjectMeta: buildLBConfigSecretMeta(cr),

--- a/internal/controller/operator/factory/vmcluster/vmcluster_test.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster_test.go
@@ -385,7 +385,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			if tt.args.cr.Spec.VMInsert != nil {
 				var vminsert appsv1.Deployment
 				eventuallyUpdateStatusToOk(func() error {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMInsertName(), Namespace: tt.args.cr.Namespace}, &vminsert); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetInsertName(), Namespace: tt.args.cr.Namespace}, &vminsert); err != nil {
 						return err
 					}
 					vminsert.Status.Conditions = append(vminsert.Status.Conditions, appsv1.DeploymentCondition{
@@ -403,7 +403,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			if tt.args.cr.Spec.VMSelect != nil {
 				var vmselect appsv1.StatefulSet
 				eventuallyUpdateStatusToOk(func() error {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMSelectName(), Namespace: tt.args.cr.Namespace}, &vmselect); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetSelectName(), Namespace: tt.args.cr.Namespace}, &vmselect); err != nil {
 						return err
 					}
 					vmselect.Status.ReadyReplicas = *tt.args.cr.Spec.VMSelect.ReplicaCount
@@ -417,7 +417,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			if tt.args.cr.Spec.VMStorage != nil {
 				var vmstorage appsv1.StatefulSet
 				eventuallyUpdateStatusToOk(func() error {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMStorageName(), Namespace: tt.args.cr.Namespace}, &vmstorage); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetStorageName(), Namespace: tt.args.cr.Namespace}, &vmstorage); err != nil {
 						return err
 					}
 					vmstorage.Status.ReadyReplicas = *tt.args.cr.Spec.VMStorage.ReplicaCount
@@ -439,17 +439,17 @@ func TestCreateOrUpdate(t *testing.T) {
 				var vmselect, vmstorage appsv1.StatefulSet
 				var vminsert appsv1.Deployment
 				if tt.args.cr.Spec.VMInsert != nil {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMInsertName(), Namespace: tt.args.cr.Namespace}, &vminsert); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetInsertName(), Namespace: tt.args.cr.Namespace}, &vminsert); err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
 				}
 				if tt.args.cr.Spec.VMSelect != nil {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMSelectName(), Namespace: tt.args.cr.Namespace}, &vmselect); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetSelectName(), Namespace: tt.args.cr.Namespace}, &vmselect); err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
 				}
 				if tt.args.cr.Spec.VMStorage != nil {
-					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetVMStorageName(), Namespace: tt.args.cr.Namespace}, &vmstorage); err != nil {
+					if err := fclient.Get(ctx, types.NamespacedName{Name: tt.args.cr.GetStorageName(), Namespace: tt.args.cr.Namespace}, &vmstorage); err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
 				}

--- a/internal/controller/operator/factory/vtcluster/cluster.go
+++ b/internal/controller/operator/factory/vtcluster/cluster.go
@@ -87,7 +87,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				return fmt.Errorf("cannot remove storage from prev state: %w", err)
 			}
 		} else {
-			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetVTStorageName()}
+			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetStorageName()}
 			if vmst.PodDisruptionBudget == nil && prevSt.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev storage: %w", err)
@@ -99,7 +99,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevSt.ServiceSpec, vmst.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVTStorageName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetStorageName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove storage additional service: %w", err)
 			}
 		}
@@ -112,7 +112,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			}
 		} else {
 			commonObjMeta := metav1.ObjectMeta{
-				Namespace: cr.Namespace, Name: cr.GetVTSelectName()}
+				Namespace: cr.Namespace, Name: cr.GetSelectName()}
 			if vmse.PodDisruptionBudget == nil && prevSe.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev select: %w", err)
@@ -129,7 +129,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevSe.ServiceSpec, vmse.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVTSelectName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetSelectName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove select additional service: %w", err)
 			}
 		}
@@ -139,7 +139,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			// remove service scrape because service was renamed
 			if !ptr.Deref(cr.Spec.Select.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTSelectName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb select svc: %w", err)
 				}
@@ -149,14 +149,14 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 		// transit to the k8s service balancing mode
 		if prevLB.Enabled && !prevLB.DisableSelectBalancing && (!newLB.Enabled || newLB.DisableSelectBalancing) {
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.GetVTSelectLBName(),
+				Name:      cr.GetSelectLBName(),
 				Namespace: cr.Namespace,
 			}}); err != nil {
 				return fmt.Errorf("cannot remove select lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.Select.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTSelectLBName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetSelectLBName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb select svc: %w", err)
 				}
@@ -171,7 +171,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			}
 		} else {
 
-			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetVTInsertName()}
+			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: cr.GetInsertName()}
 			if vmis.PodDisruptionBudget == nil && prevIs.PodDisruptionBudget != nil {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev insert: %w", err)
@@ -188,7 +188,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				}
 			}
 			prevSvc, currSvc := prevIs.ServiceSpec, vmis.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetVTInsertName(), cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, cr.GetInsertName(), cr.Namespace, prevSvc, currSvc); err != nil {
 				return fmt.Errorf("cannot remove insert additional service: %w", err)
 			}
 		}
@@ -198,7 +198,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			// remove service scrape because service was renamed
 			if !ptr.Deref(cr.Spec.Insert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTInsertName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb insert svc: %w", err)
 				}
@@ -208,14 +208,14 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 		// transit to the k8s service balancing mode
 		if prevLB.Enabled && !prevLB.DisableInsertBalancing && (!newLB.Enabled || newLB.DisableInsertBalancing) {
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.GetVTInsertLBName(),
+				Name:      cr.GetInsertLBName(),
 				Namespace: cr.Namespace,
 			}}); err != nil {
 				return fmt.Errorf("cannot remove insert lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.Insert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
-					ObjectMeta: metav1.ObjectMeta{Name: cr.GetVTInsertLBName(), Namespace: cr.Namespace},
+					ObjectMeta: metav1.ObjectMeta{Name: cr.GetInsertLBName(), Namespace: cr.Namespace},
 				}); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb insert svc: %w", err)
 				}

--- a/internal/controller/operator/factory/vtcluster/cluster_test.go
+++ b/internal/controller/operator/factory/vtcluster/cluster_test.go
@@ -64,7 +64,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if opts.cr.Spec.Storage != nil {
 			var vtst appsv1.StatefulSet
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetVTStorageName(), Namespace: opts.cr.Namespace}, &vtst); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetStorageName(), Namespace: opts.cr.Namespace}, &vtst); err != nil {
 					return err
 				}
 				vtst.Status.ReadyReplicas = *opts.cr.Spec.Storage.ReplicaCount
@@ -79,7 +79,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if opts.cr.Spec.Select != nil {
 			var vts appsv1.Deployment
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetVTSelectName(), Namespace: opts.cr.Namespace}, &vts); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetSelectName(), Namespace: opts.cr.Namespace}, &vts); err != nil {
 					return err
 				}
 				vts.Status.Conditions = append(vts.Status.Conditions, appsv1.DeploymentCondition{
@@ -100,7 +100,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		if opts.cr.Spec.Insert != nil {
 			var vti appsv1.Deployment
 			eventuallyUpdateStatusToOk(func() error {
-				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetVTInsertName(), Namespace: opts.cr.Namespace}, &vti); err != nil {
+				if err := fclient.Get(ctx, types.NamespacedName{Name: opts.cr.GetInsertName(), Namespace: opts.cr.Namespace}, &vti); err != nil {
 					return err
 				}
 				vti.Status.Conditions = append(vti.Status.Conditions, appsv1.DeploymentCondition{
@@ -185,29 +185,29 @@ func TestCreateOrUpdate(t *testing.T) {
 
 			// check insert
 			var dep appsv1.Deployment
-			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVTInsertName(), Namespace: cr.Namespace}, &dep))
+			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetInsertName(), Namespace: cr.Namespace}, &dep))
 			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 			cnt := dep.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:10481", "-internalselect.disable=true", "-storageNode=vtstorage-base-0.vtstorage-base.default:10491,vtstorage-base-1.vtstorage-base.default:10491"})
 			assert.Nil(t, dep.Annotations)
-			assert.Equal(t, dep.Labels, cr.FinalLabels(cr.VTInsertSelectorLabels()))
+			assert.Equal(t, dep.Labels, cr.FinalLabels(cr.GetInsertSelectorLabels()))
 
 			// check select
-			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVTSelectName(), Namespace: cr.Namespace}, &dep))
+			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: cr.Namespace}, &dep))
 			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 			cnt = dep.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:10471", "-internalinsert.disable=true", "-storageNode=vtstorage-base-0.vtstorage-base.default:10491,vtstorage-base-1.vtstorage-base.default:10491"})
 			assert.Nil(t, dep.Annotations)
-			assert.Equal(t, dep.Labels, cr.FinalLabels(cr.VTSelectSelectorLabels()))
+			assert.Equal(t, dep.Labels, cr.FinalLabels(cr.GetSelectSelectorLabels()))
 
 			// check storage
 			var sts appsv1.StatefulSet
-			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVTStorageName(), Namespace: cr.Namespace}, &sts))
+			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetStorageName(), Namespace: cr.Namespace}, &sts))
 			assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
 			cnt = sts.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, cnt.Args, []string{"-httpListenAddr=:10491", "-storageDataPath=/vtstorage-data"})
 			assert.Nil(t, sts.Annotations)
-			assert.Equal(t, sts.Labels, cr.FinalLabels(cr.VTStorageSelectorLabels()))
+			assert.Equal(t, sts.Labels, cr.FinalLabels(cr.GetStorageSelectorLabels()))
 
 			return nil
 		},
@@ -236,7 +236,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 			// check storage
 			var sts appsv1.StatefulSet
-			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetVTStorageName(), Namespace: cr.Namespace}, &sts))
+			assert.Nil(t, rclient.Get(ctx, types.NamespacedName{Name: cr.GetStorageName(), Namespace: cr.Namespace}, &sts))
 			assert.Len(t, sts.Spec.Template.Spec.Containers, 1)
 			cnt := sts.Spec.Template.Spec.Containers[0]
 			assert.Equal(t, cnt.Args, []string{"-futureRetention=2d", "-httpListenAddr=:10491", "-retention.maxDiskSpaceUsageBytes=5GB", "-retentionPeriod=1w", "-storageDataPath=/vtstorage-data"})

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -174,9 +174,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 				},
 				func(cr *vmv1beta1.VMCluster) {
 					clusterNsnObjects := map[types.NamespacedName]client.Object{
-						{Namespace: cr.Namespace, Name: cr.GetVMInsertName()}:  &appsv1.Deployment{},
-						{Namespace: cr.Namespace, Name: cr.GetVMStorageName()}: &appsv1.StatefulSet{},
-						{Namespace: cr.Namespace, Name: cr.GetVMSelectName()}:  &appsv1.StatefulSet{},
+						{Namespace: cr.Namespace, Name: cr.GetInsertName()}:  &appsv1.Deployment{},
+						{Namespace: cr.Namespace, Name: cr.GetStorageName()}: &appsv1.StatefulSet{},
+						{Namespace: cr.Namespace, Name: cr.GetSelectName()}:  &appsv1.StatefulSet{},
 					}
 					for nsn, obj := range clusterNsnObjects {
 						By(fmt.Sprintf("verifying object with name: %s", nsn))
@@ -259,9 +259,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 				},
 				func(cr *vmv1beta1.VMCluster) {
 					clusterNsnObjects := map[types.NamespacedName]client.Object{
-						{Namespace: cr.Namespace, Name: cr.GetVMInsertName()}:  &appsv1.Deployment{},
-						{Namespace: cr.Namespace, Name: cr.GetVMStorageName()}: &appsv1.StatefulSet{},
-						{Namespace: cr.Namespace, Name: cr.GetVMSelectName()}:  &appsv1.StatefulSet{},
+						{Namespace: cr.Namespace, Name: cr.GetInsertName()}:  &appsv1.Deployment{},
+						{Namespace: cr.Namespace, Name: cr.GetStorageName()}: &appsv1.StatefulSet{},
+						{Namespace: cr.Namespace, Name: cr.GetSelectName()}:  &appsv1.StatefulSet{},
 					}
 					for nsn, obj := range clusterNsnObjects {
 						By(fmt.Sprintf("verifying object with name: %s", nsn))
@@ -407,8 +407,8 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 						cr.Spec.VMSelect.ReplicaCount = ptr.To[int32](2)
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMStorageSelectorLabels())).To(BeEmpty())
-						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMSelectSelectorLabels())).To(BeEmpty())
+						Expect(expectPodCount(k8sClient, 2, namespace, cr.GetStorageSelectorLabels())).To(BeEmpty())
+						Expect(expectPodCount(k8sClient, 2, namespace, cr.GetSelectSelectorLabels())).To(BeEmpty())
 					},
 				},
 			),
@@ -473,7 +473,7 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					verify: func(cr *vmv1beta1.VMCluster) {
 						nss := types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMStorageName(),
+							Name:      cr.GetStorageName(),
 						}
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
@@ -511,9 +511,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 						cr.Spec.VMInsert.ReplicaCount = ptr.To[int32](2)
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						Expect(expectPodCount(k8sClient, 2, namespace, cr.VMStorageSelectorLabels())).To(BeEmpty())
+						Expect(expectPodCount(k8sClient, 2, namespace, cr.GetStorageSelectorLabels())).To(BeEmpty())
 						Eventually(func() string {
-							return expectPodCount(k8sClient, 2, namespace, cr.VMInsertSelectorLabels())
+							return expectPodCount(k8sClient, 2, namespace, cr.GetInsertSelectorLabels())
 						}, eventualDeploymentPodTimeout).Should(BeEmpty())
 					},
 				},
@@ -622,7 +622,7 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
 						nss := types.NamespacedName{
-							Name:      cr.GetVMSelectName(),
+							Name:      cr.GetSelectName(),
 							Namespace: namespace,
 						}
 						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.StatefulSet{})
@@ -687,13 +687,13 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					verify: func(cr *vmv1beta1.VMCluster) {
 						nss := types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMStorageName(),
+							Name:      cr.GetStorageName(),
 						}
 						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.StatefulSet{})
 						waitResourceDeleted(ctx, k8sClient, nss, &corev1.Service{})
 						waitResourceDeleted(ctx, k8sClient, nss, &vmv1beta1.VMServiceScrape{})
 
-						nss.Name = cr.GetVMInsertName()
+						nss.Name = cr.GetInsertName()
 						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.Deployment{})
 					},
 				},
@@ -781,7 +781,7 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					verify: func(cr *vmv1beta1.VMCluster) {
 						nss := types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMSelectName() + "-additional-service",
+							Name:      cr.GetSelectName() + "-additional-service",
 						}
 						waitResourceDeleted(ctx, k8sClient, nss, &corev1.Service{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name + "-additional-service"}, &corev1.Service{})).To(Succeed())
@@ -813,7 +813,7 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					verify: func(cr *vmv1beta1.VMCluster) {
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMStorageName() + "-additional-service",
+							Name:      cr.GetStorageName() + "-additional-service",
 						}, &corev1.Service{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "my-service-name-v2"}, &corev1.Service{})).To(Succeed())
 						var stSvc corev1.Service
@@ -861,7 +861,7 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
 						var sts appsv1.StatefulSet
-						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMStorageName()}
+						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetStorageName()}
 						Expect(k8sClient.Get(ctx, nss, &sts)).To(Succeed())
 						Expect(sts.Spec.Template.Spec.ImagePullSecrets).To(HaveLen(1))
 						Expect(k8sClient.Delete(ctx,
@@ -896,14 +896,14 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster"), func() {
 				testStep{
 					setup: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 					},
 					modify: func(cr *vmv1beta1.VMCluster) {
@@ -916,31 +916,31 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &lbDep)).To(Succeed())
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &svc)).To(Succeed())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)).To(Succeed())
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
-							Name:      cr.GetVMSelectName(),
+							Name:      cr.GetSelectName(),
 							Namespace: namespace,
 						}, &vmv1beta1.VMServiceScrape{})
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
-							Name:      cr.GetVMInsertName(),
+							Name:      cr.GetInsertName(),
 							Namespace: namespace,
 						}, &vmv1beta1.VMServiceScrape{})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 					},
 				},
@@ -956,29 +956,29 @@ up{baz="bar"} 123
 						waitResourceDeleted(ctx, k8sClient, nss, &svc)
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMInsertLBName(),
+							Name:      cr.GetInsertLBName(),
 						}, &svc)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &svc)).To(Succeed())
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
 							Namespace: namespace,
-							Name:      cr.GetVMSelectLBName(),
+							Name:      cr.GetSelectLBName(),
 						}, &svc)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &svc)).To(Succeed())
 						var vss vmv1beta1.VMServiceScrape
 						waitResourceDeleted(ctx, k8sClient, nss, &vss)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &vss)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 					},
 				},
@@ -1014,30 +1014,30 @@ up{baz="bar"} 123
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
 						Expect(k8sClient.Get(ctx, nss, &lbDep)).To(Succeed())
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &svc)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &svc)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &svc)).To(Succeed())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &vss)).To(Succeed())
 
 					},
 				},
@@ -1054,25 +1054,25 @@ up{baz="bar"} 123
 						Expect(*lbDep.Spec.Replicas).To(BeEquivalentTo(int32(2)))
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &svc)).To(Succeed())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &vss)
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &vss)
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 					},
 				},
@@ -1091,25 +1091,25 @@ up{baz="bar"} 123
 						Expect(*lbDep.Spec.Replicas).To(BeEquivalentTo(int32(2)))
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &svc)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &svc)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &svc)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &svc)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &svc)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &svc)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &svc)).To(Succeed())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &vss)
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 					},
 				},
@@ -1158,14 +1158,14 @@ up{baz="bar"} 123
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
@@ -1182,10 +1182,10 @@ up{baz="bar"} 123
 						Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.Parse("8431")))
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertLBName()}, &vss)).To(Succeed())
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectLBName()}, &vss)).To(Succeed())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMSelectName()}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetVMInsertName()}, &vss)
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertLBName()}, &vss)).To(Succeed())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectLBName()}, &vss)).To(Succeed())
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}, &vss)
+						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}, &vss)
 						var pdb policyv1.PodDisruptionBudget
 						Expect(k8sClient.Get(ctx, nss, &pdb)).To(Succeed())
 					},
@@ -1200,14 +1200,14 @@ up{baz="bar"} 123
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetVMInsertName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.GetInsertName(), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetVMSelectName(), namespace),
+							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.GetSelectName(), namespace),
 						})
 						var lbDep appsv1.Deployment
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.GetVMAuthLBName()}
@@ -1255,7 +1255,7 @@ up{baz="bar"} 123
 					verify: func(cr *vmv1beta1.VMCluster) {
 						expectedAnnotations := map[string]string{"annotation-1": "value-a-1", "annotation-2": "value-a-2"}
 						expectedLabels := map[string]string{"label-1": "value-1", "label-2": "value-2", "managed-by": "vm-operator"}
-						selectN, insertN, storageN, lbName, saName := cr.GetVMSelectName(), cr.GetVMInsertName(), cr.GetVMStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()
+						selectN, insertN, storageN, lbName, saName := cr.GetSelectName(), cr.GetInsertName(), cr.GetStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()
 						objectsByNss := map[types.NamespacedName][]client.Object{
 							{Name: selectN}:  {&corev1.Service{}, &appsv1.StatefulSet{}},
 							{Name: storageN}: {&corev1.Service{}, &appsv1.StatefulSet{}},
@@ -1280,7 +1280,7 @@ up{baz="bar"} 123
 					verify: func(cr *vmv1beta1.VMCluster) {
 						expectedAnnotations := map[string]string{"annotation-1": "value-a-1", "annotation-2": ""}
 						expectedLabels := map[string]string{"label-1": "", "label-2": "", "managed-by": "vm-operator"}
-						selectN, insertN, storageN, lbName, saName := cr.GetVMSelectName(), cr.GetVMInsertName(), cr.GetVMStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()
+						selectN, insertN, storageN, lbName, saName := cr.GetSelectName(), cr.GetInsertName(), cr.GetStorageName(), cr.GetVMAuthLBName(), cr.PrefixedName()
 						objectsByNss := map[types.NamespacedName][]client.Object{
 							{Name: selectN}:  {&corev1.Service{}, &appsv1.StatefulSet{}},
 							{Name: storageN}: {&corev1.Service{}, &appsv1.StatefulSet{}},
@@ -1385,7 +1385,7 @@ up{baz="bar"} 123
 							podList := &corev1.PodList{}
 							k8sClient.List(ctx, podList, &client.ListOptions{
 								Namespace:     namespace,
-								LabelSelector: labels.SelectorFromSet(cr.VMStorageSelectorLabels()),
+								LabelSelector: labels.SelectorFromSet(cr.GetStorageSelectorLabels()),
 							})
 							podsUpdated := 0
 							podsUnavailable := 0
@@ -1441,7 +1441,7 @@ up{baz="bar"} 123
 							podList := &corev1.PodList{}
 							k8sClient.List(ctx, podList, &client.ListOptions{
 								Namespace:     namespace,
-								LabelSelector: labels.SelectorFromSet(cr.VMStorageSelectorLabels()),
+								LabelSelector: labels.SelectorFromSet(cr.GetStorageSelectorLabels()),
 							})
 							podsUpdated := 0
 							podsOutdated := 0
@@ -1504,7 +1504,7 @@ up{baz="bar"} 123
 							podList := &corev1.PodList{}
 							k8sClient.List(ctx, podList, &client.ListOptions{
 								Namespace:     namespace,
-								LabelSelector: labels.SelectorFromSet(cr.VMStorageSelectorLabels()),
+								LabelSelector: labels.SelectorFromSet(cr.GetStorageSelectorLabels()),
 							})
 							podsUpdated := 0
 							for _, pod := range podList.Items {
@@ -1515,7 +1515,7 @@ up{baz="bar"} 123
 							var pdb policyv1.PodDisruptionBudget
 							k8sClient.Get(ctx, types.NamespacedName{
 								Namespace: namespace,
-								Name:      cr.GetVMStorageName(),
+								Name:      cr.GetStorageName(),
 							}, &pdb)
 							Expect(pdb.Status.CurrentHealthy).To(BeNumerically(">=", 4), "at least 4 pods should be healthy during the update")
 							return podsUpdated

--- a/test/e2e/vtcluster_test.go
+++ b/test/e2e/vtcluster_test.go
@@ -106,7 +106,7 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 					},
 					verify: func(cr *vmv1.VTCluster) {
 						nsss := []types.NamespacedName{
-							{Namespace: namespace, Name: cr.GetVTStorageName()},
+							{Namespace: namespace, Name: cr.GetStorageName()},
 						}
 						expectedAnnotations := map[string]string{"added-annotation": "some-value"}
 						for _, nss := range nsss {
@@ -118,8 +118,8 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 							assertStrictSecurity(sts.Spec.Template.Spec)
 						}
 						nsss = []types.NamespacedName{
-							{Namespace: namespace, Name: cr.GetVTInsertName()},
-							{Namespace: namespace, Name: cr.GetVTSelectName()},
+							{Namespace: namespace, Name: cr.GetInsertName()},
+							{Namespace: namespace, Name: cr.GetSelectName()},
 						}
 						for _, nss := range nsss {
 							sts := &appsv1.Deployment{}
@@ -134,15 +134,15 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 					},
 					verify: func(cr *vmv1.VTCluster) {
 						nsss := []types.NamespacedName{
-							{Namespace: namespace, Name: cr.GetVTStorageName()},
+							{Namespace: namespace, Name: cr.GetStorageName()},
 						}
 						expectedAnnotations := map[string]string{"added-annotation": ""}
 						for _, nss := range nsss {
 							assertAnnotationsOnObjects(ctx, nss, []client.Object{&appsv1.StatefulSet{}, &corev1.Service{}}, expectedAnnotations)
 						}
 						nsss = []types.NamespacedName{
-							{Namespace: namespace, Name: cr.GetVTInsertName()},
-							{Namespace: namespace, Name: cr.GetVTSelectName()},
+							{Namespace: namespace, Name: cr.GetInsertName()},
+							{Namespace: namespace, Name: cr.GetSelectName()},
 						}
 						for _, nss := range nsss {
 							assertAnnotationsOnObjects(ctx, nss, []client.Object{&appsv1.Deployment{}, &corev1.Service{}}, expectedAnnotations)
@@ -163,18 +163,18 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetVMAuthLBName(), Namespace: namespace}, &dep)).To(Succeed())
 
 						var svc corev1.Service
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetVTSelectName(), Namespace: namespace}, &svc)).To(Succeed())
-						Expect(svc.Spec.Selector).To(Equal(cr.VMAuthLBSelectorLabels()))
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: namespace}, &svc)).To(Succeed())
+						Expect(svc.Spec.Selector).To(Equal(cr.GetVMAuthLBSelectorLabels()))
 
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetVTInsertName(), Namespace: namespace}, &svc)).To(Succeed())
-						Expect(svc.Spec.Selector).To(Equal(cr.VMAuthLBSelectorLabels()))
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetInsertName(), Namespace: namespace}, &svc)).To(Succeed())
+						Expect(svc.Spec.Selector).To(Equal(cr.GetVMAuthLBSelectorLabels()))
 
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.GetVTInsertName(), namespace),
+							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.GetInsertName(), namespace),
 							expectedCode: 200,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.GetVTSelectName(), namespace),
+							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.GetSelectName(), namespace),
 							payload:      ``,
 							expectedCode: 200,
 						})
@@ -189,18 +189,18 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cr.GetVMAuthLBName(), Namespace: namespace}, &dep)
 
 						var svc corev1.Service
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetVTSelectName(), Namespace: namespace}, &svc)).To(Succeed())
-						Expect(svc.Spec.Selector).To(Equal(cr.VTSelectSelectorLabels()))
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetSelectName(), Namespace: namespace}, &svc)).To(Succeed())
+						Expect(svc.Spec.Selector).To(Equal(cr.GetSelectSelectorLabels()))
 
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetVTInsertName(), Namespace: namespace}, &svc)).To(Succeed())
-						Expect(svc.Spec.Selector).To(Equal(cr.VTInsertSelectorLabels()))
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetInsertName(), Namespace: namespace}, &svc)).To(Succeed())
+						Expect(svc.Spec.Selector).To(Equal(cr.GetInsertSelectorLabels()))
 
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.GetVTInsertName(), namespace),
+							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.GetInsertName(), namespace),
 							expectedCode: 200,
 						})
 						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
-							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.GetVTSelectName(), namespace),
+							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.GetSelectName(), namespace),
 							payload:      ``,
 							expectedCode: 200,
 						})
@@ -219,17 +219,17 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						})
 					},
 					verify: func(cr *vmv1.VTCluster) {
-						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetVTStorageName()}
+						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetStorageName()}
 						sts := &appsv1.StatefulSet{}
 						Expect(k8sClient.Get(ctx, nsn, sts)).To(Succeed())
 						Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTInsertName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}
 						dep := &appsv1.Deployment{}
 						Expect(k8sClient.Get(ctx, nsn, dep)).To(Succeed())
 						Expect(*dep.Spec.Replicas).To(Equal(int32(3)))
 
 						// vtselect must be removed
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTSelectName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}
 						waitResourceDeleted(ctx, k8sClient, nsn, dep)
 					},
 				},
@@ -246,16 +246,16 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						})
 					},
 					verify: func(cr *vmv1.VTCluster) {
-						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetVTStorageName()}
+						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetStorageName()}
 						sts := &appsv1.StatefulSet{}
 						Expect(k8sClient.Get(ctx, nsn, sts)).To(Succeed())
 						Expect(*sts.Spec.Replicas).To(Equal(int32(2)))
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTSelectName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}
 						dep := &appsv1.Deployment{}
 						Expect(k8sClient.Get(ctx, nsn, dep)).To(Succeed())
 						Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 						// vtselect must be removed
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTInsertName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}
 						waitResourceDeleted(ctx, k8sClient, nsn, dep)
 					},
 				},
@@ -276,15 +276,15 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						})
 					},
 					verify: func(cr *vmv1.VTCluster) {
-						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetVTStorageName()}
+						nsn := types.NamespacedName{Namespace: namespace, Name: cr.GetStorageName()}
 						sts := &appsv1.StatefulSet{}
 						Expect(k8sClient.Get(ctx, nsn, sts)).To(Succeed())
 						Expect(*sts.Spec.Replicas).To(Equal(int32(0)))
 						dep := &appsv1.Deployment{}
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTInsertName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetInsertName()}
 						Expect(k8sClient.Get(ctx, nsn, dep)).To(Succeed())
 						Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
-						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetVTSelectName()}
+						nsn = types.NamespacedName{Namespace: namespace, Name: cr.GetSelectName()}
 						Expect(k8sClient.Get(ctx, nsn, dep)).To(Succeed())
 						Expect(*dep.Spec.Replicas).To(Equal(int32(0)))
 					},


### PR DESCRIPTION
remove VM, VT, VL prefixes for CR functions to make them similar for all implementations
this allows to simplify/unify removal logic for cluster's dangling resources
related issue https://github.com/VictoriaMetrics/operator/issues/1580