### PR TITLE
vol 3: extracted subset of changes from #1564

### DIFF
--- a/internal/controller/operator/factory/finalize/orphaned.go
+++ b/internal/controller/operator/factory/finalize/orphaned.go
@@ -49,6 +49,15 @@ func RemoveOrphanedPDBs(ctx context.Context, rclient client.Client, cr orphanedC
 	return removeOrphaned(ctx, rclient, cr, gvk, keepNames)
 }
 
+// RemoveOrphanedServices removes Services detached from given object
+func RemoveOrphanedServices(ctx context.Context, rclient client.Client, cr orphanedCRD, keepNames map[string]struct{}) error {
+	gvk := schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "Service",
+	}
+	return removeOrphaned(ctx, rclient, cr, gvk, keepNames)
+}
+
 // removeOrphaned removes orphaned resources
 func removeOrphaned(ctx context.Context, rclient client.Client, cr orphanedCRD, gvk schema.GroupVersionKind, keepNames map[string]struct{}) error {
 	var l unstructured.UnstructuredList

--- a/internal/controller/operator/factory/finalize/vlcluster.go
+++ b/internal/controller/operator/factory/finalize/vlcluster.go
@@ -83,8 +83,9 @@ func OnVLInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace}})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -124,8 +125,9 @@ func OnVLSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLClu
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace}})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -157,9 +159,9 @@ func OnVLStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLCl
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
 	}
-
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -173,7 +175,6 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 		Namespace: cr.Namespace,
 		Name:      commonName,
 	}
-
 	objsToRemove := []client.Object{
 		&appsv1.Deployment{ObjectMeta: objMeta},
 		&corev1.Secret{ObjectMeta: objMeta},
@@ -208,9 +209,9 @@ func OnVLClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			Namespace: cr.Namespace,
 		}})
 	}
-
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove lb object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vmcluster.go
+++ b/internal/controller/operator/factory/finalize/vmcluster.go
@@ -60,8 +60,9 @@ func OnVMInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 			},
 		})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -111,8 +112,9 @@ func OnVMSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 			},
 		})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -145,8 +147,9 @@ func OnVMStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
 	}
 
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -236,9 +239,9 @@ func OnVMClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			Namespace: cr.Namespace,
 		}})
 	}
-
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove lb object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vtcluster.go
+++ b/internal/controller/operator/factory/finalize/vtcluster.go
@@ -84,8 +84,9 @@ func OnVTInsertDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableInsertBalancing {
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace}})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -125,8 +126,9 @@ func OnVTSelectDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTClu
 	if cr.Spec.RequestsLoadBalancer.Enabled && !cr.Spec.RequestsLoadBalancer.DisableSelectBalancing {
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace}})
 	}
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -158,9 +160,9 @@ func OnVTStorageDelete(ctx context.Context, rclient client.Client, cr *vmv1.VTCl
 	if !ptr.Deref(obj.DisableSelfServiceScrape, getCfg().DisableSelfServiceScrapeCreation) {
 		objsToRemove = append(objsToRemove, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta})
 	}
-
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}
@@ -209,9 +211,9 @@ func OnVTClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, c
 			Namespace: cr.Namespace,
 		}})
 	}
-
+	owner := cr.AsOwner()
 	for _, objToRemove := range objsToRemove {
-		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove); err != nil {
+		if err := SafeDeleteWithFinalizer(ctx, rclient, objToRemove, &owner); err != nil {
 			return fmt.Errorf("failed to remove lb object=%s: %w", objToRemove.GetObjectKind().GroupVersionKind(), err)
 		}
 	}

