### PR TITLE
chore: use k8s.io/apimachinery/pkg/util/sets instead of map[string]struct{}

### DIFF
--- a/internal/controller/operator/factory/build/build.go
+++ b/internal/controller/operator/factory/build/build.go
@@ -12,26 +12,23 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 )
 
 // disabledControllers defines set of disabled VM operator controllers
-var disabledControllers map[string]struct{}
+var disabledControllers sets.Set[string]
 
 // SetDisabledControllers configures set of disabled controllers
-func SetDisabledControllers(controllers map[string]struct{}) {
+func SetDisabledControllers(controllers sets.Set[string]) {
 	disabledControllers = controllers
 }
 
 // IsControllerDisabled checks if controller for given kind is disabled
 func IsControllerDisabled(kind string) bool {
-	if len(disabledControllers) > 0 {
-		_, ok := disabledControllers[kind]
-		return ok
-	}
-	return false
+	return disabledControllers.Has(kind)
 }
 
 // mustSkipRuntimeValidation defines whether runtime object validation must be skipped

--- a/internal/controller/operator/factory/finalize/cluster.go
+++ b/internal/controller/operator/factory/finalize/cluster.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -161,47 +162,47 @@ func OnClusterLoadBalancerDelete(ctx context.Context, rclient client.Client, cr 
 // ChildCleaner cleans dependent resources for cluster CRs excluding ones
 // which are listed in cleaner maps
 type ChildCleaner struct {
-	pdbs     map[string]struct{}
-	hpas     map[string]struct{}
-	vpas     map[string]struct{}
-	services map[string]struct{}
-	scrapes  map[string]struct{}
+	pdbs     sets.Set[string]
+	hpas     sets.Set[string]
+	vpas     sets.Set[string]
+	services sets.Set[string]
+	scrapes  sets.Set[string]
 }
 
 // NewChildCleaner initializes ChildCleaner
 func NewChildCleaner() *ChildCleaner {
 	return &ChildCleaner{
-		pdbs:     make(map[string]struct{}),
-		hpas:     make(map[string]struct{}),
-		vpas:     make(map[string]struct{}),
-		services: make(map[string]struct{}),
-		scrapes:  make(map[string]struct{}),
+		pdbs:     sets.New[string](),
+		hpas:     sets.New[string](),
+		vpas:     sets.New[string](),
+		services: sets.New[string](),
+		scrapes:  sets.New[string](),
 	}
 }
 
 // KeepPDB adds given PodDisruptionBudget's name to a map of resource names to be excluded from deletion
 func (cc *ChildCleaner) KeepPDB(v string) {
-	cc.pdbs[v] = struct{}{}
+	cc.pdbs.Insert(v)
 }
 
 // KeepHPA adds given HorizontalPodAutoscaler's name to a map of resource names to be excluded from deletion
 func (cc *ChildCleaner) KeepHPA(v string) {
-	cc.hpas[v] = struct{}{}
+	cc.hpas.Insert(v)
 }
 
 // KeepVPA adds given VerticalPodAutoscaler's name to a map of resource names to be excluded from deletion
 func (cc *ChildCleaner) KeepVPA(v string) {
-	cc.vpas[v] = struct{}{}
+	cc.vpas.Insert(v)
 }
 
 // KeepService adds given HorizontalPodAutoscaler's name to a map of resource names to be excluded from deletion
 func (cc *ChildCleaner) KeepService(v string) {
-	cc.services[v] = struct{}{}
+	cc.services.Insert(v)
 }
 
 // KeepScrape adds given VMServiceScrape's name to a map of resource names to be excluded from deletion
 func (cc *ChildCleaner) KeepScrape(v string) {
-	cc.scrapes[v] = struct{}{}
+	cc.scrapes.Insert(v)
 }
 
 // RemoveOrphaned removes cr dependent resources excluding ones, which are defined in cleaner's maps

--- a/internal/controller/operator/factory/finalize/orphaned_test.go
+++ b/internal/controller/operator/factory/finalize/orphaned_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -18,7 +19,7 @@ import (
 func TestRemoveOrphanedDeployments(t *testing.T) {
 	type opts struct {
 		cr                orphanedCRD
-		keepDeployments   map[string]struct{}
+		keepDeployments   sets.Set[string]
 		wantDepCount      int
 		predefinedObjects []runtime.Object
 	}
@@ -41,7 +42,7 @@ func TestRemoveOrphanedDeployments(t *testing.T) {
 				Namespace: "default",
 			},
 		},
-		keepDeployments: map[string]struct{}{"base": {}},
+		keepDeployments: sets.New[string]("base"),
 		predefinedObjects: []runtime.Object{
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +72,7 @@ func TestRemoveOrphanedDeployments(t *testing.T) {
 				Namespace: "default",
 			},
 		},
-		keepDeployments: map[string]struct{}{"base-0": {}},
+		keepDeployments: sets.New[string]("base-0"),
 		predefinedObjects: []runtime.Object{
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/operator/factory/vlagent/vlagent.go
+++ b/internal/controller/operator/factory/vlagent/vlagent.go
@@ -15,6 +15,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -702,16 +703,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1.VLAgent
 		}
 	}
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepPodScrapes := make(map[string]struct{})
+	keepServices := sets.New(svcName)
+	keepPodScrapes := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
-		keepPodScrapes[svcName] = struct{}{}
+		keepPodScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)

--- a/internal/controller/operator/factory/vlsingle/vlogs.go
+++ b/internal/controller/operator/factory/vlsingle/vlogs.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -301,16 +302,14 @@ func createOrUpdateVLogsService(ctx context.Context, rclient client.Client, cr, 
 
 func deleteVLogsPrevStateResources(ctx context.Context, rclient client.Client, cr *vmv1beta1.VLogs) error {
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepServicesScrapes := make(map[string]struct{})
+	keepServices := sets.New(svcName)
+	keepServicesScrapes := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
-		keepServicesScrapes[svcName] = struct{}{}
+		keepServicesScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)

--- a/internal/controller/operator/factory/vlsingle/vlsingle.go
+++ b/internal/controller/operator/factory/vlsingle/vlsingle.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -328,16 +329,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1.VLSingl
 	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepServicesScrapes := make(map[string]struct{})
+	keepServices := sets.New(svcName)
+	keepServicesScrapes := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
-		keepServicesScrapes[svcName] = struct{}{}
+		keepServicesScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)

--- a/internal/controller/operator/factory/vmalert/vmalert.go
+++ b/internal/controller/operator/factory/vmalert/vmalert.go
@@ -13,6 +13,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -724,16 +725,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 		}
 	}
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepServicesScrapes := make(map[string]struct{})
+	keepServices := sets.New(svcName)
+	keepServicesScrapes := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
-		keepServicesScrapes[svcName] = struct{}{}
+		keepServicesScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)

