### PR TITLE
test: fixed allure attachments

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,4 +113,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: allure-report
-          path: /tmp/allure-report.html
+          path: ./allure-report

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ vendor
 vmdocs/
 config/crd/bases/*
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+allure-report/
+allure-results/

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: load-kind ginkgo crust-gather
-	env CRUST_GATHER_BIN=$(CRUST_GATHER_BIN) $(GINKGO_BIN) \
+	env REPORTS_DIR=$(shell pwd) CRUST_GATHER_BIN=$(CRUST_GATHER_BIN) $(GINKGO_BIN) \
 		-procs=$(E2E_TESTS_CONCURRENCY) \
 		-timeout=30m \
 		-junit-report=report.xml ./test/e2e/...
@@ -483,7 +483,7 @@ $(CRUST_GATHER_BIN): $(LOCALBIN)
 
 .PHONY: allure-report
 allure-report:
-	npx allure awesome --single-file /tmp/allure-results -o /tmp/allure-report.html
+	npx allure awesome --single-file ./allure-results -o ./allure-report
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.25.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/Moon1706/ginkgo2allure v0.3.0
 	github.com/VictoriaMetrics/VictoriaMetrics v1.132.0
 	github.com/VictoriaMetrics/metrics v1.40.2
 	github.com/VictoriaMetrics/metricsql v0.84.8
 	github.com/VictoriaMetrics/operator/api v0.51.3
 	github.com/caarlos0/env/v11 v11.3.1
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-test/deep v1.1.1
@@ -53,7 +53,6 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
@@ -75,7 +74,6 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
@@ -88,7 +86,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/ozontech/allure-go/pkg/allure v0.7.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/alertmanager v0.31.0 // indirect
@@ -124,13 +121,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/VictoriaMetrics/operator/api => ./api
-
-// TODO: remove this line once https://github.com/kubernetes-sigs/controller-runtime/issues/3418 is merged
-replace sigs.k8s.io/structured-merge-diff/v6 => github.com/TwoStone/structured-merge-diff/v6 v6.3.1-fix
-
-replace github.com/Moon1706/ginkgo2allure => github.com/vrutkovs/ginkgo2allure v0.0.0-20260128072217-9d33a03669bb

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/TwoStone/structured-merge-diff/v6 v6.3.1-fix h1:Pwq8wRLsRlxyTmKjNgNW3237tJy7Q/wUD1O/DXaEBA0=
-github.com/TwoStone/structured-merge-diff/v6 v6.3.1-fix/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 github.com/VictoriaMetrics/VictoriaLogs v1.36.2-0.20251008164716-21c0fb3de84d h1:fV15mhBCGpCCBbuOAbOflO8Air+tLklMt8bG35FimzQ=
 github.com/VictoriaMetrics/VictoriaLogs v1.36.2-0.20251008164716-21c0fb3de84d/go.mod h1:JKZK8LZ9O38pW3+CbBSqL64nswBg6nJ0GE788b0Ps/8=
 github.com/VictoriaMetrics/VictoriaMetrics v1.132.0 h1:7J6U3j4WvjyEez+Ibb2bAYBbM+znWWoSCRclrrkPrhg=
@@ -110,8 +108,6 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
-github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -167,8 +163,6 @@ github.com/onsi/ginkgo/v2 v2.27.5 h1:ZeVgZMx2PDMdJm/+w5fE/OyG6ILo1Y3e+QX4zSR0zTE
 github.com/onsi/ginkgo/v2 v2.27.5/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/ozontech/allure-go/pkg/allure v0.7.5 h1:ARPVnEXzp197ZUCVjKRyckBTtpFWRH0l17MISG9QZ/s=
-github.com/ozontech/allure-go/pkg/allure v0.7.5/go.mod h1:kM/K/js8tPzl9huIsmgnK1kM6XeqOr7WQu87BBno7ZE=
 github.com/pires/go-proxyproto v0.8.0 h1:5unRmEAPbHXHuLjDg01CxJWf91cw3lKHc/0xzKpXEe0=
 github.com/pires/go-proxyproto v0.8.0/go.mod h1:iknsfgnH8EkjrMeMyvfKByp9TiBZCKZM0jx2xmKqnVY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -222,8 +216,6 @@ github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OL
 github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/valyala/quicktemplate v1.8.0 h1:zU0tjbIqTRgKQzFY1L42zq0qR3eh4WoQQdIdqCysW5k=
 github.com/valyala/quicktemplate v1.8.0/go.mod h1:qIqW8/igXt8fdrUln5kOSb+KWMaJ4Y8QUsfd1k6L2jM=
-github.com/vrutkovs/ginkgo2allure v0.0.0-20260128072217-9d33a03669bb h1:uo/I65kXfnRJ/cKiaHE6LIZXExQX1Ezl0t5zUVfCMUY=
-github.com/vrutkovs/ginkgo2allure v0.0.0-20260128072217-9d33a03669bb/go.mod h1:CwO6NP5u1WN9O1tAbRTx5y5ZLkoCajZVVXRruDn1RJw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -318,5 +310,7 @@ sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5E
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80uLmm0wJkk8=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/test/e2e/childobjects/suite_test.go
+++ b/test/e2e/childobjects/suite_test.go
@@ -11,6 +11,7 @@ import (
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/test/e2e/suite"
+	"github.com/VictoriaMetrics/operator/test/e2e/suite/allure"
 )
 
 const eventualDeletionTimeout = 20
@@ -42,7 +43,9 @@ var (
 		})
 
 	_ = AfterEach(suite.CollectK8SResources)
-	_ = ReportAfterSuite("allure report", suite.AllureReport)
+	_ = ReportAfterSuite("allure report", func(report Report) {
+		_ = allure.FromGinkgoReport(report)
+	})
 )
 
 func expectConditionOkFor(conds []vmv1beta1.Condition, typeCondtains string) error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/VictoriaMetrics/operator/test/e2e/suite"
+	"github.com/VictoriaMetrics/operator/test/e2e/suite/allure"
 )
 
 var (
@@ -65,7 +66,9 @@ var (
 	)
 
 	_ = AfterEach(suite.CollectK8SResources)
-	_ = ReportAfterSuite("allure report", suite.AllureReport)
+	_ = ReportAfterSuite("allure report", func(report Report) {
+		_ = allure.FromGinkgoReport(report)
+	})
 
 	// _ = AfterSuite()
 

--- a/test/e2e/suite/allure/api.go
+++ b/test/e2e/suite/allure/api.go
@@ -1,0 +1,21 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func AddAttachment(name string, mimeType MimeType, content []byte) {
+	a, _ := addAttachment(name, mimeType, content)
+	// Here we are marshalling the attachment object itself to JSON, so it can be transferred between parallel processes
+	ginkgo.AddReportEntry(attachmentReportEntryName, ginkgo.ReportEntryVisibilityNever, ginkgo.Offset(1), string(saveAsJSONAttachment(&a)))
+}
+
+func FromGinkgoReport(report types.Report) error {
+	return newTestContainer().createFromReport(report).write()
+}

--- a/test/e2e/suite/allure/attachment.go
+++ b/test/e2e/suite/allure/attachment.go
@@ -1,0 +1,84 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/onsi/gomega"
+)
+
+type attachment struct {
+	uuid    string
+	Name    string   `json:"name"`
+	Source  string   `json:"source"`
+	Type    MimeType `json:"type"`
+	content []byte
+}
+
+type MimeType string
+
+const (
+	MimeTypeGZIP MimeType = "application/gzip"
+)
+
+const attachmentReportEntryName = "ATTACHMENT"
+
+func saveAsJSONAttachment(msg any) []byte {
+	res, e := json.MarshalIndent(msg, "", "  ")
+	gomega.Expect(e).ShouldNot(gomega.HaveOccurred(), "while marshalling raw message")
+	return res
+}
+
+func addAttachment(name string, mimeType MimeType, content []byte) (*attachment, error) {
+	attachment := newAttachment(name, mimeType, content)
+	err := attachment.writeAttachmentFile()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create an attachment file: %w", err)
+	}
+
+	return attachment, nil
+}
+
+func (a *attachment) writeAttachmentFile() error {
+	resultsPathEnv := os.Getenv(resultsPathEnvKey)
+	ensureFolderCreated()
+	if resultsPath == "" {
+		resultsPath = fmt.Sprintf("%s/allure-results", resultsPathEnv)
+	}
+
+	a.Source = fmt.Sprintf("%s-attachment.%s", a.uuid, resolveExtension(a.Type))
+	err := os.WriteFile(strings.Join([]string{resultsPath, a.Source}, "/"), a.content, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write in file: %w", err)
+	}
+
+	return nil
+}
+
+func newAttachment(name string, mimeType MimeType, content []byte) *attachment {
+	result := &attachment{
+		uuid:    uuid.New().String(),
+		content: content,
+		Name:    name,
+		Type:    mimeType,
+	}
+
+	return result
+}
+
+func resolveExtension(mimeType MimeType) string {
+	switch mimeType {
+	case MimeTypeGZIP:
+		return "tar.gz"
+	default:
+		return ""
+	}
+}

--- a/test/e2e/suite/allure/container.go
+++ b/test/e2e/suite/allure/container.go
@@ -1,0 +1,82 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"github.com/google/uuid"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+type container struct {
+	UUID        string       `json:"uuid"`
+	Name        string       `json:"name"`
+	Children    []string     `json:"children"`
+	Description string       `json:"description"`
+	Befores     []stepObject `json:"befores"`
+	Afters      []stepObject `json:"afters"`
+	Links       []string     `json:"links"`
+	Start       int64        `json:"start"`
+	Stop        int64        `json:"stop"`
+}
+
+func (c *container) write() error {
+	content, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	writeErr := writeFile(fmt.Sprintf("%s-container.json", c.UUID), content)
+	if writeErr != nil {
+		return writeErr
+	}
+
+	return nil
+}
+
+func (c *container) createFromReport(report types.Report) *container {
+	c.Start = getTimestampMsFromTime(report.StartTime)
+	c.Stop = getTimestampMsFromTime(report.EndTime)
+
+	c.Name = path.Base(report.SuitePath)
+	c.Description = report.SuiteDescription
+
+	for _, specReport := range report.SpecReports {
+		switch specReport.LeafNodeType {
+		case types.NodeTypeBeforeSuite, types.NodeTypeSynchronizedBeforeSuite:
+			attachmentEntries := filterForAttachments(specReport.ReportEntries)
+			befores, _ := createSteps(specReport.SpecEvents, attachmentEntries)
+			c.Befores = append(c.Befores, befores...)
+		case types.NodeTypeIt:
+			res := newResult().
+				addParentSuite(report.SuiteDescription).
+				createFromSpecReport(specReport)
+
+			c.Children = append(c.Children, res.UUID)
+
+			res.write()
+		case types.NodeTypeAfterSuite, types.NodeTypeSynchronizedAfterSuite, types.NodeTypeCleanupAfterSuite:
+			attachmentEntries := filterForAttachments(specReport.ReportEntries)
+			afters, _ := createSteps(specReport.SpecEvents, attachmentEntries)
+			c.Afters = append(c.Afters, afters...)
+		default:
+			continue
+		}
+	}
+
+	return c
+}
+
+func newTestContainer() *container {
+	return &container{
+		UUID:    uuid.New().String(),
+		Befores: []stepObject{},
+		Afters:  []stepObject{},
+	}
+}

--- a/test/e2e/suite/allure/label.go
+++ b/test/e2e/suite/allure/label.go
@@ -1,0 +1,17 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+type label struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+const (
+	labelSuite = "suite"
+
+	labelParentSuite = "parentSuite"
+)

--- a/test/e2e/suite/allure/misc.go
+++ b/test/e2e/suite/allure/misc.go
@@ -1,0 +1,79 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	resultsPathEnvKey = "REPORTS_DIR"
+	wsPathEnvKey      = "ALLURE_WORKSPACE_PATH"
+)
+
+var (
+	resultsPath      string
+	createFolderOnce sync.Once
+)
+
+func getTimestampMs() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}
+
+func getTimestampMsFromTime(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
+}
+
+func writeFile(filename string, content []byte) error {
+	ensureFolderCreated()
+
+	err := os.WriteFile(fmt.Sprintf("%s/%s", resultsPath, filename), content, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write in file: %w", err)
+	}
+
+	return nil
+}
+
+func createFolderIfNotExists() {
+	resultsPathEnv := os.Getenv(resultsPathEnvKey)
+	if resultsPathEnv == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			panic(fmt.Errorf("cannot get current workdir: %w", err))
+		}
+
+		resultsPathEnv = cwd
+
+		err = os.Setenv(resultsPathEnvKey, resultsPathEnv)
+		if err != nil {
+			panic(fmt.Errorf("cannot set resultsPathEnv: %w", err))
+		}
+	}
+
+	if _, err := os.Stat(resultsPathEnv); os.IsNotExist(err) {
+		err = os.Mkdir(resultsPathEnv, 0755)
+		if err != nil {
+			panic(fmt.Errorf("failed to create reports folder: %w", err))
+		}
+	}
+
+	resultsPath = fmt.Sprintf("%s/allure-results", resultsPathEnv)
+
+	if _, err := os.Stat(resultsPath); os.IsNotExist(err) {
+		err = os.Mkdir(resultsPath, 0755)
+		if err != nil {
+			panic(fmt.Errorf("failed to create allure-results folder: %w", err))
+		}
+	}
+}
+
+func ensureFolderCreated() {
+	createFolderOnce.Do(createFolderIfNotExists)
+}

--- a/test/e2e/suite/allure/result.go
+++ b/test/e2e/suite/allure/result.go
@@ -1,0 +1,293 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+const descriptionReportEntryName = "DESCRIPTION"
+
+// result is the top level report object for a test.
+type result struct {
+	UUID          string         `json:"uuid,omitempty"`
+	TestCaseID    string         `json:"testCaseId,omitempty"`
+	HistoryID     string         `json:"historyId,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	StatusDetails *statusDetails `json:"statusDetails,omitempty"`
+	Stage         string         `json:"stage,omitempty"`
+	Steps         []stepObject   `json:"steps,omitempty"`
+	Attachments   []attachment   `json:"attachments,omitempty"`
+	Start         int64          `json:"start,omitempty"`
+	Stop          int64          `json:"stop,omitempty"`
+	Children      []string       `json:"children,omitempty"`
+	FullName      string         `json:"fullName,omitempty"`
+	Labels        []label        `json:"labels,omitempty"`
+	Suite         string         `json:"-"`
+	ParentSuite   string         `json:"-"`
+}
+
+func (r *result) addSuite(suite string) {
+	r.Suite = suite
+	r.addLabel(labelSuite, suite)
+}
+
+func (r *result) addParentSuite(parentSuite string) *result {
+	r.ParentSuite = parentSuite
+	r.addLabel(labelParentSuite, parentSuite)
+
+	return r
+}
+
+func (r *result) addAttachment(attachment *attachment) *result {
+	if attachment == nil {
+		panic(fmt.Errorf("nil attachment pointer"))
+	}
+
+	r.Attachments = append(r.Attachments, *attachment)
+
+	return r
+}
+
+func (r *result) addFullName(fullName string) {
+	r.FullName = fullName
+}
+
+func (r *result) addLabel(name string, value string) {
+	r.Labels = append(r.Labels, label{
+		Name:  name,
+		Value: value,
+	})
+}
+
+func (r *result) setStatusDetails(details statusDetails) *result {
+	r.StatusDetails = &details
+
+	return r
+}
+
+func (r *result) createFromSpecReport(specReport ginkgo.SpecReport) *result {
+	r.Start = getTimestampMsFromTime(specReport.StartTime)
+	r.Stop = getTimestampMsFromTime(specReport.EndTime)
+
+	if r.Stop < r.Start { // Workaround for incorrect skipped tests execution time
+		r.Stop = r.Start
+	}
+
+	r.Name = specReport.LeafNodeText
+	r.Description = buildDescription(specReport)
+
+	r.setDefaultLabels(specReport)
+
+	if len(specReport.ContainerHierarchyTexts) > 0 {
+		r.addSuite(specReport.ContainerHierarchyTexts[len(specReport.ContainerHierarchyTexts)-1])
+	} else {
+		r.addSuite(r.Name)
+	}
+
+	attachmentEntries := filterForAttachments(specReport.ReportEntries)
+	var toSkip map[int]struct{}
+	r.Steps, toSkip = createSteps(specReport.SpecEvents, attachmentEntries)
+
+	for i, entry := range attachmentEntries {
+		if _, ok := toSkip[i]; !ok {
+
+			var att attachment
+			err := json.Unmarshal([]byte(entry.Value.GetRawValue().(string)), &att)
+
+			if err != nil {
+				panic(fmt.Errorf("error processing attachment for entry %s on line %d", entry.Location.FileName, entry.Location.LineNumber))
+			} else if reflect.DeepEqual(att, attachment{}) {
+				panic(fmt.Errorf("nil pointer attachment for entry %s on line %d", entry.Location.FileName, entry.Location.LineNumber))
+			}
+
+			r.addAttachment(&att)
+		}
+	}
+
+	currentHash := uuid.NewSHA1(
+		uuid.Nil, []byte(strings.Join([]string{r.Name, r.Suite, r.ParentSuite}, ""))).String()
+	r.TestCaseID = currentHash
+	r.HistoryID = currentHash
+
+	r.Stage = "finished"
+	r.Status = getTestStatus(specReport)
+
+	if r.Status == failed || r.Status == broken {
+		details := statusDetails{
+			Message: specReport.Failure.Message,
+			Trace:   specReport.Failure.Location.FullStackTrace,
+		}
+		r.setStatusDetails(details)
+	}
+
+	return r
+}
+
+func createSteps(events types.SpecEvents, entries types.ReportEntries) (steps []stepObject, indicesToSkip map[int]struct{}) {
+	currentEndIndex := -1
+	indicesToSkip = make(map[int]struct{})
+	steps = []stepObject{}
+
+	for startEventIndex, startEvent := range events {
+		if currentEndIndex >= startEventIndex {
+			// Skipping all nested steps from previous iterations
+			continue
+		}
+
+		if startEvent.SpecEventType == types.SpecEventByStart {
+			step := newStep()
+			step.addName(startEvent.Message)
+			step.Status = passed
+			step.Stage = "finished"
+			endEvent, endIndex := findByEventEnd(events, startEvent)
+
+			if endEvent != nil {
+				step.Start = getTimestampMsFromTime(startEvent.TimelineLocation.Time)
+				step.Stop = getTimestampMsFromTime(endEvent.TimelineLocation.Time)
+
+				childrenSteps, toSkip := createSteps(events[startEventIndex+1:endIndex], entries)
+
+				step.ChildrenSteps = childrenSteps
+
+				for i, entry := range entries {
+					if _, ok := toSkip[i]; !ok {
+						if entry.TimelineLocation.Order > startEvent.TimelineLocation.Order &&
+							entry.TimelineLocation.Order < endEvent.TimelineLocation.Order {
+							var att attachment
+							err := json.Unmarshal([]byte(entry.Value.GetRawValue().(string)), &att)
+							if err != nil {
+								panic(fmt.Errorf("error processing attachment for entry %s on line %d", entry.Location.FileName, entry.Location.LineNumber))
+							} else if reflect.DeepEqual(att, attachment{}) {
+								panic(fmt.Errorf("nil pointer attachment for entry %s on line %d", entry.Location.FileName, entry.Location.LineNumber))
+							}
+							step.addAttachment(&att)
+
+							toSkip[i] = struct{}{}
+						}
+					}
+				}
+
+				for k, v := range toSkip {
+					indicesToSkip[k] = v
+				}
+				currentEndIndex = endIndex
+			}
+
+			steps = append(steps, *step)
+		}
+	}
+	return steps, indicesToSkip
+}
+
+func findByEventEnd(events types.SpecEvents, startEvent types.SpecEvent) (event *types.SpecEvent, index int) {
+	for i, e := range events {
+		if e.SpecEventType == types.SpecEventByEnd &&
+			startEvent.CodeLocation.LineNumber == e.CodeLocation.LineNumber &&
+			startEvent.TimelineLocation.Order < e.TimelineLocation.Order {
+			return &e, i
+		}
+	}
+
+	return nil, -1
+}
+
+func filterForAttachments(entries types.ReportEntries) types.ReportEntries {
+	var res types.ReportEntries
+	for _, entry := range entries {
+		if entry.Name == attachmentReportEntryName {
+			res = append(res, entry)
+		}
+	}
+
+	return res
+}
+
+func buildDescription(specReport ginkgo.SpecReport) string {
+	containerDescs := make([]string, 0)
+	if len(specReport.ContainerHierarchyTexts) > 1 {
+		// every container text excluding the top-level suite desc
+		containerDescs = append(containerDescs, specReport.ContainerHierarchyTexts[1:]...)
+	}
+
+	var nodeDesc string
+	for _, entry := range specReport.ReportEntries {
+		if entry.Name == descriptionReportEntryName {
+			nodeDesc = entry.Value.GetRawValue().(string)
+		}
+	}
+
+	return strings.Join(append(containerDescs, nodeDesc), "\n")
+}
+
+func (r *result) setDefaultLabels(report ginkgo.SpecReport) *result {
+	wsd := os.Getenv(wsPathEnvKey)
+
+	programCounters := make([]uintptr, 10)
+	callersCount := runtime.Callers(0, programCounters)
+	var testFile string
+	for i := 0; i < callersCount; i++ {
+		_, testFile, _, _ = runtime.Caller(i)
+		if strings.Contains(testFile, "_test.go") {
+			break
+		}
+	}
+	testPackage := strings.TrimSuffix(strings.ReplaceAll(strings.TrimPrefix(testFile, wsd+"/"), "/", "."), ".go")
+
+	if report.IsSerial {
+		r.addLabel("thread", "0")
+	} else {
+		r.addLabel("thread", strconv.Itoa(report.ParallelProcess))
+	}
+
+	r.addLabel("package", testPackage)
+	r.addLabel("testClass", testPackage)
+	r.addLabel("testMethod", report.LeafNodeText)
+	if len(wsd) == 0 {
+		r.addFullName(fmt.Sprintf("%s:%s", report.FileName(), report.LeafNodeText))
+	} else {
+		r.addFullName(fmt.Sprintf("%s:%s", strings.TrimPrefix(report.FileName(), wsd+"/"), report.LeafNodeText))
+	}
+	if hostname, err := os.Hostname(); err == nil {
+		r.addLabel("host", hostname)
+	}
+
+	r.addLabel("language", "golang")
+
+	return r
+}
+
+func (r *result) write() {
+	content, err := json.Marshal(r)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshall result into MimeTypeJSON: %w", err))
+	}
+
+	err = writeFile(fmt.Sprintf("%s-result.json", r.TestCaseID), content)
+	if err != nil {
+		panic(fmt.Errorf("failed to write content of result to json file: %w", err))
+	}
+}
+
+func newResult() *result {
+	return &result{
+		UUID:  uuid.New().String(),
+		Start: getTimestampMs(),
+		Steps: []stepObject{},
+	}
+}

--- a/test/e2e/suite/allure/status.go
+++ b/test/e2e/suite/allure/status.go
@@ -1,0 +1,41 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+const (
+	broken  = "broken"
+	passed  = "passed"
+	failed  = "failed"
+	skipped = "skipped"
+)
+
+type statusDetails struct {
+	Known   bool   `json:"known,omitempty"`
+	Muted   bool   `json:"muted,omitempty"`
+	Flaky   bool   `json:"flaky,omitempty"`
+	Message string `json:"message,omitempty"`
+	Trace   string `json:"trace,omitempty"`
+}
+
+func getTestStatus(report ginkgo.SpecReport) string {
+	switch report.State {
+	case types.SpecStatePanicked:
+		return broken
+	case types.SpecStateAborted, types.SpecStateInterrupted, types.SpecStateSkipped, types.SpecStatePending:
+		return skipped
+	case types.SpecStateFailed:
+		return failed
+	case types.SpecStatePassed:
+		return passed
+	default:
+		return ""
+	}
+}

--- a/test/e2e/suite/allure/step.go
+++ b/test/e2e/suite/allure/step.go
@@ -1,0 +1,40 @@
+/*
+The following code was adapted from https://github.com/ramich2077/allure-ginkgo/
+License: No explicit license found in original repository (All Rights Reserved).
+*/
+
+package allure
+
+import (
+	"fmt"
+)
+
+type stepObject struct {
+	Name          string         `json:"name,omitempty"`
+	Status        string         `json:"status,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	StatusDetails *statusDetails `json:"statusDetails,omitempty"`
+	Stage         string         `json:"stage"`
+	ChildrenSteps []stepObject   `json:"steps"`
+	Attachments   []attachment   `json:"attachments"`
+	Start         int64          `json:"start"`
+	Stop          int64          `json:"stop"`
+}
+
+func (sc *stepObject) addName(name string) {
+	sc.Name = name
+}
+
+func (sc *stepObject) addAttachment(attachment *attachment) {
+	if attachment == nil {
+		panic(fmt.Errorf("nil attachment pointer"))
+	}
+	sc.Attachments = append(sc.Attachments, *attachment)
+}
+
+func newStep() *stepObject {
+	return &stepObject{
+		Attachments:   make([]attachment, 0),
+		ChildrenSteps: make([]stepObject, 0),
+	}
+}

--- a/test/e2e/watchnamespace/suite_test.go
+++ b/test/e2e/watchnamespace/suite_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/VictoriaMetrics/operator/test/e2e/suite"
+	"github.com/VictoriaMetrics/operator/test/e2e/suite/allure"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -55,5 +56,7 @@ var (
 		})
 
 	_ = AfterEach(suite.CollectK8SResources)
-	_ = ReportAfterSuite("allure report", suite.AllureReport)
+	_ = ReportAfterSuite("allure report", func(report Report) {
+		_ = allure.FromGinkgoReport(report)
+	})
 )


### PR DESCRIPTION
fixed attachments in allure reports

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the external Allure integration with a built-in writer and binary-safe attachments to fix broken/missing e2e report artifacts. Results now write to ./allure-results, and failed tests attach a per-test crust-gather .tar.gz.

- **Bug Fixes**
  - Built-in Allure writer: outputs to ./allure-results, links tests/steps (incl. Before/After Suite), supports parallel runs and nested steps.
  - New AddAttachment API: binary-safe; crust-gather attached as application/gzip; per-test archives use a deterministic xxhash; works across parallel processes.
  - Switched ReportAfterSuite to allure.FromGinkgoReport; Makefile sets REPORTS_DIR and builds ./allure-report; CI uploads ./allure-report; .gitignore ignores allure-results/ and allure-report/.

- **Dependencies**
  - Removed ginkgo2allure and allure-go; added cespare/xxhash/v2.
  - Bumped sigs.k8s.io/structured-merge-diff/v6 to v6.3.2 and removed the temporary replace.

<sup>Written for commit 308e5c7ab63c6da7014c979b363e2f8bd674ca51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

