### PR TITLE
vmuser: fixed object key generation

### DIFF
--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -288,7 +288,7 @@ func (cr *VMUser) AsKey(hide bool) string {
 		if cr.Spec.Username != nil {
 			id = "basicAuth:" + hideFn(*cr.Spec.Username)
 		} else {
-			id = "basicAuth:" + hideFn(cr.Name)
+			id = "basicAuth:" + cr.Name
 		}
 		if cr.Spec.Password != nil {
 			id = id + ":" + hideFn(*cr.Spec.Password)


### PR DESCRIPTION
follow up for https://github.com/VictoriaMetrics/operator/pull/1686

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed VMUser key generation to include the namespace and handle bearer token/basic auth consistently. Prevents key collisions and correctly masks sensitive values.

- **Bug Fixes**
  - Prefix keys with namespace to ensure uniqueness.
  - Prefer bearerToken; otherwise use username or fallback to resource name for basicAuth.
  - Append password for basicAuth when present and apply masking via a single helper when hide is true.

<sup>Written for commit d5a7a63610d45ae01e4dc3739d08d3f9cc946279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

