### PR TITLE
added a single `operator_bad_objects_total` for bad objects managed by VMAgent, VMAuth, VMAlert and VMAlertmanager

### DIFF
--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -1256,7 +1256,8 @@ func (hc *HTTPConfig) validate() error {
 	return nil
 }
 
-func (r *VMAlertmanagerConfig) AsKey() string {
+// AsKey returns unique key for object
+func (r *VMAlertmanagerConfig) AsKey(_ bool) string {
 	return fmt.Sprintf("%s/%s", r.Namespace, r.Name)
 }
 

--- a/api/operator/v1beta1/vmnodescrape_types.go
+++ b/api/operator/v1beta1/vmnodescrape_types.go
@@ -87,6 +87,11 @@ func (cr *VMNodeScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// AsKey returns unique key for object
+func (cr *VMNodeScrape) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 func init() {
 	SchemeBuilder.Register(&VMNodeScrape{}, &VMNodeScrapeList{})
 }

--- a/api/operator/v1beta1/vmpodscrape_types.go
+++ b/api/operator/v1beta1/vmpodscrape_types.go
@@ -142,6 +142,11 @@ func (cr *VMPodScrape) Validate() error {
 	return nil
 }
 
+// AsKey returns unique key for object
+func (cr *VMPodScrape) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 // GetStatusMetadata implements reconcile.objectWithStatus interface
 func (cr *VMPodScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata

--- a/api/operator/v1beta1/vmprobe_types.go
+++ b/api/operator/v1beta1/vmprobe_types.go
@@ -141,6 +141,11 @@ func (cr *VMProbe) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// AsKey returns unique key for object
+func (cr *VMProbe) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 // Validate returns error if CR is invalid
 func (cr *VMProbe) Validate() error {
 	if MustSkipCRValidation(cr) {

--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -144,6 +144,11 @@ func (cr *VMRule) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// AsKey returns unique key for object
+func (cr *VMRule) AsKey(_ bool) string {
+	return fmt.Sprintf("%s-%s.yaml", cr.Namespace, cr.Name)
+}
+
 // Validate performs semantic validation of object
 func (cr *VMRule) Validate() error {
 	if MustSkipCRValidation(cr) {

--- a/api/operator/v1beta1/vmscrapeconfig_types.go
+++ b/api/operator/v1beta1/vmscrapeconfig_types.go
@@ -530,6 +530,11 @@ func (cr *VMScrapeConfig) Validate() error {
 	return cr.Spec.validate()
 }
 
+// AsKey returns unique key for object
+func (cr *VMScrapeConfig) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 // GetStatusMetadata implements reconcile.objectWithStatus interface
 func (cr *VMScrapeConfig) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata

--- a/api/operator/v1beta1/vmservicescrape_types.go
+++ b/api/operator/v1beta1/vmservicescrape_types.go
@@ -164,6 +164,11 @@ func (cr *VMServiceScrape) Validate() error {
 	return nil
 }
 
+// AsKey returns unique key for object
+func (cr *VMServiceScrape) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 // GetStatusMetadata implements reconcile.objectWithStatus interface
 func (cr *VMServiceScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata

--- a/api/operator/v1beta1/vmstaticscrape_types.go
+++ b/api/operator/v1beta1/vmstaticscrape_types.go
@@ -93,6 +93,11 @@ func (cr *VMStaticScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// AsKey returns unique key for object
+func (cr *VMStaticScrape) AsKey(_ bool) string {
+	return cr.Namespace + "/" + cr.Name
+}
+
 func init() {
 	SchemeBuilder.Register(&VMStaticScrape{}, &VMStaticScrapeList{})
 }

--- a/api/operator/v1beta1/vmuser_types_test.go
+++ b/api/operator/v1beta1/vmuser_types_test.go
@@ -18,7 +18,7 @@ func TestVMUser_Validate(t *testing.T) {
 	// invalid auths
 	f(&VMUser{
 		Spec: VMUserSpec{
-			UserName:    ptr.To("user"),
+			Username:    ptr.To("user"),
 			BearerToken: ptr.To("bearer"),
 		},
 	}, true)
@@ -26,7 +26,7 @@ func TestVMUser_Validate(t *testing.T) {
 	// invalid ref
 	f(&VMUser{
 		Spec: VMUserSpec{
-			UserName: ptr.To("some-user"),
+			Username: ptr.To("some-user"),
 			TargetRefs: []TargetRef{
 				{
 					CRD:    &CRDRef{Name: "sm"},
@@ -39,7 +39,7 @@ func TestVMUser_Validate(t *testing.T) {
 	// invalid ref wo targets
 	f(&VMUser{
 		Spec: VMUserSpec{
-			UserName: ptr.To("some-user"),
+			Username: ptr.To("some-user"),
 			TargetRefs: []TargetRef{
 				{
 					Paths: []string{"/some-path"},
@@ -51,7 +51,7 @@ func TestVMUser_Validate(t *testing.T) {
 	// invalid ref crd, bad empty ns
 	f(&VMUser{
 		Spec: VMUserSpec{
-			UserName: ptr.To("some-user"),
+			Username: ptr.To("some-user"),
 			TargetRefs: []TargetRef{
 				{
 					CRD: &CRDRef{
@@ -68,7 +68,7 @@ func TestVMUser_Validate(t *testing.T) {
 	// incorrect password
 	f(&VMUser{
 		Spec: VMUserSpec{
-			UserName: ptr.To("some-user"),
+			Username: ptr.To("some-user"),
 			Password: ptr.To("some-password"),
 			PasswordRef: &corev1.SecretKeySelector{
 				Key: "some-key",

--- a/api/operator/v1beta1/zz_generated.deepcopy.go
+++ b/api/operator/v1beta1/zz_generated.deepcopy.go
@@ -6955,8 +6955,8 @@ func (in *VMUserSpec) DeepCopyInto(out *VMUserSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.UserName != nil {
-		in, out := &in.UserName, &out.UserName
+	if in.Username != nil {
+		in, out := &in.Username, &out.Username
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -41233,7 +41233,7 @@ spec:
                 x-kubernetes-map-type: atomic
               username:
                 description: |-
-                  UserName basic auth user name for accessing protected endpoint,
+                  Username basic auth user name for accessing protected endpoint,
                   will be replaced with metadata.name of VMUser if omitted.
                 type: string
             required:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ aliases:
 
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): support `namespace` parameter in `attach_metadata` section for all scrape configurations. See [#1654](https://github.com/VictoriaMetrics/operator/issues/1654).
 * FEATURE: [vlagent](https://docs.victoriametrics.com/operator/resources/vlagent): support logs collection. See [#1501](https://github.com/VictoriaMetrics/operator/issues/1501).
-* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): add `object_namespace` label to the `operator_alertmanager_bad_objects_count` and `operator_vmalert_bad_objects_count` metrics.
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): use `operator_bad_objects_total` metric with `object_namespace` and `crd` labels to track invalid objects managed by VMAgent, VMAuth, VMAlert and VMAlertmanager. Old `operator_alertmanager_bad_objects_count` and `operator_vmalert_bad_objects_count` are deprecated and will be removed in next releases.
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fixed HPA cleanup logic for all cluster resources, before it was constantly recreated. Bug introduced in [this commit](https://github.com/VictoriaMetrics/operator/commit/983d1678c37497a7d03d2f57821219fd4975deec).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4952,7 +4952,7 @@ Appears in: [VMUser](#vmuser)
 | targetRefs<a href="#vmuserspec-targetrefs" id="vmuserspec-targetrefs">#</a><br/>_[TargetRef](#targetref) array_ | _(Required)_<br/>TargetRefs - reference to endpoints, which user may access. |
 | tlsConfig<a href="#vmuserspec-tlsconfig" id="vmuserspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig defines tls configuration for the backend connection |
 | tokenRef<a href="#vmuserspec-tokenref" id="vmuserspec-tokenref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#secretkeyselector-v1-core)_ | _(Optional)_<br/>TokenRef allows fetching token from user-created secrets by its name and key. |
-| username<a href="#vmuserspec-username" id="vmuserspec-username">#</a><br/>_string_ | _(Optional)_<br/>UserName basic auth user name for accessing protected endpoint,<br />will be replaced with metadata.name of VMUser if omitted. |
+| username<a href="#vmuserspec-username" id="vmuserspec-username">#</a><br/>_string_ | _(Optional)_<br/>Username basic auth user name for accessing protected endpoint,<br />will be replaced with metadata.name of VMUser if omitted. |
 
 
 

--- a/internal/controller/operator/factory/build/child_object.go
+++ b/internal/controller/operator/factory/build/child_object.go
@@ -1,0 +1,172 @@
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
+)
+
+var badObjectsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "operator_bad_objects_total",
+		Help: "Number of incorrect child objects by CRD type and namespace",
+	},
+	[]string{"crd", "object_namespace"},
+)
+
+var badObjectsCountDeprecated = map[string]prometheus.Counter{
+	"vmalertmanagerconfig": prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "operator_alertmanager_bad_objects_count",
+			Help: "Number of child CRDs with bad or incomplete configurations",
+			ConstLabels: prometheus.Labels{
+				"crd": "vmalertmanager_config",
+			},
+		},
+	),
+	"vmrule": prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "operator_vmalert_bad_objects_count",
+			Help: "Number of incorrect objects by controller",
+			ConstLabels: prometheus.Labels{
+				"controller": "vmrules",
+			},
+		},
+	),
+}
+
+func init() {
+	metrics.Registry.MustRegister(badObjectsTotal)
+	for _, m := range badObjectsCountDeprecated {
+		metrics.Registry.MustRegister(m)
+	}
+}
+
+type scrapeObjectWithStatus interface {
+	client.Object
+	GetStatusMetadata() *vmv1beta1.StatusMetadata
+	AsKey(bool) string
+}
+
+// ChildObjects represents collected by parent CR child objects and provides interface for validating them using externally defined callbacks
+// and updating metrics, that represent current status.
+type ChildObjects[T scrapeObjectWithStatus] struct {
+	valid             []T
+	broken            []T
+	brokenByNamespace map[string]int
+	nsn               []string
+	zero              T
+	name              string
+}
+
+// NewChildObjects creates new ChildObject instance
+func NewChildObjects[T scrapeObjectWithStatus](name string, valid []T, nsn []string) *ChildObjects[T] {
+	OrderByKeys(valid, nsn)
+	return &ChildObjects[T]{
+		valid: valid,
+		name:  name,
+		nsn:   nsn,
+	}
+}
+
+// Get returns first valid or broken object with same name and namespace as of t, returns nil if not found
+func (co *ChildObjects[T]) Get(t T) T {
+	for _, o := range co.valid {
+		if o.GetName() == t.GetName() && o.GetNamespace() == t.GetNamespace() {
+			return o
+		}
+	}
+	for _, o := range co.broken {
+		if o.GetName() == t.GetName() && o.GetNamespace() == t.GetNamespace() {
+			return o
+		}
+	}
+	return co.zero
+}
+
+// Broken returns slice of broken objects
+func (co *ChildObjects[T]) Broken() []T {
+	return co.broken
+}
+
+// All returns slice of valid and broken objects
+func (co *ChildObjects[T]) All() []T {
+	return append(co.valid, co.broken...)
+}
+
+// UpdateMetrics updates internal metrics depending on current ChildObjects instance state
+func (co *ChildObjects[T]) UpdateMetrics(ctx context.Context) {
+	logger.SelectedObjects(ctx, co.name, len(co.nsn), len(co.broken), co.nsn)
+	m, hasDeprecatedMetric := badObjectsCountDeprecated[co.name]
+	var total int
+	for ns, cnt := range co.brokenByNamespace {
+		if hasDeprecatedMetric {
+			total += cnt
+		}
+		badObjectsTotal.WithLabelValues(co.name, ns).Add(float64(cnt))
+	}
+	if hasDeprecatedMetric {
+		m.Add(float64(total))
+	}
+}
+
+// ForEachCollectSkipInvalid iterates over all valid objects applying validate to each of them
+// object is added to broken slice of validation failed, but it doesn't break a loop
+func (co *ChildObjects[T]) ForEachCollectSkipInvalid(validate func(s T) error) {
+	if err := co.forEachCollectSkipOn(validate, func(_ error) bool { return true }); err != nil {
+		panic(fmt.Sprintf("BUG: unexpected error: %s", err))
+	}
+}
+
+// ForEachCollectSkipNotFound iterates over all valid objects applying validate to each of them
+// object is added to broken slice of validation failed and breaks a loop if error type is not NotFound
+func (co *ChildObjects[T]) ForEachCollectSkipNotFound(validate func(s T) error) error {
+	return co.forEachCollectSkipOn(validate, IsNotFound)
+}
+
+func (co *ChildObjects[T]) setErrorStatus(v T, err error) {
+	st := v.GetStatusMetadata()
+	st.CurrentSyncError = err.Error()
+	co.broken = append(co.broken, v)
+	if co.brokenByNamespace == nil {
+		co.brokenByNamespace = make(map[string]int)
+	}
+	co.brokenByNamespace[v.GetNamespace()]++
+}
+
+func (co *ChildObjects[T]) forEachCollectSkipOn(apply func(s T) error, shouldIgnoreError func(error) bool) error {
+	valid := co.valid[:0]
+	uniqIds := make(map[string]int)
+	for _, o := range co.valid {
+		if err := apply(o); err != nil {
+			if !shouldIgnoreError(err) {
+				return err
+			}
+			co.setErrorStatus(o, err)
+			continue
+		}
+		key := o.AsKey(false)
+		idx, ok := uniqIds[key]
+		if !ok {
+			idx = len(valid)
+			valid = append(valid, o)
+			uniqIds[key] = idx
+			continue
+		}
+		item := valid[idx]
+		if item.GetCreationTimestamp().After(o.GetCreationTimestamp().Time) {
+			item, o = o, item
+			valid[idx] = o
+		}
+		err := fmt.Errorf("%s=%s has duplicate id with %s=%s", co.name, o.AsKey(true), co.name, item.AsKey(true))
+		co.setErrorStatus(o, err)
+	}
+	co.valid = valid
+	return nil
+}

--- a/internal/controller/operator/factory/vmagent/collect_scrapes_test.go
+++ b/internal/controller/operator/factory/vmagent/collect_scrapes_test.go
@@ -55,7 +55,7 @@ func TestSelectServiceMonitors(t *testing.T) {
 	f := func(o opts) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
-		got, err := selectServiceScrapes(context.TODO(), o.cr, fclient)
+		got, _, err := selectServiceScrapes(context.TODO(), o.cr, fclient)
 		if err != nil {
 			t.Errorf("SelectServiceScrapes() error = %v", err)
 			return
@@ -267,7 +267,7 @@ func TestSelectPodMonitors(t *testing.T) {
 	}
 	f := func(o opts) {
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
-		got, err := selectPodScrapes(context.TODO(), o.cr, fclient)
+		got, _, err := selectPodScrapes(context.TODO(), o.cr, fclient)
 		if err != nil {
 			t.Errorf("SelectPodScrapes() error = %v", err)
 			return
@@ -341,7 +341,7 @@ func TestSelectPodMonitors(t *testing.T) {
 	})
 }
 
-func TestSelectVMProbes(t *testing.T) {
+func TestSelectProbes(t *testing.T) {
 	type opts struct {
 		cr                *vmv1beta1.VMAgent
 		want              []string
@@ -351,9 +351,9 @@ func TestSelectVMProbes(t *testing.T) {
 	f := func(o opts) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
-		got, err := selectVMProbes(context.TODO(), o.cr, fclient)
+		got, _, err := selectProbes(context.TODO(), o.cr, fclient)
 		if err != nil {
-			t.Errorf("SelectVMProbes() error = %v", err)
+			t.Errorf("SelectProbes() error = %v", err)
 			return
 		}
 		var result []string
@@ -362,7 +362,7 @@ func TestSelectVMProbes(t *testing.T) {
 		}
 		sort.Strings(result)
 		if !reflect.DeepEqual(result, o.want) {
-			t.Errorf("SelectVMProbes(): %s", cmp.Diff(got, o.want))
+			t.Errorf("SelectProbes(): %s", cmp.Diff(got, o.want))
 		}
 	}
 

--- a/internal/controller/operator/factory/vmagent/nodescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape_test.go
@@ -27,7 +27,7 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generateNodeScrapeConfig(ctx, o.cr, o.sc, nil, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generateNodeScrapeConfig(ctx, o.cr, o.sc, ac)
 		if err != nil {
 			t.Errorf("cannot generate NodeScrapeConfig, err: %e", err)
 			return

--- a/internal/controller/operator/factory/vmagent/podscrape.go
+++ b/internal/controller/operator/factory/vmagent/podscrape.go
@@ -16,10 +16,11 @@ func generatePodScrapeConfig(
 	sc *vmv1beta1.VMPodScrape,
 	ep vmv1beta1.PodMetricsEndpoint,
 	i int,
-	apiserverConfig *vmv1beta1.APIServerConfig,
 	ac *build.AssetsCache,
-	se vmv1beta1.VMAgentSecurityEnforcements,
 ) (yaml.MapSlice, error) {
+	spec := &sc.Spec
+	apiserverConfig := cr.Spec.APIServerConfig
+	se := cr.Spec.VMAgentSecurityEnforcements
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
@@ -27,25 +28,25 @@ func generatePodScrapeConfig(
 		},
 	}
 
-	scrapeClass := getScrapeClass(sc.Spec.ScrapeClassName, cr)
+	scrapeClass := getScrapeClass(spec.ScrapeClassName, cr)
 	if scrapeClass != nil {
-		mergeEndPointAuthWithScrapeClass(&ep.EndpointAuth, scrapeClass)
+		mergeEndpointAuthWithScrapeClass(&ep.EndpointAuth, scrapeClass)
 		mergeEndpointRelabelingsWithScrapeClass(&ep.EndpointRelabelings, scrapeClass)
 		mergeAttachMetadataWithScrapeClass(&ep.AttachMetadata, scrapeClass)
 	}
 
-	selectedNamespaces := getNamespacesFromNamespaceSelector(&sc.Spec.NamespaceSelector, sc.Namespace, se.IgnoreNamespaceSelectors)
+	selectedNamespaces := getNamespacesFromNamespaceSelector(&spec.NamespaceSelector, sc.Namespace, se.IgnoreNamespaceSelectors)
 	if ep.AttachMetadata.Node == nil && sc.Spec.AttachMetadata.Node != nil {
-		ep.AttachMetadata.Node = sc.Spec.AttachMetadata.Node
+		ep.AttachMetadata.Node = spec.AttachMetadata.Node
 	}
-	if ep.AttachMetadata.Namespace == nil && sc.Spec.AttachMetadata.Namespace != nil {
-		ep.AttachMetadata.Namespace = sc.Spec.AttachMetadata.Namespace
+	if ep.AttachMetadata.Namespace == nil && spec.AttachMetadata.Namespace != nil {
+		ep.AttachMetadata.Namespace = spec.AttachMetadata.Namespace
 	}
 
 	k8sSDOpts := generateK8SSDConfigOptions{
 		namespaces:         selectedNamespaces,
 		shouldAddSelectors: cr.Spec.EnableKubernetesAPISelectors,
-		selectors:          sc.Spec.Selector,
+		selectors:          spec.Selector,
 		apiServerConfig:    apiserverConfig,
 		role:               k8sSDRolePod,
 		attachMetadata:     &ep.AttachMetadata,
@@ -62,10 +63,10 @@ func generatePodScrapeConfig(
 
 	// set defaults
 	if ep.SampleLimit == 0 {
-		ep.SampleLimit = sc.Spec.SampleLimit
+		ep.SampleLimit = spec.SampleLimit
 	}
 	if ep.SeriesLimit == 0 {
-		ep.SeriesLimit = sc.Spec.SeriesLimit
+		ep.SeriesLimit = spec.SeriesLimit
 	}
 
 	setScrapeIntervalToWithLimit(ctx, &ep.EndpointScrapeParams, cr)
@@ -83,7 +84,7 @@ func generatePodScrapeConfig(
 	}
 
 	skipRelabelSelectors := cr.Spec.EnableKubernetesAPISelectors
-	relabelings = addSelectorToRelabelingFor(relabelings, "pod", sc.Spec.Selector, skipRelabelSelectors)
+	relabelings = addSelectorToRelabelingFor(relabelings, "pod", spec.Selector, skipRelabelSelectors)
 
 	// Filter targets based on correct port for the endpoint.
 	switch {
@@ -133,7 +134,7 @@ func generatePodScrapeConfig(
 	}...)
 
 	// Relabel targetLabels from Pod onto target.
-	for _, l := range sc.Spec.PodTargetLabels {
+	for _, l := range spec.PodTargetLabels {
 		relabelings = append(relabelings, yaml.MapSlice{
 			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(l)}},
 			{Key: "target_label", Value: sanitizeLabelName(l)},
@@ -152,9 +153,9 @@ func generatePodScrapeConfig(
 		{Key: "target_label", Value: "job"},
 		{Key: "replacement", Value: fmt.Sprintf("%s/%s", sc.GetNamespace(), sc.GetName())},
 	})
-	if sc.Spec.JobLabel != "" {
+	if spec.JobLabel != "" {
 		relabelings = append(relabelings, yaml.MapSlice{
-			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(sc.Spec.JobLabel)}},
+			{Key: "source_labels", Value: []string{"__meta_kubernetes_pod_label_" + sanitizeLabelName(spec.JobLabel)}},
 			{Key: "target_label", Value: "job"},
 			{Key: "regex", Value: "(.+)"},
 			{Key: "replacement", Value: "${1}"},

--- a/internal/controller/operator/factory/vmagent/podscrape_test.go
+++ b/internal/controller/operator/factory/vmagent/podscrape_test.go
@@ -26,7 +26,7 @@ func Test_generatePodScrapeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(nil)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generatePodScrapeConfig(ctx, o.cr, o.sc, o.ep, 0, nil, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generatePodScrapeConfig(ctx, o.cr, o.sc, o.ep, 0, ac)
 		if err != nil {
 			t.Errorf("cannot generate PodScrapeConfig, err: %e", err)
 			return

--- a/internal/controller/operator/factory/vmagent/probe_test.go
+++ b/internal/controller/operator/factory/vmagent/probe_test.go
@@ -28,7 +28,7 @@ func Test_generateProbeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generateProbeConfig(ctx, o.cr, o.sc, 0, nil, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generateProbeConfig(ctx, o.cr, o.sc, ac)
 		if err != nil {
 			t.Errorf("cannot generate ProbeConfig, err: %e", err)
 			return
@@ -69,7 +69,7 @@ func Test_generateProbeConfig(t *testing.T) {
 				},
 			},
 		},
-		want: `job_name: probe/default/static-probe/0
+		want: `job_name: probe/default/static-probe
 honor_labels: false
 metrics_path: /probe2
 params:
@@ -124,7 +124,7 @@ relabel_configs:
 				},
 			},
 		},
-		want: `job_name: probe/monitor/probe-ingress/0
+		want: `job_name: probe/monitor/probe-ingress
 honor_labels: false
 metrics_path: /probe
 params:
@@ -233,7 +233,7 @@ relabel_configs:
 				},
 			},
 		},
-		want: `job_name: probe/default/static-probe/0
+		want: `job_name: probe/default/static-probe
 honor_labels: false
 scrape_interval: 10s
 scrape_timeout: 15s
@@ -327,7 +327,7 @@ basic_auth:
 				},
 			},
 		},
-		want: `job_name: probe/monitor/probe-ingress/0
+		want: `job_name: probe/monitor/probe-ingress
 honor_labels: false
 metrics_path: /probe
 params:

--- a/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/scrapeconfig_test.go
@@ -29,7 +29,7 @@ func TestGenerateScrapeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generateScrapeConfig(ctx, o.cr, o.sc, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generateScrapeConfig(ctx, o.cr, o.sc, ac)
 		if err != nil {
 			t.Errorf("cannot execute generateScrapeConfig, err: %e", err)
 			return

--- a/internal/controller/operator/factory/vmagent/servicescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/servicescrape_test.go
@@ -29,7 +29,7 @@ func Test_generateServiceScrapeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generateServiceScrapeConfig(ctx, o.cr, o.sc, o.sc.Spec.Endpoints[0], 0, o.cr.Spec.APIServerConfig, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generateServiceScrapeConfig(ctx, o.cr, o.sc, o.sc.Spec.Endpoints[0], 0, ac)
 		if err != nil {
 			t.Errorf("cannot generate ServiceScrapeConfig, err: %e", err)
 			return

--- a/internal/controller/operator/factory/vmagent/staticscrape.go
+++ b/internal/controller/operator/factory/vmagent/staticscrape.go
@@ -17,8 +17,9 @@ func generateStaticScrapeConfig(
 	ep *vmv1beta1.TargetEndpoint,
 	i int,
 	ac *build.AssetsCache,
-	se vmv1beta1.VMAgentSecurityEnforcements,
 ) (yaml.MapSlice, error) {
+	spec := &sc.Spec
+	se := cr.Spec.VMAgentSecurityEnforcements
 	cfg := yaml.MapSlice{
 		{
 			Key:   "job_name",
@@ -26,9 +27,9 @@ func generateStaticScrapeConfig(
 		},
 	}
 
-	scrapeClass := getScrapeClass(sc.Spec.ScrapeClassName, cr)
+	scrapeClass := getScrapeClass(spec.ScrapeClassName, cr)
 	if scrapeClass != nil {
-		mergeEndPointAuthWithScrapeClass(&ep.EndpointAuth, scrapeClass)
+		mergeEndpointAuthWithScrapeClass(&ep.EndpointAuth, scrapeClass)
 		mergeEndpointRelabelingsWithScrapeClass(&ep.EndpointRelabelings, scrapeClass)
 	}
 
@@ -41,10 +42,10 @@ func generateStaticScrapeConfig(
 
 	// set defaults
 	if ep.SampleLimit == 0 {
-		ep.SampleLimit = sc.Spec.SampleLimit
+		ep.SampleLimit = spec.SampleLimit
 	}
 	if ep.SeriesLimit == 0 {
-		ep.SeriesLimit = sc.Spec.SeriesLimit
+		ep.SeriesLimit = spec.SeriesLimit
 	}
 	if ep.ScrapeTimeout == "" {
 		ep.ScrapeTimeout = cr.Spec.ScrapeTimeout
@@ -55,10 +56,10 @@ func generateStaticScrapeConfig(
 
 	var relabelings []yaml.MapSlice
 
-	if sc.Spec.JobName != "" {
+	if spec.JobName != "" {
 		relabelings = append(relabelings, yaml.MapSlice{
 			{Key: "target_label", Value: "job"},
-			{Key: "replacement", Value: sc.Spec.JobName},
+			{Key: "replacement", Value: spec.JobName},
 		})
 	}
 

--- a/internal/controller/operator/factory/vmagent/staticscrape_test.go
+++ b/internal/controller/operator/factory/vmagent/staticscrape_test.go
@@ -28,7 +28,7 @@ func Test_generateStaticScrapeConfig(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		got, err := generateStaticScrapeConfig(ctx, o.cr, o.sc, o.sc.Spec.TargetEndpoints[0], 0, ac, o.cr.Spec.VMAgentSecurityEnforcements)
+		got, err := generateStaticScrapeConfig(ctx, o.cr, o.sc, o.sc.Spec.TargetEndpoints[0], 0, ac)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
@@ -587,7 +587,7 @@ scrape_configs:
     ca_file: /etc/vmagent-tls/certs/default_access-creds_ca
     cert_file: /etc/vmagent-tls/certs/default_access-creds_cert
     key_file: /etc/vmagent-tls/certs/default_access-creds_key
-- job_name: probe/kube-system/test-vmp/0
+- job_name: probe/kube-system/test-vmp
   honor_labels: false
   metrics_path: /probe
   static_configs:

--- a/internal/controller/operator/factory/vmalert/rules.go
+++ b/internal/controller/operator/factory/vmalert/rules.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -16,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
@@ -25,21 +23,6 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/reconcile"
 )
-
-var badConfigsTotal = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "operator_vmalert_bad_objects_count",
-		Help: "Number of incorrect objects by controller",
-		ConstLabels: prometheus.Labels{
-			"controller": "vmrules",
-		},
-	},
-	[]string{"object_namespace"},
-)
-
-func init() {
-	metrics.Registry.MustRegister(badConfigsTotal)
-}
 
 var (
 	managedByOperatorLabel      = "managed-by"
@@ -171,37 +154,39 @@ func rulesCMDiff(currentCMs []corev1.ConfigMap, newCMs []corev1.ConfigMap) (toCr
 }
 
 func reconcileVMAlertConfig(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlert, childCR *vmv1beta1.VMRule) ([]string, error) {
-	rulesData, vmRules, err := selectRulesContent(ctx, rclient, cr)
+	pos, data, err := selectRules(ctx, rclient, cr)
 	if err != nil {
 		return nil, err
 	}
 	// perform config maps content update
-	ruleCMNames, err := reconcileConfigsData(ctx, rclient, cr, rulesData)
+	cmNames, err := reconcileConfigsData(ctx, rclient, cr, data)
 	if err != nil {
 		return nil, err
 	}
 	parentObject := fmt.Sprintf("%s.%s.vmalert", cr.Name, cr.Namespace)
 	if childCR != nil {
-		for _, rule := range vmRules {
-			if rule.Name == childCR.Name && rule.Namespace == childCR.Namespace {
-				// fast path update a single object that triggered event
-				// it should be fast path for the most cases
-				if err := reconcile.StatusForChildObjects(ctx, rclient, parentObject, []*vmv1beta1.VMRule{rule}); err != nil {
-					return nil, err
-				}
-				return ruleCMNames, nil
+		if o := pos.rules.Get(childCR); o != nil {
+			// fast path update a single object that triggered event
+			// it should be fast path for the most cases
+			if err := reconcile.StatusForChildObjects(ctx, rclient, parentObject, []*vmv1beta1.VMRule{o}); err != nil {
+				return nil, err
 			}
+			return cmNames, nil
 		}
 	}
-	if err := reconcile.StatusForChildObjects(ctx, rclient, parentObject, vmRules); err != nil {
+	if err := reconcile.StatusForChildObjects(ctx, rclient, parentObject, pos.rules.All()); err != nil {
 		return nil, err
 	}
-	return ruleCMNames, nil
+	return cmNames, nil
 }
 
-func selectRulesContent(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlert) (map[string]string, []*vmv1beta1.VMRule, error) {
-	var vmRules []*vmv1beta1.VMRule
-	var namespacedNames []string
+type parsedObjects struct {
+	rules *build.ChildObjects[*vmv1beta1.VMRule]
+}
+
+func selectRules(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlert) (*parsedObjects, map[string]string, error) {
+	var rules []*vmv1beta1.VMRule
+	var nsn []string
 	opts := &k8stools.SelectorOpts{
 		SelectAll:         cr.Spec.SelectAllByDefault,
 		ObjectSelector:    cr.Spec.RuleSelector,
@@ -213,50 +198,33 @@ func selectRulesContent(ctx context.Context, rclient client.Client, cr *vmv1beta
 			if !item.DeletionTimestamp.IsZero() {
 				continue
 			}
-			vmRules = append(vmRules, item.DeepCopy())
-			namespacedNames = append(namespacedNames, fmt.Sprintf("%s/%s", item.Namespace, item.Name))
+			rules = append(rules, item.DeepCopy())
+			nsn = append(nsn, fmt.Sprintf("%s/%s", item.Namespace, item.Name))
 		}
 	}); err != nil {
 		return nil, nil, err
 	}
-
-	rules := make(map[string]string, len(vmRules))
-
 	if cr.NeedDedupRules() {
 		logger.WithContext(ctx).Info("deduplicating vmalert rules")
-		vmRules = deduplicateRules(ctx, vmRules)
+		rules = deduplicateRules(ctx, rules)
 	}
-	var brokenRulesByNamespace map[string]int
-	var brokenRulesTotal int
-	for _, pRule := range vmRules {
+	pos := &parsedObjects{rules: build.NewChildObjects("vmrule", rules, nsn)}
+	data := make(map[string]string)
+	pos.rules.ForEachCollectSkipInvalid(func(rule *vmv1beta1.VMRule) error {
 		if !build.MustSkipRuntimeValidation {
-			if err := pRule.Validate(); err != nil {
-				pRule.Status.CurrentSyncError = err.Error()
-				if brokenRulesByNamespace == nil {
-					brokenRulesByNamespace = map[string]int{}
-				}
-				brokenRulesTotal++
-				brokenRulesByNamespace[pRule.Namespace]++
-				continue
+			if err := rule.Validate(); err != nil {
+				return err
 			}
 		}
-		content, err := generateContent(pRule.Spec, cr.Spec.EnforcedNamespaceLabel, pRule.Namespace)
+		content, err := generateContent(rule.Spec, cr.Spec.EnforcedNamespaceLabel, rule.Namespace)
 		if err != nil {
-			pRule.Status.CurrentSyncError = fmt.Sprintf("cannot generate content for rule: %s, err :%s", pRule.Name, err)
-			if brokenRulesByNamespace == nil {
-				brokenRulesByNamespace = map[string]int{}
-			}
-			brokenRulesTotal++
-			brokenRulesByNamespace[pRule.Namespace]++
-			continue
+			return err
 		}
-		rules[fmt.Sprintf("%s-%s.yaml", pRule.Namespace, pRule.Name)] = content
-	}
-	logger.SelectedObjects(ctx, "VMRules", len(namespacedNames), brokenRulesTotal, namespacedNames)
-	for ns, cnt := range brokenRulesByNamespace {
-		badConfigsTotal.WithLabelValues(ns).Add(float64(cnt))
-	}
-	return rules, vmRules, nil
+		data[rule.AsKey(false)] = content
+		return nil
+	})
+	pos.rules.UpdateMetrics(ctx)
+	return pos, data, nil
 }
 
 func generateContent(promRule vmv1beta1.VMRuleSpec, enforcedNsLabel, ns string) (string, error) {

--- a/internal/controller/operator/factory/vmalert/rules_test.go
+++ b/internal/controller/operator/factory/vmalert/rules_test.go
@@ -27,7 +27,7 @@ func TestSelectRules(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
-		got, _, err := selectRulesContent(ctx, fclient, o.cr)
+		_, got, err := selectRules(ctx, fclient, o.cr)
 		if err != nil {
 			t.Errorf("SelectRules() error = %v", err)
 			return

--- a/internal/controller/operator/factory/vmalertmanager/alertmanager.go
+++ b/internal/controller/operator/factory/vmalertmanager/alertmanager.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -21,20 +19,6 @@ import (
 )
 
 const templatesDir = "/etc/vm/templates"
-
-var badConfigsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name: "operator_alertmanager_bad_objects_count",
-	Help: "Number of child CRDs with bad or incomplete configurations",
-	ConstLabels: prometheus.Labels{
-		"crd": "vmalertmanager_config",
-	},
-},
-	[]string{"object_namespace"},
-)
-
-func init() {
-	metrics.Registry.MustRegister(badConfigsTotal)
-}
 
 // CreateOrUpdateAlertManager creates alertmanager and builds config for it
 func CreateOrUpdateAlertManager(ctx context.Context, cr *vmv1beta1.VMAlertmanager, rclient client.Client) error {

--- a/internal/controller/operator/factory/vmalertmanager/statefulset.go
+++ b/internal/controller/operator/factory/vmalertmanager/statefulset.go
@@ -500,11 +500,11 @@ func CreateOrUpdateConfig(ctx context.Context, rclient client.Client, cr *vmv1be
 		alertmananagerConfig = []byte(cr.Spec.ConfigRawYaml)
 		configSourceName = "inline configuration at configRawYaml"
 	}
-	mergedCfg, err := buildAlertmanagerConfigWithCRDs(ctx, rclient, cr, alertmananagerConfig, ac)
+	pos, data, err := buildAlertmanagerConfigWithCRDs(ctx, rclient, cr, alertmananagerConfig, ac)
 	if err != nil {
 		return fmt.Errorf("cannot build alertmanager config with configSelector, err: %w", err)
 	}
-	alertmananagerConfig = mergedCfg.data
+	alertmananagerConfig = data
 	// apply default config to be able just start alertmanager
 	if len(alertmananagerConfig) == 0 {
 		alertmananagerConfig = []byte(defaultAMConfig)
@@ -535,7 +535,7 @@ func CreateOrUpdateConfig(ctx context.Context, rclient client.Client, cr *vmv1be
 	}
 
 	if err := vmv1beta1.ValidateAlertmanagerConfigSpec(alertmananagerConfig); err != nil {
-		return fmt.Errorf("incorrect result configuration, config source=%s,am cfgs count=%d: %w", configSourceName, len(mergedCfg.amcfgs), err)
+		return fmt.Errorf("incorrect result configuration, config source=%s: %w", configSourceName, err)
 	}
 
 	newAMSecretConfig := &corev1.Secret{
@@ -570,22 +570,12 @@ func CreateOrUpdateConfig(ctx context.Context, rclient client.Client, cr *vmv1be
 
 	if childCR != nil {
 		// fast path update only single object
-		for _, amc := range mergedCfg.amcfgs {
-			if amc.Name == childCR.Name && amc.Namespace == childCR.Namespace {
-				return reconcile.StatusForChildObjects(ctx, rclient, parent, []*vmv1beta1.VMAlertmanagerConfig{amc})
-			}
-		}
-		for _, amc := range mergedCfg.brokenAMCfgs {
-			if amc.Name == childCR.Name && amc.Namespace == childCR.Namespace {
-				return reconcile.StatusForChildObjects(ctx, rclient, parent, []*vmv1beta1.VMAlertmanagerConfig{amc})
-			}
+		if o := pos.configs.Get(childCR); o != nil {
+			return reconcile.StatusForChildObjects(ctx, rclient, parent, []*vmv1beta1.VMAlertmanagerConfig{o})
 		}
 	}
-	if err := reconcile.StatusForChildObjects(ctx, rclient, parent, mergedCfg.amcfgs); err != nil {
+	if err := reconcile.StatusForChildObjects(ctx, rclient, parent, pos.configs.All()); err != nil {
 		return fmt.Errorf("failed to update vmalertmanagerConfigs statuses: %w", err)
-	}
-	if err := reconcile.StatusForChildObjects(ctx, rclient, parent, mergedCfg.brokenAMCfgs); err != nil {
-		return fmt.Errorf("failed to update broken vmalertmanagerConfigs statuses: %w", err)
 	}
 	return nil
 }
@@ -717,10 +707,9 @@ func getSecretContentForAlertmanager(ctx context.Context, rclient client.Client,
 	return nil, fmt.Errorf("cannot find alertmanager config key: %q at secret: %q", alertmanagerSecretConfigKey, secretName)
 }
 
-func buildAlertmanagerConfigWithCRDs(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlertmanager, originConfig []byte, ac *build.AssetsCache) (*parsedConfig, error) {
-	var amCfgs []*vmv1beta1.VMAlertmanagerConfig
-	var badCfgs []*vmv1beta1.VMAlertmanagerConfig
-	var namespacedNames []string
+func buildAlertmanagerConfigWithCRDs(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAlertmanager, originConfig []byte, ac *build.AssetsCache) (*parsedObjects, []byte, error) {
+	var configs []*vmv1beta1.VMAlertmanagerConfig
+	var nsn []string
 	opts := &k8stools.SelectorOpts{
 		SelectAll:         cr.Spec.SelectAllByDefault,
 		ObjectSelector:    cr.Spec.ConfigSelector,
@@ -733,43 +722,19 @@ func buildAlertmanagerConfigWithCRDs(ctx context.Context, rclient client.Client,
 			if !item.DeletionTimestamp.IsZero() {
 				continue
 			}
-			namespacedNames = append(namespacedNames, fmt.Sprintf("%s/%s", item.Namespace, item.Name))
-			item.Status.ObservedGeneration = item.Generation
-			if item.Spec.ParsingError != "" {
-				item.Status.CurrentSyncError = item.Spec.ParsingError
-				badCfgs = append(badCfgs, item)
-				continue
-			}
-			if !build.MustSkipRuntimeValidation {
-				if err := item.Validate(); err != nil {
-					item.Status.CurrentSyncError = err.Error()
-					badCfgs = append(badCfgs, item)
-					continue
-				}
-
-			}
-			amCfgs = append(amCfgs, item)
+			nsn = append(nsn, fmt.Sprintf("%s/%s", item.Namespace, item.Name))
+			configs = append(configs, item.DeepCopy())
 		}
 	}); err != nil {
-		return nil, fmt.Errorf("cannot select alertmanager configs: %w", err)
+		return nil, nil, fmt.Errorf("cannot select alertmanager configs: %w", err)
 	}
-
-	parsedCfg, err := buildConfig(cr, originConfig, amCfgs, ac)
+	pos := &parsedObjects{configs: build.NewChildObjects("vmalertmanagerconfig", configs, nsn)}
+	data, err := pos.buildConfig(cr, originConfig, ac)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	parsedCfg.brokenAMCfgs = append(parsedCfg.brokenAMCfgs, badCfgs...)
-	logger.SelectedObjects(ctx, "VMAlertmanagerConfigs", len(parsedCfg.amcfgs), len(parsedCfg.brokenAMCfgs), namespacedNames)
-	if len(parsedCfg.brokenAMCfgs) > 0 {
-		brokenCfgByNamespace := make(map[string]int)
-		for _, bamc := range parsedCfg.brokenAMCfgs {
-			brokenCfgByNamespace[bamc.Namespace]++
-		}
-		for ns, cnt := range brokenCfgByNamespace {
-			badConfigsTotal.WithLabelValues(ns).Add(float64(cnt))
-		}
-	}
-	return parsedCfg, nil
+	pos.configs.UpdateMetrics(ctx)
+	return pos, data, nil
 }
 
 func subPathForStorage(s *vmv1beta1.StorageSpec) string {

--- a/internal/controller/operator/factory/vmauth/vmauth_test.go
+++ b/internal/controller/operator/factory/vmauth/vmauth_test.go
@@ -168,7 +168,7 @@ func TestCreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: vmv1beta1.VMUserSpec{
-					UserName: ptr.To("user-1"),
+					Username: ptr.To("user-1"),
 					Password: ptr.To("password-1"),
 					TargetRefs: []vmv1beta1.TargetRef{
 						{
@@ -204,7 +204,7 @@ func TestCreateOrUpdate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: vmv1beta1.VMUserSpec{
-					UserName: ptr.To("user-1"),
+					Username: ptr.To("user-1"),
 					Password: ptr.To("password-1"),
 					TargetRefs: []vmv1beta1.TargetRef{
 						{

--- a/test/e2e/childobjects/vmrule_test.go
+++ b/test/e2e/childobjects/vmrule_test.go
@@ -229,8 +229,7 @@ var _ = Describe("test vmrule Controller", Label("vm", "child", "alert"), func()
 						}
 					},
 				},
-			},
-			),
+			}),
 			Entry("by skipping broken vmrules", &opts{
 				alerts: []*vmv1beta1.VMAlert{
 					{

--- a/test/e2e/childobjects/vmuser_test.go
+++ b/test/e2e/childobjects/vmuser_test.go
@@ -104,7 +104,7 @@ var _ = Describe("test vmuser Controller", Label("vm", "child", "auth"), func() 
 							Namespace: namespace,
 						},
 						Spec: vmv1beta1.VMUserSpec{
-							UserName: ptr.To("user"),
+							Username: ptr.To("user"),
 							Password: ptr.To("password-1"),
 							TargetRefs: []vmv1beta1.TargetRef{
 								{
@@ -154,7 +154,7 @@ var _ = Describe("test vmuser Controller", Label("vm", "child", "auth"), func() 
 							Namespace: namespace,
 						},
 						Spec: vmv1beta1.VMUserSpec{
-							UserName: ptr.To("user"),
+							Username: ptr.To("user"),
 							PasswordRef: &corev1.SecretKeySelector{
 								Key: "password",
 								LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
PR built on https://github.com/VictoriaMetrics/operator/pull/1671
unify child objects managenent for VMAgent, VMAuth, VMAlert and VMAlertsmanager