### PR TITLE
Dockerfile: tweak go-build to support Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ARG GODEBUG_ARGS
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 ENV GOCACHE=/root/.cache/go-build
-RUN --mount=type=cache,target="/root/.cache/go-build"
 RUN \
+  --mount=type=cache,target="/root/.cache/go-build" \
   --mount=type=cache,target=/root/.cache \
   --mount=type=cache,target=/go/pkg/mod \
   CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GODEBUG=${GODEBUG_ARGS} GOFIPS140=${FIPS_VERSION} go build -a \


### PR DESCRIPTION
Podman parser is more strict, as it requires a
single RUN for command. This has no change on Docker builds