### PR TITLE
docs: refactor VMNodeScrape config examples

### DIFF
--- a/config/examples/vmnodescrape.yaml
+++ b/config/examples/vmnodescrape.yaml
@@ -11,12 +11,7 @@ spec:
     insecureSkipVerify: true
     caFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  metrics_path: /metrics/cadvisor
   relabelConfigs:
   - action: labelmap
     regex: __meta_kubernetes_node_label_(.+)
-  - targetLabel: __address__
-    replacement: kubernetes.default.svc:443
-  - sourceLabels: [__meta_kubernetes_node_name]
-    regex: (.+)
-    targetLabel: __metrics_path__
-    replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor

--- a/docs/resources/vmnodescrape.md
+++ b/docs/resources/vmnodescrape.md
@@ -47,13 +47,8 @@ spec:
     insecureSkipVerify: true
     caFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  metrics_path: /metrics/cadvisor
   relabelConfigs:
     - action: labelmap
       regex: __meta_kubernetes_node_label_(.+)
-    - targetLabel: __address__
-      replacement: kubernetes.default.svc:443
-    - sourceLabels: [__meta_kubernetes_node_name]
-      regex: (.+)
-      targetLabel: __metrics_path__
-      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
 ```


### PR DESCRIPTION
Use direct `metrics_path` instead of kubelet's proxy endpoint to fetch cAdvisor metrics

Ref: https://github.com/VictoriaMetrics/operator/issues/1753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch VMNodeScrape examples to fetch cAdvisor metrics directly via metrics_path, avoiding the kubelet proxy. This simplifies the config and removes reliance on the Kubernetes API server proxy.

- **Refactors**
  - Set metrics_path: /metrics/cadvisor in examples.
  - Removed relabels for __address__ and __metrics_path__ that used kubernetes.default.svc:443 and /api/v1/nodes/$1/proxy/metrics/cadvisor.

<sup>Written for commit 5bb887c62a2af2218c79f98e8fcfb2b4ac72ffbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

