### PR TITLE
fix github link in quick start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -59,7 +59,7 @@ If you are new to metrics and monitoring, we recommend reading the following art
 
 ## Operator
 
-Download the latest [operator release](https://github.com/VictoriaMetrics/operator/latest) from GitHub:
+Download the latest [operator release](https://github.com/VictoriaMetrics/operator/releases/latest) from GitHub:
 ```sh
 export VM_OPERATOR_VERSION=$(basename $(curl -fs -o /dev/null -w %{redirect_url} https://github.com/VictoriaMetrics/operator/releases/latest));
 echo "VM_OPERATOR_VERSION=$VM_OPERATOR_VERSION";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Operator download link in Quick Start to the correct GitHub releases/latest URL. This fixes the broken link and ensures users fetch the latest version with the provided curl command.

<sup>Written for commit ea7107a66fcec2b1f304b19fb3dceffd6102f30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

