### PR TITLE
chore: consistently start log messages with lowercase symbol, add space between colon and error message

### DIFF
--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -146,7 +146,7 @@ func (cr *VMAgent) Validate() error {
 	if cr.Spec.InlineScrapeConfig != "" {
 		var inlineCfg yaml.MapSlice
 		if err := yaml.Unmarshal([]byte(cr.Spec.InlineScrapeConfig), &inlineCfg); err != nil {
-			return fmt.Errorf("bad cr.spec.inlineScrapeConfig it must be valid yaml, err :%w", err)
+			return fmt.Errorf("bad cr.spec.inlineScrapeConfig it must be valid yaml: %w", err)
 		}
 	}
 	if len(cr.Spec.InlineRelabelConfig) > 0 {
@@ -156,11 +156,11 @@ func (cr *VMAgent) Validate() error {
 	}
 	for idx, rw := range cr.Spec.RemoteWrite {
 		if rw.URL == "" {
-			return fmt.Errorf("remoteWrite.url cannot be empty at idx: %d", idx)
+			return fmt.Errorf("remoteWrite[%d].url cannot be empty", idx)
 		}
 		if len(rw.InlineUrlRelabelConfig) > 0 {
 			if err := checkRelabelConfigs(rw.InlineUrlRelabelConfig); err != nil {
-				return fmt.Errorf("bad urlRelabelingConfig at idx: %d, err: %w", idx, err)
+				return fmt.Errorf("bad remoteWrite[%d].urlRelabelingConfig: %w", idx, err)
 			}
 		}
 	}
@@ -179,7 +179,7 @@ func (cr *VMAgent) Validate() error {
 	defaultScrapeClass := false
 	for _, sc := range cr.Spec.ScrapeClasses {
 		if _, ok := scrapeClassNames[sc.Name]; ok {
-			return fmt.Errorf("duplicate scrape class name %q", sc.Name)
+			return fmt.Errorf("duplicated scrapeClass=%q", sc.Name)
 		}
 		if ptr.Deref(sc.Default, false) {
 			if defaultScrapeClass {
@@ -189,17 +189,17 @@ func (cr *VMAgent) Validate() error {
 		}
 		if sc.TLSConfig != nil {
 			if err := sc.TLSConfig.Validate(); err != nil {
-				return fmt.Errorf("incorrect tlsConfig for scrape class %q: %w", sc.Name, err)
+				return fmt.Errorf("incorrect tlsConfig for scrapeClass=%q: %w", sc.Name, err)
 			}
 		}
 		if err := sc.OAuth2.validate(); err != nil {
-			return fmt.Errorf("incorrect oauth2 for scrape class %q: %w", sc.Name, err)
+			return fmt.Errorf("incorrect oauth2 for scrapeClass=%q: %w", sc.Name, err)
 		}
 		if err := sc.Authorization.validate(); err != nil {
-			return fmt.Errorf("incorrect authorization for scrape class %q:: %w", sc.Name, err)
+			return fmt.Errorf("incorrect authorization for scrapeClass=%q: %w", sc.Name, err)
 		}
 		if err := sc.validate(); err != nil {
-			return fmt.Errorf("incorrect relabeling for scrape class %q:: %w", sc.Name, err)
+			return fmt.Errorf("incorrect relabeling for scrapeClass=%q: %w", sc.Name, err)
 		}
 	}
 	return nil

--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -265,7 +265,7 @@ func parseNestedRoutes(src *Route) error {
 		decoder := json.NewDecoder(bytes.NewReader(nestedRoute.Raw))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(&subRoute); err != nil {
-			return fmt.Errorf("cannot parse json value: %s for nested route, err :%w", string(nestedRoute.Raw), err)
+			return fmt.Errorf("cannot parse json value=%s for nested route: %w", string(nestedRoute.Raw), err)
 		}
 		if err := parseNestedRoutes(&subRoute); err != nil {
 			return err

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -1101,7 +1101,7 @@ func HasStateChanges(crMeta metav1.ObjectMeta, spec any) (bool, error) {
 func LastAppliedChangesAsPatch(spec any) (client.Patch, error) {
 	data, err := json.Marshal(spec)
 	if err != nil {
-		return nil, fmt.Errorf("possible bug, cannot serialize single specification as json :%w", err)
+		return nil, fmt.Errorf("possible bug, cannot serialize single specification as json: %w", err)
 	}
 	patch := fmt.Sprintf(`{"metadata":{"annotations":{%q: %q }}}`, LastAppliedSpecAnnotation, data)
 	return client.RawPatch(types.MergePatchType, []byte(patch)), nil

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -251,7 +251,7 @@ func buildStatusPatch(currentStatus any) (client.Patch, error) {
 	}
 	data, err := json.Marshal(ops)
 	if err != nil {
-		return nil, fmt.Errorf("possible bug, cannot serialize patch specification as json :%w", err)
+		return nil, fmt.Errorf("possible bug, cannot serialize patch specification as json: %w", err)
 	}
 
 	return client.RawPatch(types.JSONPatchType, data), nil

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -407,7 +407,7 @@ func generateConfig(
 ) ([]byte, error) {
 	cfg := yaml.MapSlice{}
 	if !config.IsClusterWideAccessAllowed() && cr.IsOwnsServiceAccount() {
-		logger.WithContext(ctx).Info("Setting discovery for the single namespace only." +
+		logger.WithContext(ctx).Info("setting discovery for the single namespace only." +
 			"Since operator launched with set WATCH_NAMESPACE param. " +
 			"Set custom ServiceAccountName property for VMAgent if needed.")
 		cr.Spec.IgnoreNamespaceSelectors = true

--- a/internal/controller/operator/factory/vmalertmanager/config.go
+++ b/internal/controller/operator/factory/vmalertmanager/config.go
@@ -27,7 +27,7 @@ func (pos *parsedObjects) buildConfig(cr *vmv1beta1.VMAlertmanager, baseCfg []by
 	}
 	var baseYAMlCfg alertmanagerConfig
 	if err := yaml.Unmarshal(baseCfg, &baseYAMlCfg); err != nil {
-		return nil, fmt.Errorf("cannot parse base cfg :%w", err)
+		return nil, fmt.Errorf("cannot parse base cfg: %w", err)
 	}
 
 	if baseYAMlCfg.Route == nil {
@@ -123,7 +123,7 @@ func addConfigTemplates(baseCfg []byte, templates []string) ([]byte, error) {
 	}
 	var baseYAMlCfg alertmanagerConfig
 	if err := yaml.Unmarshal(baseCfg, &baseYAMlCfg); err != nil {
-		return nil, fmt.Errorf("cannot parse base cfg :%w", err)
+		return nil, fmt.Errorf("cannot parse base cfg: %w", err)
 	}
 	templatesSetByIdx := make(map[string]int)
 	for idx, v := range baseYAMlCfg.Templates {

--- a/internal/controller/operator/factory/vmauth/vmauth.go
+++ b/internal/controller/operator/factory/vmauth/vmauth.go
@@ -63,7 +63,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMAuth, rclient client.Cl
 	}
 	svc, err := createOrUpdateService(ctx, rclient, cr, prevCR)
 	if err != nil {
-		return fmt.Errorf("cannot create or update vmauth service :%w", err)
+		return fmt.Errorf("cannot create or update vmauth service: %w", err)
 	}
 	if err := createOrUpdateIngress(ctx, rclient, cr); err != nil {
 		return fmt.Errorf("cannot create or update ingress for vmauth: %w", err)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -219,7 +219,7 @@ func RunManager(ctx context.Context) error {
 	flagsAsMetrics(r, managerFlags)
 	config.ConfigAsMetrics(r, baseConfig)
 
-	setupLog.Info("Registering Components.")
+	setupLog.Info("registering Components.")
 	var watchNsCacheByName map[string]cache.Config
 	if len(baseConfig.WatchNamespaces) > 0 {
 		setupLog.Info("operator configured with watching for subset of namespaces, cluster wide access is disabled", "namespaces", strings.Join(baseConfig.WatchNamespaces, ","))

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -1477,7 +1477,7 @@ up{baz="bar"} 123
 						RetentionPeriod: "1",
 						VMStorage: &vmv1beta1.VMStorage{
 							CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
-								ReplicaCount: ptr.To[int32](5),
+								ReplicaCount: ptr.To[int32](4),
 							},
 							PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{
 								Labels: map[string]string{"version": "old"},
@@ -1486,7 +1486,7 @@ up{baz="bar"} 123
 								MaxUnavailable: ptr.To(intstr.FromString("100%")),
 							},
 							PodDisruptionBudget: &vmv1beta1.EmbeddedPodDisruptionBudgetSpec{
-								MinAvailable: ptr.To(intstr.FromInt32(4)),
+								MinAvailable: ptr.To(intstr.FromInt32(3)),
 							},
 						},
 						VMSelect: &vmv1beta1.VMSelect{
@@ -1525,9 +1525,9 @@ up{baz="bar"} 123
 								Namespace: namespace,
 								Name:      cr.PrefixedName(vmv1beta1.ClusterComponentStorage),
 							}, &pdb)
-							Expect(pdb.Status.CurrentHealthy).To(BeNumerically(">=", 4), "at least 4 pods should be healthy during the update")
+							Expect(pdb.Status.CurrentHealthy).To(BeNumerically(">=", 3), "at least 3 pods should be healthy during the update")
 							return podsUpdated
-						}, eventualStatefulsetAppReadyTimeout).Should(BeNumerically("==", 5))
+						}, eventualStatefulsetAppReadyTimeout).Should(BeNumerically("==", 4))
 					},
 				},
 			),


### PR DESCRIPTION
fixed inconsistencies in error and log messages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized logging and error message formatting across the operator for consistency and readability. Messages now start lowercase and use a space before wrapped errors (": %w"); several validation errors were clarified.

- **Refactors**
  - Logging: start messages with lowercase (e.g., component registration, single-namespace discovery note).
  - Errors: replace "err :%w" with ": %w"; improve paths in VMAgent validation (remoteWrite[idx], scrapeClass); unify wording for Alertmanager and patch serialization errors.
  - Tests: update vmcluster e2e to 4 replicas and PDB minAvailable=3; adjust health and readiness expectations.

<sup>Written for commit 1184ff4318a92d7d783b53875caeab0339f592f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