--- a/internal/controller/operator/factory/vmauth/vmauth.go
+++ b/internal/controller/operator/factory/vmauth/vmauth.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -655,16 +656,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	}
 
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepServiceScrapes := make(map[string]struct{})
-	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) && !cr.UseProxyProtocol() {
-		keepServiceScrapes[svcName] = struct{}{}
+	keepServices := sets.New(svcName)
+	keepServiceScrapes := sets.New[string]()
+	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
+		keepServiceScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -437,16 +438,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	owner := cr.AsOwner()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	svcName := cr.PrefixedName()
-	keepServices := map[string]struct{}{
-		svcName: {},
-	}
-	keepServiceScrapes := make(map[string]struct{})
+	keepServices := sets.New[string](svcName)
+	keepServiceScrapes := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
-		keepServiceScrapes[svcName] = struct{}{}
+		keepServiceScrapes.Insert(svcName)
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
-		keepServices[extraSvcName] = struct{}{}
+		keepServices.Insert(extraSvcName)
 	}
 	if err := finalize.RemoveOrphanedServices(ctx, rclient, cr, keepServices); err != nil {
 		return fmt.Errorf("cannot remove services: %w", err)


### PR DESCRIPTION
util/sets package provides a better interface to handle sets

Fixed #1765

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all map[string]struct{} “sets” with k8s.io/apimachinery/pkg/util/sets across the operator. This standardizes set ops (Has/Insert), reduces boilerplate, and keeps behavior the same.

- **Refactors**
  - Switched disabled-controller tracking, flag parsing, and all “keep” lists to sets.Set[string] (services, scrapes, PDBs, HPAs, VPAs, STSs, Deployments).
  - Updated ChildCleaner and RemoveOrphaned* function signatures/tests to use sets; simplified delete checks to Has.
  - Used sets in reconcile mergeMaps (deleted keys) and StatefulSet validation (volume names).
  - Simplified IsControllerDisabled and manager disabled-controller checks with sets.

<sup>Written for commit 6288ab1256ab47b64631ac3192de62cc5be47054. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

