### PR TITLE
fix: update vmselect/vminsert service selector when RequestsLoadBalancer is set

### DIFF
--- a/internal/controller/operator/factory/vmcluster/vmcluster.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster.go
@@ -200,6 +200,7 @@ func buildVMSelectService(cr *vmv1beta1.VMCluster) *corev1.Service {
 		svc.Spec.ClusterIP = corev1.ClusterIPNone
 		svc.Spec.Type = corev1.ServiceTypeClusterIP
 		svc.Labels[vmv1beta1.VMAuthLBServiceProxyJobNameLabel] = b.PrefixedName()
+		svc.Spec.Selector = cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)
 	}
 
 	return svc
@@ -338,6 +339,7 @@ func buildVMInsertService(cr *vmv1beta1.VMCluster) *corev1.Service {
 		svc.Spec.ClusterIP = corev1.ClusterIPNone
 		svc.Spec.Type = corev1.ServiceTypeClusterIP
 		svc.Labels[vmv1beta1.VMAuthLBServiceProxyJobNameLabel] = cr.PrefixedName(vmv1beta1.ClusterComponentInsert)
+		svc.Spec.Selector = cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)
 	}
 	return svc
 }

--- a/internal/controller/operator/factory/vmcluster/vmcluster_test.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster_test.go
@@ -1222,7 +1222,7 @@ spec:
 			},
 		},
 	})
-	// insert with load-balanacer
+	// insert with load-balancer
 	f(vmv1beta1.ClusterComponentInsert, &vmv1beta1.VMCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default-1"},
 		Spec: vmv1beta1.VMClusterSpec{
@@ -1293,7 +1293,7 @@ spec:
     selector:
         app.kubernetes.io/component: monitoring
         app.kubernetes.io/instance: test
-        app.kubernetes.io/name: vminsert
+        app.kubernetes.io/name: vmclusterlb-vmauth-balancer
         managed-by: vm-operator
     type: ClusterIP
     clusterip: "None"
@@ -1314,4 +1314,92 @@ spec:
 			},
 		},
 	})
+	// insert with load-balancer: internal service keeps vminsert selector;
+	// the external (LB proxy) service selector must change to vmauth.
+	f(vmv1beta1.ClusterComponentInsert, &vmv1beta1.VMCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default-1"},
+		Spec: vmv1beta1.VMClusterSpec{
+			RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
+				Enabled: true,
+			},
+			VMInsert: &vmv1beta1.VMInsert{},
+		},
+	}, `
+objectmeta:
+    name: vminsertinternal-test
+    namespace: default-1
+    resourceversion: "1"
+    labels:
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/name: vminsert
+        app.kubernetes.io/part-of: vmcluster
+        managed-by: vm-operator
+        operator.victoriametrics.com/vmauthlb-proxy-job-name: vminsert-test
+    ownerreferences:
+        - apiversion: ""
+          name: test
+          controller: true
+          blockownerdeletion: true
+    finalizers:
+        - apps.victoriametrics.com/finalizer
+spec:
+    ports:
+        - name: http
+          protocol: TCP
+          port: 8480
+          targetport:
+            intval: 8480
+    selector:
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/name: vmclusterlb-vmauth-balancer
+        managed-by: vm-operator
+    clusterip: "None"
+    type: ClusterIP
+`)
+	// select with RequestsLoadBalancer
+	f(vmv1beta1.ClusterComponentSelect, &vmv1beta1.VMCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default-1"},
+		Spec: vmv1beta1.VMClusterSpec{
+			RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
+				Enabled: true,
+			},
+			VMSelect: &vmv1beta1.VMSelect{},
+		},
+	}, `
+objectmeta:
+    name: vmselectinternal-test
+    namespace: default-1
+    resourceversion: "1"
+    labels:
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/name: vmselect
+        app.kubernetes.io/part-of: vmcluster
+        managed-by: vm-operator
+        operator.victoriametrics.com/vmauthlb-proxy-job-name: vmselect-test
+    ownerreferences:
+        - apiversion: ""
+          name: test
+          controller: true
+          blockownerdeletion: true
+    finalizers:
+        - apps.victoriametrics.com/finalizer
+spec:
+    ports:
+        - name: http
+          protocol: TCP
+          port: 8481
+          targetport:
+            intval: 8481
+    selector:
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/name: vmclusterlb-vmauth-balancer
+        managed-by: vm-operator
+    clusterip: "None"
+    type: ClusterIP
+    publishnotreadyaddresses: true
+`)
 }


### PR DESCRIPTION
Make sure that RequestsLoadBalancer setting changes labels and selector of vminsert/vmselect internal services and points to lb instead of vmselect/vminsert services directly

Fixes #1814

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update vmselect and vminsert internal services to route through the vmauth RequestsLoadBalancer when enabled. This ensures traffic goes via the LB instead of directly to vmselect/vminsert pods.

- **Bug Fixes**
  - Set Service.Spec.Selector to the balancer (ClusterComponentBalancer) for vmselect and vminsert when RequestsLoadBalancer is enabled.
  - Added tests covering both insert and select services to verify selector and label updates.

<sup>Written for commit 3e4808f4962197e28f93d13355bc46b5ff15eba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

