### PR TITLE
internal/config: update VM_METRICS_VERSION to release v1.135.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ var (
 	initConf sync.Once
 
 	defaultEnvs = map[string]string{
-		"VM_METRICS_VERSION":  "v1.134.0",
+		"VM_METRICS_VERSION":  "v1.135.0",
 		"VM_LOGS_VERSION":     "v1.44.0",
 		"VM_ANOMALY_VERSION":  "v1.28.5",
 		"VM_TRACES_VERSION":   "v0.7.0",


### PR DESCRIPTION
Changelog: https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md#v11350

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the default VM_METRICS_VERSION from v1.134.0 to v1.135.0 to align with the latest VictoriaMetrics release for this cut. This ensures new fixes and metric changes from v1.135.0 are used by default.

<sup>Written for commit f4361633858061e850fc1f4aeb3b83d29e4a3b56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

