### PR TITLE
vmagent: support both endpointslice and endpointslices roles

### DIFF
--- a/api/operator/v1beta1/vmservicescrape_types.go
+++ b/api/operator/v1beta1/vmservicescrape_types.go
@@ -20,7 +20,7 @@ type VMServiceScrapeSpec struct {
 	// note, that with service setting, you have to use port: "name"
 	// and cannot use targetPort for endpoints.
 	// +optional
-	// +kubebuilder:validation:Enum=endpoints;service;endpointslices
+	// +kubebuilder:validation:Enum=endpoints;service;endpointslices;endpointslice
 	DiscoveryRole string `json:"discoveryRole,omitempty"`
 	// The label to use to retrieve the job name from.
 	// +optional

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -23194,6 +23194,7 @@ spec:
                             - endpoints
                             - service
                             - endpointslices
+                            - endpointslice
                             type: string
                           endpoints:
                             items:
@@ -28981,6 +28982,7 @@ spec:
                 - endpoints
                 - service
                 - endpointslices
+                - endpointslice
                 type: string
               endpoints:
                 items:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fixed conflicts for `VMAlert`, `VMAlertmanager` and `VMAuth` reconcilers, which are updating same objects concurrently with reconcilers for their child objects.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): previously PVC downscaling always emitted a warning, which is not expected, while using PVC autoresizer; now warning during attempt to downsize PVC is only emitted if `operator.victoriametrics.com/pvc-allow-volume-expansion: false` is not set. See [#1747](https://github.com/VictoriaMetrics/operator/issues/1747).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): skip self scrape objects management if respective controller is disabled. See [#1718](https://github.com/VictoriaMetrics/operator/issues/1718).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): support both prometheus-compatible `endpointslice` and old `endpointslices` roles.
 
 ## [v0.67.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.67.0)
 **Release date:** 23 January 2026
@@ -38,6 +39,7 @@ aliases:
 **Update note 5**: VMAgent's, VMAuth's, VMAlert's and VMAlertmanager's spec.configReloaderImageTag is deprecated and will be removed in next releases. Use spec.configReloaderImage instead.
 **Update note 6**: VMAgent's spec.vmAgentExternalLabelName is deprecated and will be removed in next releases. Use spec.externalLabelName instead.
 **Update note 7**: VMAuth's spec.unauthorizedUserAccessSpec.url_prefix and spec.unauthorizedUserAccessSpec.url_map are deprecated and will be removed in next releases. Use spec.unauthorizedUserAccessSpec.targetRef instead.
+**Update note 8**: VMServiceScrape's `endpointslices` role is deprecated and will be removed in 0.70.0. Use `endpointslice` instead.
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.134.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.134.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.43.1](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.43.1).

--- a/docs/resources/vmservicescrape.md
+++ b/docs/resources/vmservicescrape.md
@@ -23,7 +23,7 @@ need to reconfigure.
 It has various options for scraping configuration of target (with basic auth,tls access, by specific port name etc.).
 
 Monitoring configuration is based on `discoveryRole` setting. By default, `endpoints` is used to get objects from kubernetes api.
-It's also possible to use `discoveryRole: service` or `discoveryRole: endpointslices`.
+It's also possible to use `discoveryRole: service` or `discoveryRole: endpointslice`.
 
 `Endpoints` objects are essentially lists of IP addresses.
 Typically, `Endpoints` objects are populated by `Service` object. `Service` object discovers `Pod`s by a label

--- a/internal/controller/operator/factory/vmagent/servicescrape.go
+++ b/internal/controller/operator/factory/vmagent/servicescrape.go
@@ -87,7 +87,7 @@ func generateServiceScrapeConfig(
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_endpoint_port_name"}},
 				{Key: "regex", Value: ep.Port},
 			})
-		case k8sSDRoleEndpointslice:
+		case k8sSDRoleEndpointslice, k8sSDRoleLegacyEndpointslices:
 			relabelings = append(relabelings, yaml.MapSlice{
 				{Key: "action", Value: "keep"},
 				{Key: "source_labels", Value: []string{"__meta_kubernetes_endpointslice_port_name"}},
@@ -120,7 +120,7 @@ func generateServiceScrapeConfig(
 	switch spec.DiscoveryRole {
 	case k8sSDRoleService:
 		// nothing to do, service doesn't have relations with pods.
-	case k8sSDRoleEndpointslice:
+	case k8sSDRoleEndpointslice, k8sSDRoleLegacyEndpointslices:
 		// Relabel namespace and pod and service labels into proper labels.
 		relabelings = append(relabelings, []yaml.MapSlice{
 			{ // Relabel node labels for pre v2.3 meta labels

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig.go
@@ -185,6 +185,9 @@ const (
 	k8sSDRolePod           = "pod"
 	k8sSDRoleIngress       = "ingress"
 	k8sSDRoleNode          = "node"
+
+	// before 0.67.0 endpointslice was called endpointslices. keeping old name for backward compatibility. will be removed in 0.70.0
+	k8sSDRoleLegacyEndpointslices = "endpointslices"
 )
 
 var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
@@ -244,7 +247,7 @@ func addAttachMetadata(dst yaml.MapSlice, am *vmv1beta1.AttachMetadata, role str
 	var items yaml.MapSlice
 	if am.Node != nil && *am.Node {
 		switch role {
-		case k8sSDRolePod, k8sSDRoleEndpoints, k8sSDRoleEndpointslice:
+		case k8sSDRolePod, k8sSDRoleEndpoints, k8sSDRoleEndpointslice, k8sSDRoleLegacyEndpointslices:
 			items = append(items, yaml.MapItem{
 				Key:   "node",
 				Value: true,
@@ -253,7 +256,7 @@ func addAttachMetadata(dst yaml.MapSlice, am *vmv1beta1.AttachMetadata, role str
 	}
 	if am.Namespace != nil && *am.Namespace {
 		switch role {
-		case k8sSDRolePod, k8sSDRoleService, k8sSDRoleEndpoints, k8sSDRoleEndpointslice, k8sSDRoleIngress:
+		case k8sSDRolePod, k8sSDRoleService, k8sSDRoleEndpoints, k8sSDRoleEndpointslice, k8sSDRoleIngress, k8sSDRoleLegacyEndpointslices:
 			items = append(items, yaml.MapItem{
 				Key:   "namespace",
 				Value: true,
@@ -462,7 +465,7 @@ func generateK8SSDConfig(ac *build.AssetsCache, opts generateK8SSDConfigOptions)
 
 		// special case, given roles create additional watchers for
 		// pod and services roles
-		if opts.role == k8sSDRoleEndpoints || opts.role == k8sSDRoleEndpointslice {
+		if opts.role == k8sSDRoleEndpoints || opts.role == k8sSDRoleEndpointslice || opts.role == k8sSDRoleLegacyEndpointslices {
 			for _, role := range []string{k8sSDRolePod, k8sSDRoleService} {
 				selectors = append(selectors, yaml.MapSlice{
 					{


### PR DESCRIPTION
in 0.67.0 updated endpointslices role value to endpointslice relying on official documentation
restoring old value and added warning to help with migration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compatibility by supporting both "endpointslice" and legacy "endpointslices" for VMServiceScrape discoveryRole. Existing configs keep working; using "endpointslices" logs a deprecation warning.

- **Bug Fixes**
  - CRD validation now accepts both values.
  - vmagent config generation treats both roles the same for relabeling, metadata, and watchers.
  - Webhook logs a warning when "endpointslices" is used; changelog updated.

<sup>Written for commit 71a008cb1bec281226922ea01214daac1ead63fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

