### PR TITLE
throw telegram message thread id in CR converter

### DIFF
--- a/internal/controller/operator/converter/v1alpha1/apis.go
+++ b/internal/controller/operator/converter/v1alpha1/apis.go
@@ -436,6 +436,11 @@ func convertReceivers(promReceivers []promv1alpha1.Receiver) []vmv1beta1.Receive
 				DisableNotifications: obj.DisableNotifications,
 				ParseMode:            obj.ParseMode,
 			}
+
+			if obj.MessageThreadID != nil {
+				vo.MessageThreadID = int(*obj.MessageThreadID)
+			}
+
 			dst.TelegramConfigs = append(dst.TelegramConfigs, vo)
 		}
 		for _, obj := range promR.MSTeamsConfigs {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Map Telegram MessageThreadID in the CR converter so thread-specific Telegram notifications are preserved during receiver conversion.

<sup>Written for commit adb6cccb0339ea17623426fa9c40111b848cd01e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

