### PR TITLE
cluster: use service labels instead of selector in vmservicescrape selector

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fixed HPA cleanup logic for all cluster resources, before it was constantly recreated. Bug introduced in [this commit](https://github.com/VictoriaMetrics/operator/commit/983d1678c37497a7d03d2f57821219fd4975deec).
 * BUGFIX: [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/), [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [VTCluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): prevent cluster load balancer secret from infinite reconcile.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/), [vlsingle](https://docs.victoriametrics.com/operator/resources/vlsingle/) and [vtsingle](https://docs.victoriametrics.com/operator/resources/vtsingle): do not mount emptydir if storage data volume is already present in volumes list. Before it was impossible to mount external PVC without overriding default storageDataPath using `spec.extraArgs` and without having unneeded emptydir listed among pod volumes. Related issues [#1477](https://github.com/VictoriaMetrics/operator/issues/1477).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): use Service labels instead of selector in VMServiceScrape selector. See [#1709](https://github.com/VictoriaMetrics/operator/issues/1709).
 
 ## [v0.66.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.66.1)
 

--- a/internal/controller/operator/factory/build/vmservicescrape.go
+++ b/internal/controller/operator/factory/build/vmservicescrape.go
@@ -143,9 +143,12 @@ func vmServiceScrapeForServiceWithSpec(service *corev1.Service, serviceScrapeSpe
 	// in some cases it may be useful
 	// for instance when additional service created with extra pod ports
 	if scrapeSvc.Spec.Selector.MatchLabels == nil && scrapeSvc.Spec.Selector.MatchExpressions == nil {
-		scrapeSvc.Spec.Selector = metav1.LabelSelector{MatchLabels: service.Spec.Selector, MatchExpressions: []metav1.LabelSelectorRequirement{
-			{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist},
-		}}
+		scrapeSvc.Spec.Selector = metav1.LabelSelector{
+			MatchLabels: service.Labels,
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist},
+			},
+		}
 	}
 
 	return scrapeSvc

--- a/internal/controller/operator/factory/build/vmservicescrape_test.go
+++ b/internal/controller/operator/factory/build/vmservicescrape_test.go
@@ -52,11 +52,9 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 				Labels: map[string]string{"my-label": "value"},
 			},
 			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Name: "http",
-					},
-				},
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+				}},
 			},
 		},
 		spec: testVMServiceScrapeForServiceWithSpecArgs{
@@ -66,15 +64,17 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 			},
 		},
 		wantServiceScrapeSpec: vmv1beta1.VMServiceScrapeSpec{
-			Endpoints: []vmv1beta1.Endpoint{
-				{
-					EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
-						Path: "/metrics",
-					},
-					Port: "http",
+			Endpoints: []vmv1beta1.Endpoint{{
+				EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
+					Path: "/metrics",
+				},
+				Port: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"my-label": "value",
 				},
 			},
-			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"my-label": "value"}},
 		},
 	})
 
@@ -100,15 +100,18 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 			metricPath: "/metrics",
 		},
 		wantServiceScrapeSpec: vmv1beta1.VMServiceScrapeSpec{
-			Endpoints: []vmv1beta1.Endpoint{
-				{
-					EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
-						Path: "/metrics",
-					},
-					Port: "http",
+			Endpoints: []vmv1beta1.Endpoint{{
+				EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
+					Path: "/metrics",
 				},
+				Port: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      vmv1beta1.AdditionalServiceLabel,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
 			},
-			Selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist}}},
 		},
 	})
 
@@ -147,18 +150,21 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 					},
 					Port: "vmbackup",
 					EndpointRelabelings: vmv1beta1.EndpointRelabelings{
-						RelabelConfigs: []*vmv1beta1.RelabelConfig{
-							{
-								SourceLabels: []string{"job"},
-								TargetLabel:  "job",
-								Regex:        vmv1beta1.StringOrArray{"(.+)"},
-								Replacement:  ptr.To("${1}-vmbackup"),
-							},
-						},
+						RelabelConfigs: []*vmv1beta1.RelabelConfig{{
+							SourceLabels: []string{"job"},
+							TargetLabel:  "job",
+							Regex:        vmv1beta1.StringOrArray{"(.+)"},
+							Replacement:  ptr.To("${1}-vmbackup"),
+						}},
 					},
 				},
 			},
-			Selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist}}},
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      vmv1beta1.AdditionalServiceLabel,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			},
 		},
 	})
 
@@ -172,11 +178,9 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Name: "http",
-					},
-				},
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+				}},
 			},
 		},
 		spec: testVMServiceScrapeForServiceWithSpecArgs{
@@ -186,16 +190,22 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 			},
 		},
 		wantServiceScrapeSpec: vmv1beta1.VMServiceScrapeSpec{
-			Endpoints: []vmv1beta1.Endpoint{
-				{
-					EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
-						Path: "/metrics",
-					},
-					Port: "http",
+			Endpoints: []vmv1beta1.Endpoint{{
+				EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
+					Path: "/metrics",
 				},
-			},
+				Port: "http",
+			}},
 			TargetLabels: []string{"key"},
-			Selector:     metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist}}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      vmv1beta1.AdditionalServiceLabel,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			},
 		},
 	})
 
@@ -209,11 +219,9 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Name: "http",
-					},
-				},
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+				}},
 			},
 		},
 		spec: testVMServiceScrapeForServiceWithSpecArgs{
@@ -256,7 +264,15 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 				},
 			},
 			TargetLabels: []string{"key"},
-			Selector:     metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist}}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      vmv1beta1.AdditionalServiceLabel,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
+			},
 		},
 	})
 
@@ -270,11 +286,9 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Name: "http",
-					},
-				},
+				Ports: []corev1.ServicePort{{
+					Name: "http",
+				}},
 			},
 		},
 		spec: testVMServiceScrapeForServiceWithSpecArgs{
@@ -285,18 +299,26 @@ func TestVMServiceScrapeForServiceWithSpec(t *testing.T) {
 			},
 		},
 		wantServiceScrapeSpec: vmv1beta1.VMServiceScrapeSpec{
-			Endpoints: []vmv1beta1.Endpoint{
-				{
-					EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
-						Path:   "/metrics",
-						Params: map[string][]string{"authKey": {"some-access-key"}},
-						Scheme: "https",
-					},
-					EndpointAuth: vmv1beta1.EndpointAuth{TLSConfig: &vmv1beta1.TLSConfig{InsecureSkipVerify: true}},
-					Port:         "http",
+			Endpoints: []vmv1beta1.Endpoint{{
+				EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
+					Path:   "/metrics",
+					Params: map[string][]string{"authKey": {"some-access-key"}},
+					Scheme: "https",
 				},
+				EndpointAuth: vmv1beta1.EndpointAuth{
+					TLSConfig: &vmv1beta1.TLSConfig{InsecureSkipVerify: true},
+				},
+				Port: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      vmv1beta1.AdditionalServiceLabel,
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				}},
 			},
-			Selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: vmv1beta1.AdditionalServiceLabel, Operator: metav1.LabelSelectorOpDoesNotExist}}},
 		},
 	})
 }


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1709