### PR TITLE
vmanomaly: fix pod metrics port in the default VMPodScrape

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): previously PVC downscaling always emitted a warning, which is not expected, while using PVC autoresizer; now warning during attempt to downsize PVC is only emitted if `operator.victoriametrics.com/pvc-allow-volume-expansion: false` is not set. See [#1747](https://github.com/VictoriaMetrics/operator/issues/1747).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): skip self scrape objects management if respective controller is disabled. See [#1718](https://github.com/VictoriaMetrics/operator/issues/1718).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): support both prometheus-compatible `endpointslice` and old `endpointslices` roles.
+* BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fix pod metrics port in the default VMPodScrape.
 
 ## [v0.67.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.67.0)
 **Release date:** 23 January 2026

--- a/internal/controller/operator/factory/build/vmservicescrape.go
+++ b/internal/controller/operator/factory/build/vmservicescrape.go
@@ -137,7 +137,7 @@ func VMPodScrape(b podScrapeBuilder) *vmv1beta1.VMPodScrape {
 	authKey := extraArgs["metricsAuthKey"]
 
 	endpoint := vmv1beta1.PodMetricsEndpoint{
-		Port: ptr.To("http"),
+		Port: ptr.To("monitoring-http"),
 		EndpointScrapeParams: vmv1beta1.EndpointScrapeParams{
 			Path: b.GetMetricsPath(),
 		},


### PR DESCRIPTION
vmanomaly stopped to use the default `cr.Port(default 8090)`, but `8080` as the VMAnomalyMonitoringPullSpec.Port in https://github.com/VictoriaMetrics/operator/commit/acc9c7fc002ac1eb11993024cb8cbf750c9b2b2a, so `http` and `monitoring-http` are different by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the default VMPodScrape for vmanomaly to use the "monitoring-http" port instead of "http". This matches vmanomaly’s 8080 metrics service and prevents default scrape failures.

- **Bug Fixes**
  - Affects setups where vmanomaly exposes metrics on 8080; custom PodScrapes are unaffected and no user action is needed.

<sup>Written for commit 1594c91fcdd75bda9bf2bc885111de361df7cf35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

