### PR TITLE
feat: support OpenShift 4.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ olm: operator-sdk opm yq docs
 		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.relatedImages = [{"name": "victoriametrics-operator", "image": "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"}, {"name": "victoriametrics-operator", "image": "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"}]' \
 		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
-	$(YQ) -i '.annotations."com.redhat.openshift.versions" = "v4.12-v4.20"' \
+	$(YQ) -i '.annotations."com.redhat.openshift.versions" = "v4.12-v4.21"' \
 		bundle/$(VERSION)/metadata/annotations.yaml
 	$(if $(findstring localhost,$(REGISTRY)), \
 		$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(REGISTRY)/$(ORG)/$(REPO)-bundle:$(TAG) .; \


### PR DESCRIPTION
Update OLM configuration to support OpenShift 4.21

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends operator bundle compatibility to OpenShift 4.21 by updating the OLM annotation com.redhat.openshift.versions to v4.12-v4.21.

<sup>Written for commit 865dcd59449b3df1eaba67eefd2655ca1205ecf5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

