### PR TITLE
api/vmagent: add global sample limit

### DIFF
--- a/api/operator/v1beta1/common_scrapeparams.go
+++ b/api/operator/v1beta1/common_scrapeparams.go
@@ -378,6 +378,9 @@ type CommonScrapeParams struct {
 	// +optional
 	// +kubebuilder:validation:Pattern:="[0-9]+(ms|s|m|h)"
 	ScrapeTimeout string `json:"scrapeTimeout,omitempty"`
+	// SampleLimit defines global per target limit of scraped samples
+	// +optional
+	SampleLimit int `json:"sampleLimit,omitempty"`
 	// SelectAllByDefault changes default behavior for empty CRD selectors, such ServiceScrapeSelector.
 	// with selectAllByDefault: true and empty serviceScrapeSelector and ServiceScrapeNamespaceSelector
 	// Operator selects all exist serviceScrapes

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -10410,6 +10410,10 @@ spec:
                   RuntimeClassName - defines runtime class for kubernetes pod.
                   https://kubernetes.io/docs/concepts/containers/runtime-class/
                 type: string
+              sampleLimit:
+                description: SampleLimit defines global per target limit of scraped
+                  samples
+                type: integer
               schedulerName:
                 description: SchedulerName - defines kubernetes scheduler name
                 type: string

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -422,6 +422,13 @@ func generateConfig(
 		{Key: "external_labels", Value: buildExternalLabels(cr)},
 	}
 
+	if cr.Spec.SampleLimit > 0 {
+		globalItems = append(globalItems, yaml.MapItem{
+			Key:   "sample_limit",
+			Value: cr.Spec.SampleLimit,
+		})
+	}
+
 	if cr.Spec.ScrapeTimeout != "" {
 		globalItems = append(globalItems, yaml.MapItem{
 			Key:   "scrape_timeout",


### PR DESCRIPTION
Relates to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10168

The `sampleLimit` defines the maximum number of samples accepted per scrape target, consistent with Prometheus configuration.