### PR TITLE
fix(docs): correct vlagent example

### DIFF
--- a/docs/resources/vlagent.md
+++ b/docs/resources/vlagent.md
@@ -199,7 +199,7 @@ metadata:
   name: resources-example
 spec:
   remoteWriteSettings:
-    maxDiskUsagePerURL: "1Gi"
+    maxDiskUsagePerURL: "1GiB"
 ```
 
 ## Examples


### PR DESCRIPTION
Minor issue corrected in the docs. Using the `1Gi` prevents the `VLAgent` from being created because it doesn't pass the validation of the operator.