### PR TITLE
fix(docs): correct vlagent image reference

### DIFF
--- a/docs/resources/vlagent.md
+++ b/docs/resources/vlagent.md
@@ -76,8 +76,8 @@ metadata:
   name: example
 spec:
   image:
-    repository: victoriametrics/victoria-logs
-    tag: v1.36.1
+    repository: victoriametrics/vlagent
+    tag: v1.40.0
     pullPolicy: Always
 ```
 
@@ -90,8 +90,8 @@ metadata:
   name: example
 spec:
   image:
-    repository: victoriametrics/victoria-logs
-    tag: v1.36.1
+    repository: victoriametrics/vlagent
+    tag: v1.40.0
     pullPolicy: Always
   imagePullSecrets:
     - name: my-repo-secret


### PR DESCRIPTION
I was pulling the few hairs I have left as to why I couldn't get VLAgent up and running. 
Turns out the image repository in the documentation was not correct. 

With the `victoriametrics/vlagent` repo VLAgent is up & running.