### PR TITLE
vmalert: fail on absent notifiers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): introduce `VMDistributed` CR, which helps to propagate changes to each zone without affecting global availability. Before distributed setup deployment was multistep manual action. See [#1515](https://github.com/VictoriaMetrics/operator/issues/1515).
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): previously the operator requested `nodes/proxy` RBAC permissions even though vmagent did not use them; now this permission is no longer required, reducing the default privilege footprint for users running vmagent. See [#1753](https://github.com/VictoriaMetrics/operator/issues/1753).
+* BUGFIX: [vmalert](https://docs.victoriametrics.com/operator/resources/vmalert/): throw error if no notifiers found. See [#1757](https://github.com/VictoriaMetrics/operator/issues/1757).
 
 ## [v0.67.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.67.0)
 **Release date:** 23 January 2026

--- a/internal/controller/operator/factory/vmalert/vmalert.go
+++ b/internal/controller/operator/factory/vmalert/vmalert.go
@@ -652,7 +652,13 @@ func buildNotifiersArgs(cr *vmv1beta1.VMAlert, ac *build.AssetsCache) ([]string,
 		}
 	}
 	if !url.IsSet() {
-		args = append(args, "-notifier.url=")
+		if _, ok := cr.Spec.ExtraArgs["notifier.url"]; ok {
+			return args, nil
+		}
+		if _, ok := cr.Spec.ExtraArgs["notifier.config"]; ok {
+			return args, nil
+		}
+		return nil, fmt.Errorf("no notifiers found, properly configure selectors or static notifiers using spec.notifiers or spec.notifier")
 	}
 	totalCount := len(notifierTargets)
 	args = build.AppendFlagsToArgs(args, totalCount, url, authUser, authPasswordFile)

--- a/internal/controller/operator/factory/vmalert/vmalert_test.go
+++ b/internal/controller/operator/factory/vmalert/vmalert_test.go
@@ -649,6 +649,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		predefinedObjects []runtime.Object
 	}
 	f := func(o opts) {
+		t.Helper()
 		ctx := context.TODO()
 		cl := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		got, err := createOrUpdateService(ctx, cl, o.cr, nil)
@@ -688,6 +689,7 @@ func Test_buildVMAlertArgs(t *testing.T) {
 		want               []string
 	}
 	f := func(o opts) {
+		t.Helper()
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
@@ -713,10 +715,15 @@ func Test_buildVMAlertArgs(t *testing.T) {
 				Datasource: vmv1beta1.VMAlertDatasourceSpec{
 					URL: "http://vmsingle-url",
 				},
+				CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+					ExtraArgs: map[string]string{
+						"notifier.url": "http://test",
+					},
+				},
 			},
 		},
 		ruleConfigMapNames: []string{"first-rule-cm.yaml"},
-		want:               []string{"-datasource.url=http://vmsingle-url", "-httpListenAddr=:", "-notifier.url=", "-rule=\"/etc/vmalert/config/first-rule-cm.yaml/*.yaml\""},
+		want:               []string{"-datasource.url=http://vmsingle-url", "-httpListenAddr=:", "-notifier.url=http://test", "-rule=\"/etc/vmalert/config/first-rule-cm.yaml/*.yaml\""},
 	}
 	f(o)
 
@@ -739,10 +746,15 @@ func Test_buildVMAlertArgs(t *testing.T) {
 						},
 					},
 				},
+				CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+					ExtraArgs: map[string]string{
+						"notifier.url": "http://test",
+					},
+				},
 			},
 		},
 		ruleConfigMapNames: []string{"first-rule-cm.yaml"},
-		want:               []string{"--datasource.headers=x-org-id:one^^x-org-tenant:5", "-datasource.tlsCAFile=/path/to/sa", "-datasource.tlsInsecureSkipVerify=true", "-datasource.tlsKeyFile=/path/to/key", "-datasource.url=http://vmsingle-url", "-httpListenAddr=:", "-notifier.url=", "-rule=\"/etc/vmalert/config/first-rule-cm.yaml/*.yaml\""},
+		want:               []string{"--datasource.headers=x-org-id:one^^x-org-tenant:5", "-datasource.tlsCAFile=/path/to/sa", "-datasource.tlsInsecureSkipVerify=true", "-datasource.tlsKeyFile=/path/to/key", "-datasource.url=http://vmsingle-url", "-httpListenAddr=:", "-notifier.url=http://test", "-rule=\"/etc/vmalert/config/first-rule-cm.yaml/*.yaml\""},
 	}
 	f(o)
 

--- a/test/e2e/childobjects/vmrule_test.go
+++ b/test/e2e/childobjects/vmrule_test.go
@@ -91,6 +91,11 @@ var _ = Describe("test vmrule Controller", Label("vm", "child", "alert"), func()
 							Datasource: vmv1beta1.VMAlertDatasourceSpec{
 								URL: "http://localhost:8428",
 							},
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+								ExtraArgs: map[string]string{
+									"notifier.url": "http://test",
+								},
+							},
 						},
 					},
 				},
@@ -142,6 +147,11 @@ var _ = Describe("test vmrule Controller", Label("vm", "child", "alert"), func()
 							RuleSelector:       metav1.SetAsLabelSelector(map[string]string{"exact-match-label": "value-1"}),
 							Datasource: vmv1beta1.VMAlertDatasourceSpec{
 								URL: "http://localhost:8428",
+							},
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+								ExtraArgs: map[string]string{
+									"notifier.url": "http://test",
+								},
 							},
 						},
 					},
@@ -241,6 +251,11 @@ var _ = Describe("test vmrule Controller", Label("vm", "child", "alert"), func()
 							SelectAllByDefault: true,
 							Datasource: vmv1beta1.VMAlertDatasourceSpec{
 								URL: "http://localhost:8428",
+							},
+							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
+								ExtraArgs: map[string]string{
+									"notifier.url": "http://test",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1757

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
vmalert now returns an error if no notifier targets are found, instead of starting with an empty -notifier.url. This prevents silent misconfigurations; ExtraArgs notifier.url/notifier.config are respected. Fixes #1757.

- **Bug Fixes**
  - Return error when no notifiers are discovered via selectors or static config.
  - Do not append empty -notifier.url; use ExtraArgs notifier.url or notifier.config when provided.
  - Updated tests to reflect new behavior.

- **Migration**
  - Configure notifiers via spec.notifiers/spec.notifier, or set ExtraArgs: notifier.url or notifier.config.
  - Deployments that previously ran without notifiers will now fail until configured.

<sup>Written for commit fa4f4471ad5e0479c67767d08ebfbf5c2cdc3f36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