--- a/internal/controller/operator/factory/reconcile/service.go
+++ b/internal/controller/operator/factory/reconcile/service.go
@@ -153,7 +153,7 @@ func reconcileService(ctx context.Context, rclient client.Client, newService, pr
 // by conditionally removing service from previous state
 func AdditionalServices(ctx context.Context, rclient client.Client,
 	defaultName, namespace string,
-	prevSvc, currSvc *vmv1beta1.AdditionalServiceSpec) error {
+	prevSvc, currSvc *vmv1beta1.AdditionalServiceSpec, owner *metav1.OwnerReference) error {
 
 	if currSvc == nil &&
 		prevSvc != nil &&
@@ -162,7 +162,7 @@ func AdditionalServices(ctx context.Context, rclient client.Client,
 		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient,
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      prevSvc.NameOrDefault(defaultName)}}); err != nil {
+				Name:      prevSvc.NameOrDefault(defaultName)}}, owner); err != nil {
 			return fmt.Errorf("cannot remove additional service: %w", err)
 		}
 	}
@@ -176,7 +176,7 @@ func AdditionalServices(ctx context.Context, rclient client.Client,
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient,
 				&corev1.Service{ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
-					Name:      prevSvc.NameOrDefault(defaultName)}}); err != nil {
+					Name:      prevSvc.NameOrDefault(defaultName)}}, owner); err != nil {
 				return fmt.Errorf("cannot remove additional service: %w", err)
 			}
 		}

--- a/internal/controller/operator/factory/vlsingle/vlogs.go
+++ b/internal/controller/operator/factory/vlsingle/vlogs.go
@@ -61,9 +61,9 @@ func CreateOrUpdateVLogs(ctx context.Context, rclient client.Client, cr *vmv1bet
 	if cr.ParsedLastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.ParsedLastAppliedSpec
-	}
-	if err := deleteVLogsPrevStateResources(ctx, cr, rclient); err != nil {
-		return err
+		if err := deleteVLogsPrevStateResources(ctx, rclient, cr); err != nil {
+			return err
+		}
 	}
 	if cr.Spec.Storage != nil && cr.Spec.StorageDataPath == "" {
 		if err := createOrUpdateVLogsPVC(ctx, rclient, cr, prevCR); err != nil {
@@ -316,23 +316,26 @@ func createOrUpdateVLogsService(ctx context.Context, rclient client.Client, cr, 
 	return newService, nil
 }
 
-func deleteVLogsPrevStateResources(ctx context.Context, cr *vmv1beta1.VLogs, rclient client.Client) error {
-	if cr.ParsedLastAppliedSpec == nil {
-		return nil
-	}
-	prevSvc, currSvc := cr.ParsedLastAppliedSpec.ServiceSpec, cr.Spec.ServiceSpec
-	if err := reconcile.AdditionalServices(ctx, rclient, cr.PrefixedName(), cr.Namespace, prevSvc, currSvc); err != nil {
-		return fmt.Errorf("cannot remove additional service: %w", err)
-	}
-
+func deleteVLogsPrevStateResources(ctx context.Context, rclient client.Client, cr *vmv1beta1.VLogs) error {
+	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	cfg := config.MustGetBaseConfig()
 	disableSelfScrape := cfg.DisableSelfServiceScrapeCreation
-	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(cr.ParsedLastAppliedSpec.DisableSelfServiceScrape, disableSelfScrape) {
-		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}); err != nil {
+	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) {
+		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}, &owner); err != nil {
 			return fmt.Errorf("cannot remove serviceScrape: %w", err)
 		}
 	}
-
+	svcName := cr.PrefixedName()
+	keepServices := map[string]struct{}{
+		svcName: {},
+	}
+	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
+		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
+		keepServices[extraSvcName] = struct{}{}
+	}
+	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
+		return fmt.Errorf("cannot remove additional service: %w", err)
+	}
 	return nil
 }

