### PR TITLE
reconcile: fix status update

### DIFF
--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -421,7 +421,7 @@ func reconcileAndTrackStatus[T client.Object, ST reconcile.StatusWithMetadata[ST
 var patchAnnotationPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
-			return true
+			return false
 		}
 		oldAnnotations := e.ObjectOld.GetAnnotations()
 		newAnnotations := e.ObjectNew.GetAnnotations()

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -211,16 +211,13 @@ func UpdateObjectStatus[T client.Object, ST StatusWithMetadata[STC], STC any](ct
 	}
 
 	currMeta.ObservedGeneration = object.GetGeneration()
-	object.DefaultStatusFields(currentStatus)
-	// if opts.mutateCurrentBeforeCompare != nil {
-	// 	opts.mutateCurrentBeforeCompare(opts.crStatus.(ST))
-	// }
 	// compare before send update request
 	// it reduces load at kubernetes api-server
 	if equality.Semantic.DeepEqual(currentStatus, prevStatus) && currMeta.UpdateStatus == actualStatus {
 		return nil
 	}
 	currMeta.UpdateStatus = newUpdateStatus
+	object.DefaultStatusFields(currentStatus)
 
 	// make a deep copy before passing object to Patch function
 	// it reload state of the object from API server


### PR DESCRIPTION
- align custom predicate with [GenerationChangedPredicate](https://github.com/kubernetes-sigs/controller-runtime/blob/3893e04629c6c4e0dc9639fc5da37c1e7436ae55/pkg/predicate/predicate.go#L213)
- run object.DefaultStatusFields after setting new update status as prev spec should already have valid status and new status may be incomplete if it depends on update status value (see vmsingle and vmcluster CRs)