### PR TITLE
reconcile/pvc: do not print warning, when target PVC size is smaller,…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ aliases:
 * BUGFIX: [vmalert](https://docs.victoriametrics.com/operator/resources/vmalert/): throw error if no notifiers found. See [#1757](https://github.com/VictoriaMetrics/operator/issues/1757).
 * BUGFIX: [vlagent](https://docs.victoriametrics.com/operator/resources/vlagent/): previously the operator emitted quoted `spec.k8sCollector.{msgField,timeField,ignoreFields,decolorizeFields}` values, which caused vlagent to misparse these fields; now these fields are emitted unquoted so collector settings are applied correctly. See [#1749](https://github.com/VictoriaMetrics/operator/issues/1749).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fixed conflicts for `VMAlert`, `VMAlertmanager` and `VMAuth` reconcilers, which are updating same objects concurrently with reconcilers for their child objects.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): previously PVC downscaling always emitted a warning, which is not expected, while using PVC autoresizer; now warning during attempt to downsize PVC is only emitted if `operator.victoriametrics.com/pvc-allow-volume-expansion: false` is not set. See [#1747](https://github.com/VictoriaMetrics/operator/issues/1747).
 
 ## [v0.67.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.67.0)
 **Release date:** 23 January 2026

--- a/internal/controller/operator/factory/reconcile/pvc.go
+++ b/internal/controller/operator/factory/reconcile/pvc.go
@@ -5,13 +5,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
 )
 
@@ -40,40 +37,6 @@ func PersistentVolumeClaim(ctx context.Context, rclient client.Client, newPVC, p
 			" To fix this, make backup for this pvc, delete pvc finalizers and restore from backup.")
 		return nil
 	}
-	newSize := newPVC.Spec.Resources.Requests.Storage()
-	oldSize := currentPVC.Spec.Resources.Requests.Storage()
 
-	isResizeNeeded := mayGrow(ctx, newPVC, newSize, oldSize)
-	if !isResizeNeeded &&
-		equality.Semantic.DeepEqual(newPVC.Labels, currentPVC.Labels) &&
-		isObjectMetaEqual(currentPVC, newPVC, prevPVC) {
-		return nil
-	}
-	if isResizeNeeded {
-		// check if storage class is expandable
-		isExpandable, err := isStorageClassExpandable(ctx, rclient, newPVC)
-		if err != nil {
-			return fmt.Errorf("failed to check storageClass expandability for PVC %s: %v", newPVC.Name, err)
-		}
-		if !isExpandable {
-			// don't return error to caller, since there is no point to requeue and reconcile this when sc is unexpandable
-			logger.WithContext(ctx).Info(fmt.Sprintf("storageClass %s for PVC %s doesn't support live resizing", ptr.Deref(newPVC.Spec.StorageClassName, "default"), newPVC.Name))
-			return nil
-		}
-	}
-
-	newResources := newPVC.Spec.Resources.DeepCopy()
-	// keep old spec with new resource requests
-	newPVC.Spec = currentPVC.Spec
-	newPVC.Spec.Resources = *newResources
-
-	vmv1beta1.AddFinalizer(newPVC, currentPVC)
-	mergeObjectMetadataIntoNew(currentPVC, newPVC, prevPVC)
-
-	logger.WithContext(ctx).Info(fmt.Sprintf("updating PVC %s configuration", newPVC.Name))
-
-	if err := rclient.Update(ctx, newPVC); err != nil {
-		return err
-	}
-	return nil
+	return updatePVC(ctx, rclient, currentPVC, newPVC, prevPVC)
 }

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -178,7 +178,7 @@ func HandleSTSUpdate(ctx context.Context, rclient client.Client, cr STSOptions, 
 
 		// check if pvcs need to resize
 		if cr.HasClaim {
-			err = growSTSPVC(ctx, rclient, newSts)
+			err = updateSTSPVC(ctx, rclient, newSts)
 		}
 
 		return err

--- a/internal/controller/operator/vmagent_controller_test.go
+++ b/internal/controller/operator/vmagent_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -142,7 +143,9 @@ func TestVMAgent_Reconcile_AgentSync_Unmanaged(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: vmv1beta1.VMAgentSpec{
-			IngestOnlyMode: true,
+			CommonScrapeParams: vmv1beta1.CommonScrapeParams{
+				IngestOnlyMode: ptr.To(true),
+			},
 		},
 	}
 


### PR DESCRIPTION
… than actual when `operator.victoriametrics.com/pvc-allow-volume-expansion` annotation set to `false`

use single function for updating StatefulSet ClaimTemplates and for PVC reconcile, which now besides expanding storage for StatefulSet PVCs also updates metadata. additionally fixed tests data and added check of PVC update results

fixes https://github.com/VictoriaMetrics/operator/issues/1530
fixes https://github.com/VictoriaMetrics/operator/issues/1747





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress PVC downscale warnings when operator.victoriametrics.com/pvc-allow-volume-expansion=false is set on the claim/template, and ensure PVC metadata (labels/annotations/finalizers) is synced during reconciliation. This reduces noisy logs and fixes #1747 and #1530.

- **Bug Fixes**
  - Skip the downscale warning when operator.victoriametrics.com/pvc-allow-volume-expansion=false.

- **Refactors**
  - Consolidated PVC reconciliation and StatefulSet PVC updates into updatePVC/updateSTSPVC, which also updates PVC metadata.

<sup>Written for commit 8be63f570a0f946c745f800e1d7c8aabdc3ed374. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