--- a/internal/controller/operator/factory/vlsingle/vlsingle.go
+++ b/internal/controller/operator/factory/vlsingle/vlsingle.go
@@ -65,9 +65,9 @@ func CreateOrUpdate(ctx context.Context, rclient client.Client, cr *vmv1.VLSingl
 	if cr.ParsedLastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.ParsedLastAppliedSpec
-	}
-	if err := deletePrevStateResources(ctx, cr, rclient); err != nil {
-		return err
+		if err := deleteOrphaned(ctx, rclient, cr); err != nil {
+			return err
+		}
 	}
 	if cr.Spec.Storage != nil && cr.Spec.StorageDataPath == "" {
 		if err := createOrUpdatePVC(ctx, rclient, cr, prevCR); err != nil {
@@ -337,22 +337,26 @@ func createOrUpdateService(ctx context.Context, rclient client.Client, cr, prevC
 	return newService, nil
 }
 
-func deletePrevStateResources(ctx context.Context, cr *vmv1.VLSingle, rclient client.Client) error {
-	if cr.ParsedLastAppliedSpec == nil {
-		return nil
-	}
-	prevSvc, currSvc := cr.ParsedLastAppliedSpec.ServiceSpec, cr.Spec.ServiceSpec
-	if err := reconcile.AdditionalServices(ctx, rclient, cr.PrefixedName(), cr.Namespace, prevSvc, currSvc); err != nil {
-		return fmt.Errorf("cannot remove additional service: %w", err)
-	}
-
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1.VLSingle) error {
+	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	cfg := config.MustGetBaseConfig()
 	disableSelfScrape := cfg.DisableSelfServiceScrapeCreation
-	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(cr.ParsedLastAppliedSpec.DisableSelfServiceScrape, disableSelfScrape) {
-		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}); err != nil {
+	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) {
+		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}, &owner); err != nil {
 			return fmt.Errorf("cannot remove serviceScrape: %w", err)
 		}
+	}
+	svcName := cr.PrefixedName()
+	keepServices := map[string]struct{}{
+		svcName: {},
+	}
+	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
+		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
+		keepServices[extraSvcName] = struct{}{}
+	}
+	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
+		return fmt.Errorf("cannot remove additional service: %w", err)
 	}
 
 	return nil

--- a/internal/controller/operator/factory/vmagent/rbac.go
+++ b/internal/controller/operator/factory/vmagent/rbac.go
@@ -162,6 +162,7 @@ func migrateRBAC(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAge
 	const prevNamingPrefix = "monitoring:vmagent-cluster-access-"
 	prevVersionName := prevNamingPrefix + cr.Name
 	currentVersionName := cr.GetClusterRoleName()
+	owner := cr.AsOwner()
 
 	// explicitly set namespace via ObjetMeta for unit tests
 	toMigrateObjects := []client.Object{
@@ -182,7 +183,7 @@ func migrateRBAC(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAge
 			}
 			// update name with prev version formatting
 			obj.SetName(prevVersionName)
-			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, obj); err != nil {
+			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, obj, &owner); err != nil {
 				return fmt.Errorf("cannot safe delete obj : %w", err)
 			}
 		}

--- a/internal/controller/operator/factory/vmalertmanager/alertmanager.go
+++ b/internal/controller/operator/factory/vmalertmanager/alertmanager.go
@@ -40,9 +40,9 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *vmv1beta1.VMAlertmanage
 	if cr.ParsedLastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.ParsedLastAppliedSpec
-	}
-	if err := deletePrevStateResources(ctx, cr, rclient); err != nil {
-		return fmt.Errorf("cannot delete objects from prev state: %w", err)
+		if err := deleteOrphaned(ctx, rclient, cr); err != nil {
+			return fmt.Errorf("cannot delete orphaned resources: %w", err)
+		}
 	}
 	if cr.IsOwnsServiceAccount() {
 		var prevSA *corev1.ServiceAccount
@@ -101,27 +101,32 @@ func CreateOrUpdateAlertManager(ctx context.Context, cr *vmv1beta1.VMAlertmanage
 	return reconcile.HandleSTSUpdate(ctx, rclient, stsOpts, newSts, prevSts)
 }
 
-func deletePrevStateResources(ctx context.Context, cr *vmv1beta1.VMAlertmanager, rclient client.Client) error {
-	if cr.ParsedLastAppliedSpec == nil {
-		return nil
-	}
-	prevSvc, currSvc := cr.ParsedLastAppliedSpec.ServiceSpec, cr.Spec.ServiceSpec
-	if err := reconcile.AdditionalServices(ctx, rclient, cr.PrefixedName(), cr.Namespace, prevSvc, currSvc); err != nil {
-		return fmt.Errorf("cannot remove additional service: %w", err)
-	}
-
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlertmanager) error {
+	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
-	if cr.Spec.PodDisruptionBudget == nil && cr.ParsedLastAppliedSpec.PodDisruptionBudget != nil {
-		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta}); err != nil {
+	if cr.Spec.PodDisruptionBudget == nil {
+		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta}, &owner); err != nil {
 			return fmt.Errorf("cannot delete PDB from prev state: %w", err)
 		}
 	}
 	cfg := config.MustGetBaseConfig()
 	disableSelfScrape := cfg.DisableSelfServiceScrapeCreation
