### PR TITLE
fix(vmalertmanager): cluster.peer argument hostnames

### DIFF
--- a/internal/controller/operator/factory/vmalertmanager/statefulset.go
+++ b/internal/controller/operator/factory/vmalertmanager/statefulset.go
@@ -213,10 +213,10 @@ func makeStatefulSetSpec(cr *vmv1beta1.VMAlertmanager) (*appsv1.StatefulSetSpec,
 
 	var clusterPeerDomain string
 	if cr.Spec.ClusterDomainName != "" {
-		clusterPeerDomain = fmt.Sprintf("%s.%s.svc.%s.", cr.PrefixedName(), cr.Namespace, cr.Spec.ClusterDomainName)
+		clusterPeerDomain = fmt.Sprintf("%s.svc.%s.", cr.Namespace, cr.Spec.ClusterDomainName)
 	} else {
 		// The default DNS search path is .svc.<cluster domain>
-		clusterPeerDomain = cr.PrefixedName()
+		clusterPeerDomain = cr.Namespace
 	}
 
 	for i := int32(0); i < ptr.Deref(cr.Spec.ReplicaCount, 0); i++ {


### PR DESCRIPTION
`--cluster-peer` argument values are using `cr.PrefixName()` for the namespace part in the service dns (prefix-name.prefix-name.svc.cluster.local. instead of prefix-name.namespace.svc.cluster.local.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VMAlertmanager --cluster-peer hostnames so peers resolve correctly. The service DNS suffix is now built from the namespace, not the prefixed resource name.

- **Bug Fixes**
  - Build clusterPeerDomain as "namespace.svc.<cluster-domain>" or "namespace" (when no cluster domain), instead of using PrefixedName.
  - Prevents malformed addresses like "prefix-name.namespace.svc.cluster.local." that broke peer discovery.

<sup>Written for commit 5b4a0e9e948df869de6f6887f01d9d12e892eaa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

