### PR TITLE
k8stools/test_client: store requested objects in test client, not just counters

### DIFF
--- a/internal/controller/operator/factory/reconcile/deploy_test.go
+++ b/internal/controller/operator/factory/reconcile/deploy_test.go
@@ -72,13 +72,13 @@ func TestDeployOk(t *testing.T) {
 			t.Fatalf("failed to create deploy: %s", err)
 		}
 		// expect 1 create
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(dep))
 		// expect 0 update
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("failed to update created deploy: %s", err)
 		}
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(0), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(dep))
+		assert.Equal(t, 0, clientStats.UpdateCalls.Count(dep))
 
 		// expect 1 UpdateCalls
 		reloadDep()
@@ -93,16 +93,16 @@ func TestDeployOk(t *testing.T) {
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("expect 1 failed to update created deploy: %s", err)
 		}
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(dep))
+		assert.Equal(t, 1, clientStats.UpdateCalls.Count(dep))
 
 		// expected still same 1 update
 		reloadDep()
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("expect still 1 failed to update created deploy: %s", err)
 		}
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(dep))
+		assert.Equal(t, 1, clientStats.UpdateCalls.Count(dep))
 
 		// expected 2 updates
 		prevDeploy.Spec.Template.Annotations = dep.Spec.Template.Annotations
@@ -111,8 +111,8 @@ func TestDeployOk(t *testing.T) {
 		if err := Deployment(ctx, rclient, dep, prevDeploy, false); err != nil {
 			t.Fatalf("expect 2 failed to update deploy: %s", err)
 		}
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(2), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(dep))
+		assert.Equal(t, 2, clientStats.UpdateCalls.Count(dep))
 	}
 
 	f(&appsv1.Deployment{

--- a/internal/controller/operator/factory/reconcile/statefulset_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_test.go
@@ -431,12 +431,12 @@ func TestStatefulsetReconcileOk(t *testing.T) {
 		assert.NoErrorf(t, err, "failed to create sts")
 
 		// expect 1 create
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(sts))
 		// expect 0 update
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect 0 update")
 
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(0), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(sts))
+		assert.Equal(t, 0, clientStats.UpdateCalls.Count(sts))
 
 		// expect 1 UpdateCalls
 		reloadSts()
@@ -444,23 +444,23 @@ func TestStatefulsetReconcileOk(t *testing.T) {
 
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect 1 update")
 
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(sts))
+		assert.Equal(t, 1, clientStats.UpdateCalls.Count(sts))
 
 		// expected still same 1 update
 		reloadSts()
 
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect still 1 update")
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(1), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(sts))
+		assert.Equal(t, 1, clientStats.UpdateCalls.Count(sts))
 
 		// expected 2 updates
 		prevSts.Spec.Template.Annotations = sts.Spec.Template.Annotations
 		sts.Spec.Template.Annotations = nil
 
 		assert.NoErrorf(t, HandleSTSUpdate(ctx, rclient, emptyOpts, sts, prevSts), "expect 2 updates")
-		assert.Equal(t, int64(1), clientStats.CreateCalls.Load())
-		assert.Equal(t, int64(2), clientStats.UpdateCalls.Load())
+		assert.Equal(t, 1, clientStats.CreateCalls.Count(sts))
+		assert.Equal(t, 2, clientStats.UpdateCalls.Count(sts))
 	}
 
 	f(&appsv1.StatefulSet{


### PR DESCRIPTION
store requested objects in k8s test client, which are used in https://github.com/VictoriaMetrics/operator/pull/1556 PR