### PR TITLE
vol 1: extracted subset of changes from #1564

### DIFF
--- a/api/operator/v1/vlagent_types.go
+++ b/api/operator/v1/vlagent_types.go
@@ -413,7 +413,7 @@ func (*VLAgent) ProbeNeedLiveness() bool {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VLAgent) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1/vlcluster_types.go
+++ b/api/operator/v1/vlcluster_types.go
@@ -805,7 +805,7 @@ func (cr *VLCluster) AnnotationsFiltered() map[string]string {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VLCluster) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares cluster spec with last applied cluster spec stored in annotation

--- a/api/operator/v1/vlsingle_types.go
+++ b/api/operator/v1/vlsingle_types.go
@@ -327,7 +327,7 @@ func (cr *VLSingle) AsURL() string {
 
 // LastAppliedSpecAsPatch return last applied vlsingle spec as patch annotation
 func (cr *VLSingle) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares vlsingle spec with last applied vlsingle spec stored in annotation

--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -425,7 +425,7 @@ func (cr *VMAnomaly) GetShardCount() int {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMAnomaly) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1/vtcluster_types.go
+++ b/api/operator/v1/vtcluster_types.go
@@ -720,7 +720,7 @@ func (cr *VTCluster) AnnotationsFiltered() map[string]string {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VTCluster) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares cluster spec with last applied cluster spec stored in annotation

--- a/api/operator/v1/vtsingle_types.go
+++ b/api/operator/v1/vtsingle_types.go
@@ -336,7 +336,7 @@ func (cr *VTSingle) AsURL() string {
 
 // LastAppliedSpecAsPatch return last applied vtsingle spec as patch annotation
 func (cr *VTSingle) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return vmv1beta1.LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return vmv1beta1.LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares vtsingle spec with last applied vtsingle spec stored in annotation

--- a/api/operator/v1beta1/vlogs_types.go
+++ b/api/operator/v1beta1/vlogs_types.go
@@ -324,7 +324,7 @@ func (cr *VLogs) AsURL() string {
 
 // LastAppliedSpecAsPatch return last applied vlogs spec as patch annotation
 func (cr *VLogs) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares vlogs spec with last applied vlogs spec stored in annotation

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -888,7 +888,7 @@ func (cr *VMAgent) IsScrapeConfigUnmanaged() bool {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMAgent) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1beta1/vmalert_types.go
+++ b/api/operator/v1beta1/vmalert_types.go
@@ -503,7 +503,7 @@ func (cr *VMAlert) IsUnmanaged() bool {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMAlert) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -477,7 +477,7 @@ func (cr *VMAlertmanager) IsUnmanaged() bool {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMAlertmanager) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -689,7 +689,7 @@ func (cr *VMAuth) IsUnmanaged() bool {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMAuth) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares spec with last applied cluster spec stored in annotation

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -799,7 +799,7 @@ func (cr *VMCluster) AnnotationsFiltered() map[string]string {
 
 // LastAppliedSpecAsPatch return last applied cluster spec as patch annotation
 func (cr *VMCluster) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares cluster spec with last applied cluster spec stored in annotation

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -49,8 +49,8 @@ const (
 	SkipValidationValue      = "true"
 	AdditionalServiceLabel   = "operator.victoriametrics.com/additional-service"
 	// PVCExpandableLabel controls checks for storageClass
-	PVCExpandableLabel            = "operator.victoriametrics.com/pvc-allow-volume-expansion"
-	lastAppliedSpecAnnotationName = "operator.victoriametrics/last-applied-spec"
+	PVCExpandableLabel        = "operator.victoriametrics.com/pvc-allow-volume-expansion"
+	LastAppliedSpecAnnotation = "operator.victoriametrics/last-applied-spec"
 )
 
 const (
@@ -1034,13 +1034,13 @@ type objectWithLastAppliedState[T, ST any] interface {
 
 // ParseLastAppliedStateTo parses spec from provided CR annotations and sets it to the given CR
 func ParseLastAppliedStateTo[T objectWithLastAppliedState[T, ST], ST any](cr T) error {
-	lastAppliedSpecJSON := cr.GetAnnotations()[lastAppliedSpecAnnotationName]
+	lastAppliedSpecJSON := cr.GetAnnotations()[LastAppliedSpecAnnotation]
 	if len(lastAppliedSpecJSON) == 0 {
 		return nil
 	}
 	var dst ST
 	if err := json.Unmarshal([]byte(lastAppliedSpecJSON), &dst); err != nil {
-		return fmt.Errorf("cannot parse last applied spec annotation=%q, remove this annotation manually from object : %w", lastAppliedSpecAnnotationName, err)
+		return fmt.Errorf("cannot parse last applied spec annotation=%q, remove this annotation manually from object : %w", LastAppliedSpecAnnotation, err)
 	}
 	cr.SetLastSpec(dst)
 	return nil
@@ -1048,7 +1048,7 @@ func ParseLastAppliedStateTo[T objectWithLastAppliedState[T, ST], ST any](cr T) 
 
 // HasSpecChanges compares single spec with last applied single spec stored in annotation
 func HasStateChanges(crMeta metav1.ObjectMeta, spec any) (bool, error) {
-	lastAppliedSpecJSON := crMeta.GetAnnotations()[lastAppliedSpecAnnotationName]
+	lastAppliedSpecJSON := crMeta.GetAnnotations()[LastAppliedSpecAnnotation]
 	if len(lastAppliedSpecJSON) == 0 {
 		return true, nil
 	}
@@ -1065,12 +1065,12 @@ func HasStateChanges(crMeta metav1.ObjectMeta, spec any) (bool, error) {
 }
 
 // LastAppliedChangesAsPatch builds patch request from provided spec
-func LastAppliedChangesAsPatch(crMeta metav1.ObjectMeta, spec any) (client.Patch, error) {
+func LastAppliedChangesAsPatch(spec any) (client.Patch, error) {
 	data, err := json.Marshal(spec)
 	if err != nil {
 		return nil, fmt.Errorf("possible bug, cannot serialize single specification as json :%w", err)
 	}
-	patch := fmt.Sprintf(`{"metadata":{"annotations":{%q: %q }}}`, lastAppliedSpecAnnotationName, data)
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{%q: %q }}}`, LastAppliedSpecAnnotation, data)
 	return client.RawPatch(types.MergePatchType, []byte(patch)), nil
 
 }

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -310,7 +310,7 @@ func (cr *VMSingle) AsURL() string {
 
 // LastAppliedSpecAsPatch return last applied single spec as patch annotation
 func (cr *VMSingle) LastAppliedSpecAsPatch() (client.Patch, error) {
-	return LastAppliedChangesAsPatch(cr.ObjectMeta, cr.Spec)
+	return LastAppliedChangesAsPatch(cr.Spec)
 }
 
 // HasSpecChanges compares single spec with last applied single spec stored in annotation

--- a/internal/controller/operator/factory/build/vmservicescrape.go
+++ b/internal/controller/operator/factory/build/vmservicescrape.go
@@ -157,6 +157,7 @@ type podScrapeBuilder interface {
 	ProbePort() string
 	SelectorLabels() map[string]string
 	GetMetricPath() string
+	AsOwner() metav1.OwnerReference
 }
 
 // VMPodScrapeForObjectWithSpec build VMPodScrape for given podScrapeBuilder with provided args
@@ -198,9 +199,10 @@ func VMPodScrapeForObjectWithSpec(psb podScrapeBuilder, serviceScrapeSpec *vmv1b
 	selectorLabels := psb.SelectorLabels()
 	podScrape := &vmv1beta1.VMPodScrape{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      psb.PrefixedName(),
-			Namespace: psb.GetNamespace(),
-			Labels:    selectorLabels,
+			Name:            psb.PrefixedName(),
+			Namespace:       psb.GetNamespace(),
+			Labels:          selectorLabels,
+			OwnerReferences: []metav1.OwnerReference{psb.AsOwner()},
 		},
 		Spec: vmv1beta1.VMPodScrapeSpec{
 			Selector: *metav1.SetAsLabelSelector(selectorLabels),

--- a/internal/controller/operator/factory/reconcile/configmap.go
+++ b/internal/controller/operator/factory/reconcile/configmap.go
@@ -24,6 +24,11 @@ func ConfigMap(ctx context.Context, rclient client.Client, newCM *corev1.ConfigM
 			return rclient.Create(ctx, newCM)
 		}
 	}
+	if !newCM.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for configmap %q to be removed", newCM.Name),
+		}
+	}
 	var prevCM *corev1.ConfigMap
 	if prevCMMEta != nil {
 		prevCM = &corev1.ConfigMap{

--- a/internal/controller/operator/factory/reconcile/rbac.go
+++ b/internal/controller/operator/factory/reconcile/rbac.go
@@ -25,6 +25,11 @@ func RoleBinding(ctx context.Context, rclient client.Client, newRB, prevRB *rbac
 		}
 		return fmt.Errorf("cannot get exist rolebinding: %w", err)
 	}
+	if !newRB.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for rolebinding %q to be removed", newRB.Name),
+		}
+	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &currentRB); err != nil {
 		return err
 	}
@@ -51,6 +56,11 @@ func Role(ctx context.Context, rclient client.Client, newRL, prevRL *rbacv1.Role
 		}
 		return fmt.Errorf("cannot get exist role: %w", err)
 	}
+	if !newRL.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for role %q to be removed", newRL.Name),
+		}
+	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &currentRL); err != nil {
 		return err
 	}
@@ -76,6 +86,11 @@ func ClusterRoleBinding(ctx context.Context, rclient client.Client, newCRB, prev
 			return rclient.Create(ctx, newCRB)
 		}
 		return fmt.Errorf("cannot get crb: %w", err)
+	}
+	if !newCRB.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for clusterrolebinding %q to be removed", newCRB.Name),
+		}
 	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &currentCRB); err != nil {
 		return err
@@ -105,6 +120,11 @@ func ClusterRole(ctx context.Context, rclient client.Client, newClusterRole, pre
 			return rclient.Create(ctx, newClusterRole)
 		}
 		return fmt.Errorf("cannot get exist cluster role: %w", err)
+	}
+	if !newClusterRole.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for clusterrole %q to be removed", newClusterRole.Name),
+		}
 	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &currentClusterRole); err != nil {
 		return err

--- a/internal/controller/operator/factory/reconcile/secret.go
+++ b/internal/controller/operator/factory/reconcile/secret.go
@@ -26,6 +26,11 @@ func Secret(ctx context.Context, rclient client.Client, newS *corev1.Secret, pre
 		}
 		return err
 	}
+	if !newS.DeletionTimestamp.IsZero() {
+		return &errRecreate{
+			origin: fmt.Errorf("waiting for secret %q to be removed", newS.Name),
+		}
+	}
 	if err := finalize.FreeIfNeeded(ctx, rclient, &currentS); err != nil {
 		return err
 	}

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -91,7 +90,7 @@ func updateChildStatusConditions[T any, PT interface {
 		Namespace: childObject.GetNamespace(),
 		Name:      childObject.GetName(),
 	}
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return retryOnConflict(func() error {
 		dst := PT(new(T))
 		if err := rclient.Get(ctx, nsn, dst); err != nil {
 			return err

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -116,5 +116,6 @@ func (r *VLAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -104,5 +104,6 @@ func (r *VLClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -94,5 +94,6 @@ func (r *VLogsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -104,5 +104,6 @@ func (r *VLSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -138,5 +138,6 @@ func (r *VMAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -117,5 +117,6 @@ func (r *VMAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -113,5 +113,6 @@ func (r *VMAlertmanagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -110,5 +110,6 @@ func (r *VMAnomalyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -109,5 +109,6 @@ func (r *VMAuthReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -93,5 +93,6 @@ func (r *VMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -111,5 +111,6 @@ func (r *VMSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -104,5 +104,6 @@ func (r *VTClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -104,5 +104,6 @@ func (r *VTSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).
+		WithEventFilter(patchAnnotationPredicate).
 		Complete(r)
 }


### PR DESCRIPTION
PR contains subset of straightforward changes from https://github.com/VictoriaMetrics/operator/pull/1564 that should be easy to review

- simplify LastAppliedChangesAsPatch signature, object metadata is not needed there
- added predicate to disable reconcile for `operator.victoriametrics/last-applied-spec` annotation change
- add owner reference for vmpodscrape 
- add retryOnConflict function that retries if conflict happens or if resource is being deleted (errRecreate was thrown)
- throw errRecreate for resources that have non-zero deletion timestamp