### PR TITLE
test: ensure that VMDistributed changes state on paused

### DIFF
--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -63,11 +63,19 @@ func expectObjectStatusExpanding(ctx context.Context,
 	name types.NamespacedName) error {
 	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusExpanding)
 }
+
 func expectObjectStatusOperational(ctx context.Context,
 	rclient client.Client,
 	object client.Object,
 	name types.NamespacedName) error {
 	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusOperational)
+}
+
+func expectObjectStatusPaused(ctx context.Context,
+	rclient client.Client,
+	object client.Object,
+	name types.NamespacedName) error {
+	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusPaused)
 }
 
 type httpRequestOpts struct {

--- a/test/e2e/vmdistributed_test.go
+++ b/test/e2e/vmdistributed_test.go
@@ -801,6 +801,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 				cr.Spec.Paused = true
 				return k8sClient.Update(ctx, cr)
 			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			Eventually(func() error {
+				return expectObjectStatusPaused(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
+			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
 
 			By("attempting to scale the VMCluster while paused")
 			var vmCluster1 vmv1beta1.VMCluster


### PR DESCRIPTION
Update tests to check VMDistributed correctly changing state to `paused` and back to `extending`/`operational` when unpaused

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated e2e tests to verify VMDistributed enters paused when Spec.Paused=true and returns to expanding/operational after unpausing. Added expectObjectStatusPaused helper and an Eventually assertion in vmdistributed_test to confirm the paused state.

<sup>Written for commit db288341bbde956468d83ad4fdfcb69ef08e5753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

