### PR TITLE
alertmanger: validate mute_time_intervals in subroutes. fixes #1618

### DIFF
--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -1502,6 +1502,11 @@ func checkRouteReceiver(r *SubRoute, receivers map[string]struct{}, tiNames map[
 			return fmt.Errorf("undefined time interval %q used in route", ti)
 		}
 	}
+	for _, ti := range r.MuteTimeIntervals {
+		if _, ok := tiNames[ti]; !ok {
+			return fmt.Errorf("undefined time interval %q used in route", ti)
+		}
+	}
 	if r.Receiver == "" {
 		return nil
 	}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ aliases:
 * FEATURE: [config-reloader](https://github.com/VictoriaMetrics/operator/blob/master/cmd/config-reloader/README.md): set default config reloader image version equal to current operator version. See [#2562](https://github.com/VictoriaMetrics/helm-charts/pull/2562).
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): do not set `promscrape.cluster.membersCount` and `promscrape.cluster.memberNum` flags in ingestOnly mode. See [#1594](https://github.com/VictoriaMetrics/operator/issues/1594).
 
+* BUGFIX: [vmalertmanager](https://docs.victoriametrics.com/operator/resources/vmalertmanager/): check `mute_time_intervals` in subroutes: See [#1618](https://github.com/VictoriaMetrics/operator/issues/1618).
+
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VT apps to [v0.5.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.5.0) version.
 
 ## [v0.65.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.65.0)


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1618