### PR TITLE
fix: update builder to 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILDINFO
 ARG BASEIMAGE=scratch
 
 # Build the manager binary
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.7 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,9 +14,9 @@ COPY api/go.* api/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN \
-  --mount=type=cache,target=/go/pkg/mod \
-  --mount=type=cache,target=/root/.cache/go-build \
-  go mod download
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the go source
 COPY cmd/ cmd/
@@ -33,12 +33,12 @@ ARG GODEBUG_ARGS
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 ENV GOCACHE=/root/.cache/go-build
 RUN \
-  --mount=type=cache,target="/root/.cache/go-build" \
-  --mount=type=cache,target=/root/.cache \
-  --mount=type=cache,target=/go/pkg/mod \
-  CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GODEBUG=${GODEBUG_ARGS} GOFIPS140=${FIPS_VERSION} go build -a \
-   -ldflags="-X 'github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${BUILDINFO}'" \
-   -o app ${ROOT}/
+    --mount=type=cache,target="/root/.cache/go-build" \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GODEBUG=${GODEBUG_ARGS} GOFIPS140=${FIPS_VERSION} go build -a \
+    -ldflags="-X 'github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${BUILDINFO}'" \
+    -o app ${ROOT}/
 
 # Use scratch as minimal base image to package the manager binary
 FROM ${BASEIMAGE}


### PR DESCRIPTION
Update builder to latest golang to fix security vulnerabilities

Fixes #1775 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Dockerfile builder image from golang:1.25.5 to 1.25.7 to patch security vulnerabilities and keep builds current. No app code changes; only the build stage was updated.

<sup>Written for commit e47cd35f7e46399f0a0a6266c1238cc0ff338bfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

