### PR TITLE
fix(docs): release URLs for VictoriaTraces

### DIFF
--- a/docs/resources/vtcluster.md
+++ b/docs/resources/vtcluster.md
@@ -33,7 +33,7 @@ Also, you can check out the [examples](https://docs.victoriametrics.com/operator
 
 ## Version management
 
-To set `VTCluster` version add `spec.clusterVersion` or `spec.COMPONENT.image.tag` name from [releases](https://github.com/VictoriaMetrics/VictoriaMetrics/releases)
+To set `VTCluster` version add `spec.clusterVersion` or `spec.COMPONENT.image.tag` name from [releases](https://github.com/VictoriaMetrics/VictoriaTraces/releases)
 
 ```yaml
 apiVersion: operator.victoriametrics.com/v1

--- a/docs/resources/vtsingle.md
+++ b/docs/resources/vtsingle.md
@@ -39,7 +39,7 @@ Also, you can check out the [examples](https://docs.victoriametrics.com/operator
 
 ## Version management
 
-To set `VTSingle` version add `spec.image.tag` name from [releases](https://github.com/VictoriaMetrics/VictoriaMetrics/releases)
+To set `VTSingle` version add `spec.image.tag` name from [releases](https://github.com/VictoriaMetrics/VictoriaTraces/releases)
 
 ```yaml
 apiVersion: operator.victoriametrics.com/v1


### PR DESCRIPTION
- docs:
  - a tiny fix for `VTSingle` / `VTCluster` docs - URLs in "Version management" section point at the `VictoriaMetrics` repository instead of `VictoriaTraces`, thus the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed wrong release links in the VTSingle and VTCluster docs so they point to VictoriaTraces releases.
This ensures users select the correct image tags in the Version management section.

<sup>Written for commit 18579d9881795f1f94d91affc4ac57be599656b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

