### PR TITLE
docs: update examples and documentation after nodes/proxy permission removed

### DIFF
--- a/config/examples/vmnodescrape.yaml
+++ b/config/examples/vmnodescrape.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMNodeScrape
 metadata:
@@ -20,3 +21,25 @@ spec:
     regex: (.+)
     targetLabel: __metrics_path__
     replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmnode-scrape
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vmnode-scrape
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vmnode-scrape
+subjects:
+- kind: ServiceAccount
+  name: vmagent-vmks
+  namespace: vm

--- a/docs/resources/vmnodescrape.md
+++ b/docs/resources/vmnodescrape.md
@@ -80,6 +80,6 @@ roleRef:
   name: vmnode-scrape
 subjects:
 - kind: ServiceAccount
-  name: vmagent-vmks
-  namespace: vm
+  name: <vmagent-service-account>
+  namespace: <vmagent-namespace>
 ```

--- a/docs/resources/vmnodescrape.md
+++ b/docs/resources/vmnodescrape.md
@@ -57,3 +57,29 @@ spec:
       targetLabel: __metrics_path__
       replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
 ```
+
+Note that since 0.68.0 operator no longer ships with `nodes/proxy` permissions, you need to create a `ClusterRole` and `ClusterRoleBinding` for `VMNodeScrape` to work properly:
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmnode-scrape
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vmnode-scrape
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vmnode-scrape
+subjects:
+- kind: ServiceAccount
+  name: vmagent-vmks
+  namespace: vm
+```


### PR DESCRIPTION
`VMNodeScrape` example previously relied on operator having `nodes/proxy` permission - now it needs to be created manually. Update docs and the example to reflect that.

Followup for https://github.com/VictoriaMetrics/operator/pull/1754