### PR TITLE
tests: increase amount of characters in output

### DIFF
--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint
 	. "github.com/onsi/gomega"    //nolint
+	"github.com/onsi/gomega/format"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"go.uber.org/zap/zapcore"
@@ -80,6 +81,7 @@ func StopClient() {
 //
 // Must be called once
 func InitOperatorProcess() {
+	format.MaxLength = 50000
 	l := zap.New(zap.WriteTo(GinkgoWriter), zap.Level(zapcore.DebugLevel))
 	logf.SetLogger(l)
 


### PR DESCRIPTION
there's [one issue](https://github.com/VictoriaMetrics/operator/actions/runs/19861052321/job/56910980527), which reproduces from time to time on vmalertmanager, but it's impossible to check full output due to stdout limits. increasing limits to be able to understand a reason, when it happens next time