### PR TITLE
distributed: do no exclude zone when specs are immutable

### DIFF
--- a/internal/controller/operator/factory/reconcile/reconcile.go
+++ b/internal/controller/operator/factory/reconcile/reconcile.go
@@ -39,7 +39,7 @@ func InitDeadlines(intervalCheck, appWaitDeadline, podReadyDeadline time.Duratio
 // it deletes only labels and annotations managed by operator CRDs
 // 3-rd party kubernetes annotations and labels must be preserved
 func mergeMaps(existingMap, newMap, prevMap map[string]string) map[string]string {
-	dst := make(map[string]string)
+	var dst map[string]string
 	var deleted map[string]struct{}
 
 	for k := range prevMap {
@@ -55,9 +55,15 @@ func mergeMaps(existingMap, newMap, prevMap map[string]string) map[string]string
 		if _, ok := deleted[k]; ok {
 			continue
 		}
+		if dst == nil {
+			dst = make(map[string]string)
+		}
 		dst[k] = v
 	}
 	for k, v := range newMap {
+		if dst == nil {
+			dst = make(map[string]string)
+		}
 		dst[k] = v
 	}
 	return dst

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed.go
@@ -54,7 +54,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1alpha1.VMDistributed, rclient c
 		}
 
 		// Sleep for zoneUpdatePause time between VMClusters updates (unless its the last one)
-		if i != lastZoneIdx {
+		if i != lastZoneIdx && zs.hasChanges[i] {
 			item := fmt.Sprintf("%d/%d", i+1, len(cr.Spec.Zones))
 			logger.WithContext(ctx).Info("pausing between zone updates", "name", nsn, "zone", item, "updatePause", cr.Spec.ZoneCommon.UpdatePause.Duration)
 			select {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep zones in the VMDistr load balancer when VMCluster/VMAgent specs are unchanged, and skip the pause between those zones. Harden pod readiness polling to be more resilient and clearer.

- **Bug Fixes**
  - VMDistr zones: detect per-zone VMCluster/VMAgent spec changes using k8s semantic equality (after defaulting); only exclude/update zones and pause when a diff exists. Unchanged zones stay in rotation.
  - Reconcile: waitForPodReady now tolerates NotFound during polling, handles deletion, improves error messages, and avoids nil pod handling.

<sup>Written for commit 98609014d25019f2d4d5c641adf27b65f6603cb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



