### PR TITLE
cluster: fix infinite cluster load balancer configuration secret reconcile

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): use `operator_bad_objects_total` metric with `object_namespace` and `crd` labels to track invalid objects managed by VMAgent, VMAuth, VMAlert and VMAlertmanager. Old `operator_alertmanager_bad_objects_count` and `operator_vmalert_bad_objects_count` are deprecated and will be removed in next releases.
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fixed HPA cleanup logic for all cluster resources, before it was constantly recreated. Bug introduced in [this commit](https://github.com/VictoriaMetrics/operator/commit/983d1678c37497a7d03d2f57821219fd4975deec).
+* BUGFIX: [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/), [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [VTCluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): prevent cluster load balancer secret from infinite reconcile.
 
 ## [v0.66.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.66.1)
 

--- a/internal/controller/operator/factory/vmalert/vmalert_test.go
+++ b/internal/controller/operator/factory/vmalert/vmalert_test.go
@@ -467,7 +467,7 @@ func TestCreateOrUpdate(t *testing.T) {
 					Name:      "notifier-cfg",
 					Namespace: "default",
 				},
-				StringData: map[string]string{"cfg.yaml": "static: []"},
+				Data: map[string][]byte{"cfg.yaml": []byte("static: []")},
 			},
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Secret's `StringData` is used during creation, but `Data` is used for comparison, it leads to infinite update