-	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(cr.ParsedLastAppliedSpec.DisableSelfServiceScrape, disableSelfScrape) {
-		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}); err != nil {
+	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, disableSelfScrape) {
+		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: objMeta}, &owner); err != nil {
 			return fmt.Errorf("cannot remove serviceScrape: %w", err)
 		}
+	}
+
+	svcName := cr.PrefixedName()
+	keepServices := map[string]struct{}{
+		svcName: {},
+	}
+	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
+		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
+		keepServices[extraSvcName] = struct{}{}
+	}
+	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
+		return fmt.Errorf("cannot remove additional service: %w", err)
 	}
 
 	return nil

--- a/internal/controller/operator/factory/vmanomaly/statefulset.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset.go
@@ -31,9 +31,9 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1.VMAnomaly, rclient client.Clie
 	if cr.ParsedLastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.ParsedLastAppliedSpec
-	}
-	if err := deletePrevStateResources(ctx, rclient, cr, prevCR); err != nil {
-		return fmt.Errorf("cannot delete objects from prev state: %w", err)
+		if err := deleteOrphaned(ctx, rclient, cr); err != nil {
+			return fmt.Errorf("cannot delete orphaned resources: %w", err)
+		}
 	}
 	if cr.IsOwnsServiceAccount() {
 		var prevSA *corev1.ServiceAccount
@@ -159,14 +159,12 @@ func newK8sApp(cr *vmv1.VMAnomaly, configHash string, ac *build.AssetsCache) (*a
 	return app, nil
 }
 
-func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, prevCR *vmv1.VMAnomaly) error {
-	if prevCR == nil {
-		return nil
-	}
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1.VMAnomaly) error {
+	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	cfg := config.MustGetBaseConfig()
 	if ptr.Deref(cr.Spec.DisableSelfServiceScrape, cfg.DisableSelfServiceScrapeCreation) {
-		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMPodScrape{ObjectMeta: objMeta}); err != nil {
+		if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMPodScrape{ObjectMeta: objMeta}, &owner); err != nil {
 			return fmt.Errorf("cannot remove podScrape: %w", err)
 		}
 	}

--- a/internal/controller/operator/factory/vtcluster/cluster.go
+++ b/internal/controller/operator/factory/vtcluster/cluster.go
@@ -80,6 +80,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 	prevLB := prevCR.Spec.RequestsLoadBalancer
 
 	cfg := config.MustGetBaseConfig()
+	owner := cr.AsOwner()
 	disableSelfScrape := cfg.DisableSelfServiceScrapeCreation
 
 	if prevSt != nil {
@@ -91,17 +92,17 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			commonName := cr.PrefixedName(vmv1beta1.ClusterComponentStorage)
 			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: commonName}
 			if vmst.PodDisruptionBudget == nil && prevSt.PodDisruptionBudget != nil {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev storage: %w", err)
 				}
 			}
 			if ptr.Deref(vmst.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(prevSt.DisableSelfServiceScrape, disableSelfScrape) {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove serviceScrape from prev storage: %w", err)
 				}
 			}
 			prevSvc, currSvc := prevSt.ServiceSpec, vmst.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc, &owner); err != nil {
 				return fmt.Errorf("cannot remove storage additional service: %w", err)
 			}
 		}
