### PR TITLE
added Auth examples for secretRefs for VMUser

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -195,7 +195,7 @@ type: Opaque
 apiVersion: v1
 kind: Secret
 metadata:
-  name: victoria-reader-token # Name of the secret
+  name: victoria-reader-password # Name of the secret
   namespace: vm # Ensure this matches the namespace of your VMUser
 type: Opaque
 data:


### PR DESCRIPTION
Adds examples for using an existing secret for creating VMUsers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs showing how to create VMUser from existing Kubernetes Secrets: bearer token via bearerTokenSecret and basic auth via username + passwordRef. Examples include targetRefs to VMCluster/vmselect with target_path_suffix '/select/1' and a '/prometheus/.*' path, plus reminders to match namespaces and secret keys ('token' and 'password').

<sup>Written for commit ff94e016708774c3f9b1429a40ce3cc681cc3291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

