### PR TITLE
fixed build

### DIFF
--- a/internal/controller/operator/vmagent_controller_test.go
+++ b/internal/controller/operator/vmagent_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -142,7 +143,9 @@ func TestVMAgent_Reconcile_AgentSync_Unmanaged(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: vmv1beta1.VMAgentSpec{
-			IngestOnlyMode: true,
+			CommonScrapeParams: vmv1beta1.CommonScrapeParams{
+				IngestOnlyMode: ptr.To(true),
+			},
 		},
 	}
 


### PR DESCRIPTION
follow up for https://github.com/VictoriaMetrics/operator/commit/b68db5b68ebbfe2c4d810fd17b1b80904faf71b4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated VMAgent controller test to match the new API: IngestOnlyMode now lives under Spec.CommonScrapeParams as a *bool. Added k8s.io/utils/ptr and set IngestOnlyMode via ptr.To(true) to fix the build.

<sup>Written for commit 52a796e772e185517d42467321847bd3f17232b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

