### PR TITLE
Dockerfile: use UBI 10 as a base, add labels and license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN \
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
+COPY LICENSE .
 ARG ROOT
 ARG BUILDINFO
 ARG FIPS_VERSION
@@ -40,9 +41,16 @@ RUN \
    -o app ${ROOT}/
 
 # Use scratch as minimal base image to package the manager binary
-FROM scratch
+FROM registry.access.redhat.com/ubi10-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/app .
+COPY --from=builder /workspace/LICENSE /licenses/apache2.txt
 USER 65532:65532
+LABEL name="VictoriaMetrics/operator"
+LABEL maintainer="VictoriaMetrics, Inc."
+LABEL vendor="VictoriaMetrics, Inc."
+
+
+
 
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
In order to pass Red Hat certification the operator image has to adhere to the following rules: 
* Needs to be based on RH UBI 
* Include project license in `/licenses` folder in the image 
* Set custom name/maintainer/vendor labels

This commit applies these changes to the operator image. Changing `scratch` to UBI 10 micro (the smallest image available) bumps it size from 89 MB to 114 MB and adds few potentially unwanted binaries there