### PR TITLE
cluster: fixed labels selector for cluster resources removal

### DIFF
--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -36,6 +36,7 @@ const (
 type ClusterComponent string
 
 const (
+	ClusterComponentCommon   ClusterComponent = "common"
 	ClusterComponentRoot     ClusterComponent = "cluster"
 	ClusterComponentInsert   ClusterComponent = "insert"
 	ClusterComponentSelect   ClusterComponent = "select"
@@ -110,16 +111,21 @@ func AddClusterLabels(ls map[string]string, prefix string) map[string]string {
 
 // ClusterSelectorLabels defines selector labels for given cluster component kind
 func ClusterSelectorLabels(kind ClusterComponent, name, prefix string) map[string]string {
-	kindName := string(kind)
-	if kind == ClusterComponentBalancer {
-		kindName = "clusterlb-vmauth-balancer"
-	}
-	return map[string]string{
-		"app.kubernetes.io/name":      prefix + kindName,
+	ls := map[string]string{
 		"app.kubernetes.io/instance":  name,
 		"app.kubernetes.io/component": "monitoring",
 		"managed-by":                  "vm-operator",
 	}
+	if kind == ClusterComponentCommon {
+		return AddClusterLabels(ls, prefix)
+	} else {
+		kindName := string(kind)
+		if kind == ClusterComponentBalancer {
+			kindName = "clusterlb-vmauth-balancer"
+		}
+		ls["app.kubernetes.io/name"] = prefix + kindName
+	}
+	return ls
 }
 
 // ClusterPrefixedName defines prefixed name for given cluster component kind

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): add `app.kubernetes.io/part-of` label to orphaned resources cleaner selector.
+
 ## [v0.66.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.66.0)
 
 **Release date:** 03 December 2025

--- a/internal/controller/operator/factory/finalize/cluster.go
+++ b/internal/controller/operator/factory/finalize/cluster.go
@@ -188,12 +188,7 @@ func (cc *ChildCleaner) KeepScrape(v string) {
 
 // RemoveOrphaned removes cr dependent resources excluding ones, which are defined in cleaner's maps
 func (cc *ChildCleaner) RemoveOrphaned(ctx context.Context, rclient client.Client, cr build.ParentOpts) error {
-	b := build.NewChildBuilder(cr, vmv1beta1.ClusterComponentRoot)
-	ls := b.SelectorLabels()
-
-	// removing label, which may be different for all dependent resources
-	delete(ls, "app.kubernetes.io/name")
-	b.SetSelectorLabels(ls)
+	b := build.NewChildBuilder(cr, vmv1beta1.ClusterComponentCommon)
 	if err := RemoveOrphanedPDBs(ctx, rclient, b, cc.pdbs); err != nil {
 		return fmt.Errorf("cannot remove orphaned PDBs: %w", err)
 	}

--- a/internal/controller/operator/factory/finalize/orphaned.go
+++ b/internal/controller/operator/factory/finalize/orphaned.go
@@ -107,11 +107,11 @@ func removeOrphaned(ctx context.Context, rclient client.Client, cr orphanedCRD, 
 }
 
 func canBeRemoved(o client.Object, owner *metav1.OwnerReference) bool {
-	if owner == nil {
+	if owner == nil || len(o.GetNamespace()) == 0 {
 		return slices.Contains(o.GetFinalizers(), vmv1beta1.FinalizerName)
 	}
 	owners := o.GetOwnerReferences()
-	return slices.Contains(o.GetFinalizers(), vmv1beta1.FinalizerName) || slices.ContainsFunc(owners, func(r metav1.OwnerReference) bool {
+	return slices.ContainsFunc(owners, func(r metav1.OwnerReference) bool {
 		return r.APIVersion == owner.APIVersion && r.Kind == owner.Kind && r.Name == owner.Name
 	})
 }

--- a/internal/controller/operator/factory/finalize/orphaned_test.go
+++ b/internal/controller/operator/factory/finalize/orphaned_test.go
@@ -68,6 +68,10 @@ func TestRemoveOrphanedDeployments(t *testing.T) {
 	// remove 1 orphaned
 	f(opts{
 		cr: &vmv1beta1.VMAgent{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "VMAgent",
+				APIVersion: "v1beta1",
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "base",
 				Namespace: "default",


### PR DESCRIPTION
- during orphaned resources removal check finalizer only if owner reference for dependent resource is not defined or resource is not namespaced
- build proper selector for orphaned cluster resources removal, previously different clusters with same name could remove resources of each other