@@ -119,22 +120,22 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 				Namespace: cr.Namespace, Name: commonName,
 			}
 			if vmse.PodDisruptionBudget == nil && prevSe.PodDisruptionBudget != nil {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev select: %w", err)
 				}
 			}
 			if vmse.HPA == nil && prevSe.HPA != nil {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove HPA from prev select: %w", err)
 				}
 			}
 			if ptr.Deref(vmse.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(prevSe.DisableSelfServiceScrape, disableSelfScrape) {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove serviceScrape from prev select: %w", err)
 				}
 			}
 			prevSvc, currSvc := prevSe.ServiceSpec, vmse.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc, &owner); err != nil {
 				return fmt.Errorf("cannot remove select additional service: %w", err)
 			}
 		}
@@ -145,7 +146,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			if !ptr.Deref(cr.Spec.Select.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Name: commonName, Namespace: cr.Namespace},
-				}); err != nil {
+				}, &owner); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb select svc: %w", err)
 				}
 			}
@@ -156,13 +157,13 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 				Name:      commonInternalName,
 				Namespace: cr.Namespace,
-			}}); err != nil {
+			}}, &owner); err != nil {
 				return fmt.Errorf("cannot remove select lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.Select.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace},
-				}); err != nil {
+				}, &owner); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb select svc: %w", err)
 				}
 			}
@@ -179,22 +180,22 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 		} else {
 			commonObjMeta := metav1.ObjectMeta{Namespace: cr.Namespace, Name: commonName}
 			if vmis.PodDisruptionBudget == nil && prevIs.PodDisruptionBudget != nil {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &policyv1.PodDisruptionBudget{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove PDB from prev insert: %w", err)
 				}
 			}
 			if vmis.HPA == nil && prevIs.HPA != nil {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove HPA from prev insert: %w", err)
 				}
 			}
 			if ptr.Deref(vmis.DisableSelfServiceScrape, disableSelfScrape) && !ptr.Deref(prevIs.DisableSelfServiceScrape, disableSelfScrape) {
-				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}); err != nil {
+				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{ObjectMeta: commonObjMeta}, &owner); err != nil {
 					return fmt.Errorf("cannot remove serviceScrape from prev insert: %w", err)
 				}
 			}
 			prevSvc, currSvc := prevIs.ServiceSpec, vmis.ServiceSpec
-			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc); err != nil {
+			if err := reconcile.AdditionalServices(ctx, rclient, commonName, cr.Namespace, prevSvc, currSvc, &owner); err != nil {
 				return fmt.Errorf("cannot remove insert additional service: %w", err)
 			}
 		}
@@ -205,7 +206,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			if !ptr.Deref(cr.Spec.Insert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Name: commonName, Namespace: cr.Namespace},
-				}); err != nil {
+				}, &owner); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for non-lb insert svc: %w", err)
 				}
 			}
@@ -216,13 +217,13 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 			if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 				Name:      commonInternalName,
 				Namespace: cr.Namespace,
-			}}); err != nil {
+			}}, &owner); err != nil {
 				return fmt.Errorf("cannot remove insert lb service: %w", err)
 			}
 			if !ptr.Deref(cr.Spec.Insert.DisableSelfServiceScrape, disableSelfScrape) {
 				if err := finalize.SafeDeleteWithFinalizer(ctx, rclient, &vmv1beta1.VMServiceScrape{
 					ObjectMeta: metav1.ObjectMeta{Name: commonInternalName, Namespace: cr.Namespace},
-				}); err != nil {
+				}, &owner); err != nil {
 					return fmt.Errorf("cannot delete vmservicescrape for lb insert svc: %w", err)
 				}
 			}
@@ -243,7 +244,7 @@ func deletePrevStateResources(ctx context.Context, rclient client.Client, cr, pr
 					Name:      commonName,
 					Namespace: cr.Namespace,
 				},
-			}); err != nil {
+			}, &owner); err != nil {
 				return fmt.Errorf("cannot delete PodDisruptionBudget for cluster lb: %w", err)
 			}
 		}


### PR DESCRIPTION
extracted another portion of changes from https://github.com/VictoriaMetrics/operator/pull/1564
- removed impact of previous CR state for all non-cluster CRs
- check finalizer and ownerreference during resource removal