### PR TITLE
test: add unit tests for %ZONE% templating

### DIFF
--- a/internal/controller/operator/factory/vmdistributed/util_test.go
+++ b/internal/controller/operator/factory/vmdistributed/util_test.go
@@ -112,7 +112,7 @@ func TestMergeSpecs(t *testing.T) {
 		}, &vmv1alpha1.VMDistributedZoneAgentSpec{}, "zone-b", &vmv1alpha1.VMDistributedZoneAgentSpec{
 			CommonApplicationDeploymentParams: vmv1beta1.CommonApplicationDeploymentParams{
 				NodeSelector: map[string]string{
-					"topology.kubernetes.io/zone": "zone-a",
+					"topology.kubernetes.io/zone": "zone-b",
 				},
 			},
 		})


### PR DESCRIPTION
Ensure that %ZONE% can be templated anywhere in VMCluster / VMAgent spec

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for mergeSpecs to verify %ZONE% replacement and zone-specific overrides in VMCluster and VMAgent. Tests nodeSelector templating and retentionPeriod override.

<sup>Written for commit 4b4e4591ebdcb47807c7709c9c713acde2e8d15f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

