### PR TITLE
fix: vmdistributed: append /api/v1/write to allowed vmauth endpoints

### DIFF
--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -50,7 +50,7 @@ func appendVMAgentTargetRefs(targetRefs []vmv1beta1.TargetRef, vmAgents []*vmv1b
 				LoadBalancingPolicy: ptr.To("first_available"),
 				RetryStatusCodes:    []int{500, 502, 503},
 			},
-			Paths: []string{"/insert/.+"},
+			Paths: []string{"/insert/.+", "/api/v1/write"},
 			CRD: &vmv1beta1.CRDRef{
 				Kind:      "VMAgent",
 				Name:      vmAgent.Name,

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
@@ -370,7 +370,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				if i < len(d.zones.vmagents) {
 					assert.Equal(t, d.zones.vmagents[i].Name, targetRef.CRD.Name)
 					assert.Equal(t, d.zones.vmagents[i].Namespace, targetRef.CRD.Namespace)
-					assert.Equal(t, []string{"/insert/.+"}, targetRef.Paths)
+					assert.Equal(t, []string{"/insert/.+", "/api/v1/write"}, targetRef.Paths)
 					assert.Equal(t, "VMAgent", targetRef.CRD.Kind)
 				} else {
 					idx := i - len(d.zones.vmagents)
@@ -474,7 +474,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				if i < len(d.zones.vmagents) {
 					assert.Equal(t, d.zones.vmagents[i].Name, targetRef.CRD.Name)
 					assert.Equal(t, d.zones.vmagents[i].Namespace, targetRef.CRD.Namespace)
-					assert.Equal(t, []string{"/insert/.+"}, targetRef.Paths)
+					assert.Equal(t, []string{"/insert/.+", "/api/v1/write"}, targetRef.Paths)
 					assert.Equal(t, "VMAgent", targetRef.CRD.Kind)
 				} else {
 					idx := i - len(d.zones.vmagents)


### PR DESCRIPTION
This ensures all common inputs for vmagent remote writes are accepted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add /api/v1/write to the allowed vmauth paths for VMAgent remote writes, alongside /insert/.+.
This authorizes Prometheus-compatible remote_write clients; tests updated to reflect the new path.

<sup>Written for commit 4d962744160c65f5cc69ba88315dfd82ce11c42a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

