### PR TITLE
internal/config/vmanomaly: allow using unversioned UI mode configuration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 ## tip
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): remove orphaned ServiceAccount and RBAC resources. See [#1665](https://github.com/VictoriaMetrics/operator/issues/1665).
+* BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fix configuration parsing when running in [UI mode](https://docs.victoriametrics.com/anomaly-detection/ui/). Previously, configuration required to use `preset: ui:version` instead of `preset: ui`.
 
 ## [v0.66.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.66.0)
 

--- a/internal/controller/operator/factory/vmanomaly/config/config.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config.go
@@ -40,7 +40,7 @@ type settings struct {
 
 func (c *config) override(cr *vmv1.VMAnomaly, ac *build.AssetsCache) error {
 	c.Preset = strings.ToLower(c.Preset)
-	if strings.HasPrefix(c.Preset, "ui:") {
+	if strings.HasPrefix(c.Preset, "ui") {
 		c.Reader = &reader{
 			Class: "noop",
 		}


### PR DESCRIPTION
VMAnomaly allows using `preset: ui` without defining a specific version of the preset (docs - https://docs.victoriametrics.com/anomaly-detection/ui/#preset). Allow using "ui" to generate a noop config automatically.