### PR TITLE
vmalertmanager: fix cluster.peer dns names and add unit tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ aliases:
 
 ## tip
 
+* FEATURE: [vmalertmanager](https://docs.victoriametrics.com/operator/resources/vmalertmanager/): added namespace to `--cluster.peer` arguments explicitly when `spec.clusterDomainName` is omitted and added unit tests to test this.
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): introduce `VMDistributed` CR, which helps to propagate changes to each zone without affecting global availability. Before distributed setup deployment was multistep manual action. See [#1515](https://github.com/VictoriaMetrics/operator/issues/1515).
 
 ## [v0.67.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.67.0)

--- a/internal/controller/operator/factory/vmalertmanager/statefulset.go
+++ b/internal/controller/operator/factory/vmalertmanager/statefulset.go
@@ -211,12 +211,10 @@ func makeStatefulSetSpec(cr *vmv1beta1.VMAlertmanager) (*appsv1.StatefulSetSpec,
 		amArgs = append(amArgs, fmt.Sprintf("--cluster.advertise-address=%s", cr.Spec.ClusterAdvertiseAddress))
 	}
 
-	var clusterPeerDomain string
+	// clusterPeerDomain consists of service name and namespace
+	clusterPeerDomain := fmt.Sprintf("%s.%s", cr.PrefixedName(), cr.Namespace)
 	if cr.Spec.ClusterDomainName != "" {
-		clusterPeerDomain = fmt.Sprintf("%s.svc.%s.", cr.Namespace, cr.Spec.ClusterDomainName)
-	} else {
-		// The default DNS search path is .svc.<cluster domain>
-		clusterPeerDomain = cr.Namespace
+		clusterPeerDomain = fmt.Sprintf("%s.svc.%s.", clusterPeerDomain, cr.Spec.ClusterDomainName)
 	}
 
 	for i := int32(0); i < ptr.Deref(cr.Spec.ReplicaCount, 0); i++ {


### PR DESCRIPTION
This fixes the bug my previous PR (https://github.com/VictoriaMetrics/operator/pull/1750) introduced and adds some unit test for the cluster.peer arguments.

Let me know if I can make the unit tests better.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect vmalertmanager --cluster.peer DNS names and adds unit tests to lock the behavior. Ensures peers resolve correctly whether clusterDomainName is set or omitted.

- **Bug Fixes**
  - Generate --cluster.peer using PrefixedName and namespace; works for both default search path and custom clusterDomainName.
  - Added unit tests for both cases and updated CHANGELOG.

<sup>Written for commit 6de5d2ea3b1482c64a470d3cee890404dab3c54c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



