### PR TITLE
tests: replace most t.Fatalf calls

### DIFF
--- a/api/operator/v1beta1/vmagent_types_test.go
+++ b/api/operator/v1beta1/vmagent_types_test.go
@@ -2,6 +2,8 @@ package v1beta1
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVMAgent_Validate(t *testing.T) {
@@ -10,8 +12,10 @@ func TestVMAgent_Validate(t *testing.T) {
 		r := &VMAgent{
 			Spec: spec,
 		}
-		if err := r.Validate(); (err != nil) != wantErr {
-			t.Errorf("Validate() error = %v, wantErr %v", err, wantErr)
+		if wantErr {
+			assert.Error(t, r.Validate())
+		} else {
+			assert.NoError(t, r.Validate())
 		}
 	}
 

--- a/api/operator/v1beta1/vmalert_types_test.go
+++ b/api/operator/v1beta1/vmalert_types_test.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,9 +18,7 @@ func TestVMAlert_ValidateOk(t *testing.T) {
 			},
 			Spec: spec,
 		}
-		if err := cr.Validate(); err != nil {
-			t.Fatalf("unexpected validation error: %s", err)
-		}
+		assert.NoError(t, cr.Validate())
 	}
 	f(VMAlertSpec{
 		Datasource: VMAlertDatasourceSpec{URL: "http://some-url"},
@@ -65,9 +64,7 @@ func TestVMAlert_ValidateFail(t *testing.T) {
 			},
 			Spec: spec,
 		}
-		if err := cr.Validate(); err == nil {
-			t.Fatalf("expected configuration to fail")
-		}
+		assert.Error(t, cr.Validate())
 	}
 	// no notifier config
 	f(VMAlertSpec{Notifier: &VMAlertNotifierSpec{

--- a/api/operator/v1beta1/vmalertmanagerconfig_types_test.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types_test.go
@@ -4,28 +4,24 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateVMAlertmanagerConfigFail(t *testing.T) {
 	f := func(src string, expectedReason string) {
 		t.Helper()
 		var amc VMAlertmanagerConfig
-		if err := json.Unmarshal([]byte(src), &amc); err != nil {
-			t.Fatalf("unexpected json parse error: %s", err)
-		}
+		assert.NoError(t, json.Unmarshal([]byte(src), &amc))
 		if len(amc.Spec.ParsingError) > 0 {
-			errS := amc.Spec.ParsingError
-			if strings.Contains(errS, expectedReason) {
+			if strings.Contains(amc.Spec.ParsingError, expectedReason) {
 				return
 			}
 			t.Fatalf("unexpected parsing error: %s", amc.Spec.ParsingError)
 		}
 		err := amc.Validate()
-		if err == nil {
-			t.Fatalf("expect error:\n%s\n got nil", expectedReason)
-		}
-		if !strings.Contains(err.Error(), expectedReason) {
-			t.Fatalf("unexpected fail reason:\n%s\nmust contain:\n%s\n", err.Error(), expectedReason)
+		if assert.Error(t, err, "expect error:\n%s\n got nil", expectedReason) {
+			assert.Contains(t, err.Error(), expectedReason)
 		}
 	}
 
@@ -406,16 +402,9 @@ func TestValidateVMAlertmanagerConfigOk(t *testing.T) {
 	f := func(src string) {
 		t.Helper()
 		var amc VMAlertmanagerConfig
-		if err := json.Unmarshal([]byte(src), &amc); err != nil {
-			t.Fatalf("unexpected json parse error: %s", err)
-		}
-		if len(amc.Spec.ParsingError) > 0 {
-			t.Fatalf("unexpected parsing error: %s", amc.Spec.ParsingError)
-		}
-		err := amc.Validate()
-		if err != nil {
-			t.Fatalf("expect error:\n%s", err)
-		}
+		assert.NoError(t, json.Unmarshal([]byte(src), &amc))
+		assert.Empty(t, amc.Spec.ParsingError)
+		assert.NoError(t, amc.Validate())
 	}
 	f(`{
     "apiVersion": "v1",

--- a/api/operator/v1beta1/vmcluster_types_test.go
+++ b/api/operator/v1beta1/vmcluster_types_test.go
@@ -16,9 +16,8 @@ func TestVMBackup_SnapshotDeletePathWithFlags(t *testing.T) {
 	f := func(o opts) {
 		t.Helper()
 		cr := VMBackup{}
-		if got := cr.SnapshotDeletePathWithFlags(o.host, o.port, o.extraArgs); got != o.want {
-			t.Errorf("SnapshotDeletePathWithFlags() = %v, want %v", got, o.want)
-		}
+		got := cr.SnapshotDeletePathWithFlags(o.host, o.port, o.extraArgs)
+		assert.Equal(t, o.want, got)
 	}
 
 	// default delete path

--- a/api/operator/v1beta1/vmextra_types_test.go
+++ b/api/operator/v1beta1/vmextra_types_test.go
@@ -52,8 +52,10 @@ func TestParsingMatch(t *testing.T) {
 		t.Helper()
 		var match StringOrArray
 		err := yaml.Unmarshal([]byte(o.data), &match)
-		if (err != nil) != o.wantErr {
-			t.Errorf("Match.UnmarshalYAML() error = %v, wantErr %v", err, o.wantErr)
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 		assert.Equal(t, match, o.match)
 	}
@@ -84,9 +86,7 @@ func TestStringOrArrayMarshal(t *testing.T) {
 	f := func(src *StringOrArray, marshalF func(any) ([]byte, error), expected string) {
 		t.Helper()
 		got, err := marshalF(src)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		assert.NoError(t, err)
 		assert.Equal(t, expected, string(got))
 	}
 
@@ -108,9 +108,7 @@ func TestStringOrArrayUnMarshal(t *testing.T) {
 	f := func(src string, unmarshalF func([]byte, any) error, expected StringOrArray) {
 		t.Helper()
 		var got StringOrArray
-		if err := unmarshalF([]byte(src), &got); err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		assert.NoError(t, unmarshalF([]byte(src), &got))
 		assert.Equal(t, expected, got)
 	}
 	f(`["1","2","3"]`, json.Unmarshal, StringOrArray{"1", "2", "3"})

--- a/api/operator/v1beta1/vmuser_types_test.go
+++ b/api/operator/v1beta1/vmuser_types_test.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
@@ -10,8 +11,10 @@ import (
 func TestVMUser_Validate(t *testing.T) {
 	f := func(cr *VMUser, wantErr bool) {
 		t.Helper()
-		if err := cr.Validate(); (err != nil) != wantErr {
-			t.Errorf("Validate() error = %v, wantErr %v", err, wantErr)
+		if wantErr {
+			assert.Error(t, cr.Validate())
+		} else {
+			assert.NoError(t, cr.Validate())
 		}
 	}
 

--- a/internal/controller/operator/converter/apis_test.go
+++ b/internal/controller/operator/converter/apis_test.go
@@ -1,7 +1,6 @@
 package converter
 
 import (
-	"reflect"
 	"testing"
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -23,9 +22,7 @@ func TestConvertTlsConfig(t *testing.T) {
 	f := func(opts opts) {
 		t.Helper()
 		got := ConvertTLSConfig(opts.ptc)
-		if got.KeyFile != opts.want.KeyFile || got.CertFile != opts.want.CertFile || got.CAFile != opts.want.CAFile {
-			t.Errorf("ConvertTlsConfig() = \n%v, \nwant \n%v", got, opts.want)
-		}
+		assert.Equal(t, opts.want, got)
 	}
 
 	// replace prom secret path
@@ -117,9 +114,8 @@ func TestConvertEndpoint(t *testing.T) {
 	}
 	f := func(opts opts) {
 		t.Helper()
-		if got := convertEndpoint(opts.pe); !reflect.DeepEqual(got, opts.want) {
-			t.Errorf("ConvertEndpoint() \ngot:  \n%v\n, \nwant: \n%v", got, opts.want)
-		}
+		got := convertEndpoint(opts.pe)
+		assert.Equal(t, opts.want, got)
 	}
 
 	// convert endpoint with relabel config
@@ -164,9 +160,7 @@ func TestConvertServiceMonitor(t *testing.T) {
 			FilterPrometheusConverterLabelPrefixes:      []string{"app.kubernetes", "helm.sh"},
 			FilterPrometheusConverterAnnotationPrefixes: []string{"another-annotation-filter", "app.kubernetes"},
 		})
-		if !reflect.DeepEqual(*got, opts.want) {
-			t.Errorf("ConvertServiceMonitor() got = \n%v, \nwant \n%v", *got, opts.want)
-		}
+		assert.Equal(t, opts.want, *got)
 	}
 
 	// with metricsRelabelConfig
@@ -238,9 +232,8 @@ func TestConvertPodEndpoints(t *testing.T) {
 	}
 	f := func(opts opts) {
 		t.Helper()
-		if got := convertPodEndpoints(opts.pe); !reflect.DeepEqual(got, opts.want) {
-			t.Errorf("ConvertPodEndpoints() = %v, want %v", got, opts.want)
-		}
+		got := convertPodEndpoints(opts.pe)
+		assert.Equal(t, opts.want, got)
 	}
 
 	// with partial tls config
@@ -342,10 +335,7 @@ func TestConvertProbe(t *testing.T) {
 			FilterPrometheusConverterLabelPrefixes:      []string{"helm.sh"},
 			FilterPrometheusConverterAnnotationPrefixes: []string{"app.kubernetes"},
 		})
-
-		if !reflect.DeepEqual(*got, opts.want) {
-			t.Errorf("ConvertProbe() got = \n%v, \nwant \n%v", *got, opts.want)
-		}
+		assert.Equal(t, opts.want, *got)
 	}
 
 	// with static config
@@ -465,10 +455,7 @@ func TestConvertPromRule(t *testing.T) {
 			FilterPrometheusConverterLabelPrefixes:      []string{"helm.sh"},
 			FilterPrometheusConverterAnnotationPrefixes: []string{"app.kubernetes"},
 		})
-
-		if !reflect.DeepEqual(*got, opts.want) {
-			t.Errorf("ConvertPromRule() got = \n%v, \nwant \n%v", *got, opts.want)
-		}
+		assert.Equal(t, opts.want, *got)
 	}
 
 	// with keep firing for

--- a/internal/controller/operator/factory/build/build_test.go
+++ b/internal/controller/operator/factory/build/build_test.go
@@ -90,17 +90,11 @@ func TestGzipGunzipConfig(t *testing.T) {
 		default:
 			err = binary.Write(&b, binary.BigEndian, data)
 		}
-		if err != nil {
-			t.Errorf("failed to write data to buffer: %v", err)
-		}
+		assert.NoError(t, err, "failed to write data to buffer")
 		compressed, err := GzipConfig(b.Bytes())
-		if err != nil {
-			t.Errorf("failed to compress data: %v", err)
-		}
+		assert.NoError(t, err, "failed to compress data")
 		uncompressed, err := GunzipConfig(compressed)
-		if err != nil {
-			t.Errorf("failed to uncompress data: %v", err)
-		}
+		assert.NoError(t, err, "failed to uncompress data")
 		assert.True(t, bytes.Equal(b.Bytes(), uncompressed))
 	}
 
@@ -188,8 +182,8 @@ func TestDeepMerge(t *testing.T) {
 			assert.Equal(t, "zone-sa", merged.ServiceAccountName)
 
 			// nested merge
-			if merged.VMSelect == nil || merged.VMSelect.ReplicaCount == nil {
-				t.Fatalf("merged.VMSelect or ReplicaCount is nil")
+			if !assert.NotNil(t, merged.VMSelect) || !assert.NotNil(t, merged.VMSelect.ReplicaCount) {
+				return
 			}
 			assert.Equal(t, int32(3), *merged.VMSelect.ReplicaCount)
 			assert.Equal(t, "x", merged.VMSelect.ExtraArgs["keep"])
@@ -197,8 +191,8 @@ func TestDeepMerge(t *testing.T) {
 			assert.Equal(t, "y", merged.VMSelect.ExtraArgs["add"])
 
 			// untouched subtree
-			if merged.VMInsert == nil || merged.VMInsert.ReplicaCount == nil {
-				t.Fatalf("merged.VMInsert or ReplicaCount is nil")
+			if !assert.NotNil(t, merged.VMInsert) || !assert.NotNil(t, merged.VMInsert.ReplicaCount) {
+				return
 			}
 			assert.Equal(t, int32(1), *merged.VMInsert.ReplicaCount)
 			assert.Equal(t, "1", merged.VMInsert.ExtraArgs["insert-arg"])

--- a/internal/controller/operator/factory/build/container_test.go
+++ b/internal/controller/operator/factory/build/container_test.go
@@ -209,9 +209,7 @@ func TestFormatContainerImage(t *testing.T) {
 	f := func(globalRepo, image, wantImage string) {
 		t.Helper()
 		gotImage := formatContainerImage(globalRepo, image)
-		if gotImage != wantImage {
-			t.Errorf("unexpected container image, got: \n%s\nwant: \n%s", gotImage, wantImage)
-		}
+		assert.Equal(t, wantImage, gotImage)
 	}
 	f("", "victoria-metrics/storage", "victoria-metrics/storage")
 	f("docker.io", "victoria-metrics/storage", "docker.io/victoria-metrics/storage")

--- a/internal/controller/operator/factory/build/defaults_test.go
+++ b/internal/controller/operator/factory/build/defaults_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -27,9 +28,7 @@ func TestAddEnterpriseTagToAppCommonDefaults(t *testing.T) {
 			}
 		}
 		addDefaultsToCommonParams(cdp, license, appDefaults)
-		if cdp.Image.Tag != wantVersion {
-			t.Fatalf("unexpected spec version: (+%s,-%s)", cdp.Image.Tag, wantVersion)
-		}
+		assert.Equal(t, wantVersion, cdp.Image.Tag, "unexpected spec version")
 	}
 
 	// preserve spec version

--- a/internal/controller/operator/factory/build/shard_test.go
+++ b/internal/controller/operator/factory/build/shard_test.go
@@ -3,14 +3,14 @@ package build
 import (
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShardNumIter(t *testing.T) {
 	f := func(backward bool, upperBound int) {
 		output := slices.Collect(ShardNumIter(backward, upperBound))
-		if len(output) != upperBound {
-			t.Errorf("invalid ShardNumIter() items count, want: %d, got: %d", upperBound, len(output))
-		}
+		assert.Equal(t, upperBound, len(output), "invalid ShardNumIter() items count")
 		var lowerBound int
 		if backward {
 			lowerBound = upperBound - 1
@@ -18,9 +18,8 @@ func TestShardNumIter(t *testing.T) {
 		} else {
 			upperBound--
 		}
-		if output[0] != lowerBound || output[len(output)-1] != upperBound {
-			t.Errorf("invalid ShardNumIter() bounds, want: [%d, %d], got: [%d, %d]", lowerBound, upperBound, output[0], output[len(output)-1])
-		}
+		assert.Equal(t, lowerBound, output[0], "invalid ShardNumIter() lower bound")
+		assert.Equal(t, upperBound, output[len(output)-1], "invalid ShardNumIter() upper bound")
 	}
 	f(true, 9)
 	f(false, 5)

--- a/internal/controller/operator/factory/k8stools/placeholders_test.go
+++ b/internal/controller/operator/factory/k8stools/placeholders_test.go
@@ -3,6 +3,7 @@ package k8stools_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,9 +21,10 @@ func TestRenderPlaceholders(t *testing.T) {
 		t.Helper()
 		resource := o.resource.(*corev1.ConfigMap)
 		_, err := k8stools.RenderPlaceholders(resource, o.placeholders)
-		if (err != nil) != o.wantErr {
-			t.Errorf("RenderPlaceholders() error = %v, wantErr = %v", err, o.wantErr)
-			return
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 

--- a/internal/controller/operator/factory/reconcile/statefulset_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_test.go
@@ -29,8 +29,11 @@ func Test_waitForPodReady(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		nsn := types.NamespacedName{Namespace: o.ns, Name: o.podName}
-		if err := waitForPodReady(context.Background(), fclient, nsn, o.desiredVersion, 0); (err != nil) != o.wantErr {
-			t.Errorf("waitForPodReady() error = %v, wantErr %v", err, o.wantErr)
+		err := waitForPodReady(context.Background(), fclient, nsn, o.desiredVersion, 0)
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 
@@ -168,9 +171,8 @@ func Test_podIsReady(t *testing.T) {
 	}
 	f := func(o opts) {
 		t.Helper()
-		if got := PodIsReady(&o.pod, o.minReadySeconds); got != o.want {
-			t.Errorf("PodIsReady() = %v, want %v", got, o.want)
-		}
+		got := PodIsReady(&o.pod, o.minReadySeconds)
+		assert.Equal(t, o.want, got)
 	}
 
 	// pod is ready
@@ -271,8 +273,11 @@ func Test_performRollingUpdateOnSts(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 
-		if err := performRollingUpdateOnSts(context.Background(), false, fclient, o.stsName, o.ns, o.podLabels, o.podMaxUnavailable); (err != nil) != o.wantErr {
-			t.Errorf("performRollingUpdateOnSts() error = %v, wantErr %v", err, o.wantErr)
+		err := performRollingUpdateOnSts(context.Background(), false, fclient, o.stsName, o.ns, o.podLabels, o.podMaxUnavailable)
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 

--- a/internal/controller/operator/factory/vlagent/rbac_test.go
+++ b/internal/controller/operator/factory/vlagent/rbac_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,9 +18,7 @@ func TestCreateVLAgentClusterAccess(t *testing.T) {
 	f := func(cr *vmv1.VLAgent, predefinedObjects []runtime.Object) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(predefinedObjects)
-		if err := createK8sAPIAccess(context.TODO(), fclient, cr, nil); err != nil {
-			t.Errorf("createK8sAPIAccess() error = %v", err)
-		}
+		assert.NoError(t, createK8sAPIAccess(context.TODO(), fclient, cr, nil))
 	}
 
 	// ok create default rbac

--- a/internal/controller/operator/factory/vlsingle/vlogs_test.go
+++ b/internal/controller/operator/factory/vlsingle/vlogs_test.go
@@ -30,9 +30,10 @@ func TestCreateOrUpdateVLogs(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		err := CreateOrUpdateVLogs(context.Background(), fclient, o.cr)
-		if (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdateVLogs() error = %v, wantErr %v", err, o.wantErr)
-			return
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 
@@ -98,10 +99,12 @@ func TestCreateOrUpdateVLogsService(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ctx := context.TODO()
-		if err := createOrUpdateVLogsService(ctx, fclient, o.cr, nil); (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdateVLogsService() error = %v, wantErr %v", err, o.wantErr)
+		err := createOrUpdateVLogsService(ctx, fclient, o.cr, nil)
+		if o.wantErr {
+			assert.Error(t, err)
 			return
 		}
+		assert.NoError(t, err)
 		svc := build.Service(o.cr, o.cr.Spec.Port, nil)
 		var got corev1.Service
 		nsn := types.NamespacedName{

--- a/internal/controller/operator/factory/vlsingle/vlsingle_test.go
+++ b/internal/controller/operator/factory/vlsingle/vlsingle_test.go
@@ -32,9 +32,10 @@ func TestCreateOrUpdateVLSingle(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		err := CreateOrUpdate(context.TODO(), fclient, o.cr)
-		if (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdate() error = %v, wantErr %v", err, o.wantErr)
-			return
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 
@@ -195,10 +196,11 @@ func TestCreateOrUpdateVLSingleService(t *testing.T) {
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ctx := context.TODO()
 		err := createOrUpdateService(ctx, fclient, o.cr, nil)
-		if (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdateService() error = %v, wantErr %v", err, o.wantErr)
+		if o.wantErr {
+			assert.Error(t, err)
 			return
 		}
+		assert.NoError(t, err)
 		svc := build.Service(o.cr, o.cr.Spec.Port, nil)
 		var got corev1.Service
 		nsn := types.NamespacedName{

--- a/internal/controller/operator/factory/vmagent/nodescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/nodescrape_test.go
@@ -30,16 +30,12 @@ func Test_generateNodeScrapeConfig(t *testing.T) {
 		pos := &parsedObjects{Namespace: o.cr.Namespace}
 		sp := &o.cr.Spec.CommonScrapeParams
 		got, err := generateNodeScrapeConfig(ctx, sp, pos, o.sc, ac)
-		if err != nil {
-			t.Errorf("cannot generate NodeScrapeConfig, err: %e", err)
-			return
+		if assert.NoError(t, err, "cannot generate NodeScrapeConfig") {
+			gotBytes, err := yaml.Marshal(got)
+			if assert.NoError(t, err, "cannot marshal NodeScrapeConfig to yaml") {
+				assert.Equal(t, o.want, string(gotBytes))
+			}
 		}
-		gotBytes, err := yaml.Marshal(got)
-		if err != nil {
-			t.Errorf("cannot marshal NodeScrapeConfig to yaml, err: %e", err)
-			return
-		}
-		assert.Equal(t, o.want, string(gotBytes))
 	}
 
 	// ok build node

--- a/internal/controller/operator/factory/vmagent/podscrape_test.go
+++ b/internal/controller/operator/factory/vmagent/podscrape_test.go
@@ -29,16 +29,12 @@ func Test_generatePodScrapeConfig(t *testing.T) {
 		pos := &parsedObjects{Namespace: o.cr.Namespace}
 		sp := &o.cr.Spec.CommonScrapeParams
 		got, err := generatePodScrapeConfig(ctx, sp, pos, o.sc, o.ep, 0, ac)
-		if err != nil {
-			t.Errorf("cannot generate PodScrapeConfig, err: %e", err)
-			return
+		if assert.NoError(t, err, "cannot generate PodScrapeConfig") {
+			gotBytes, err := yaml.Marshal(got)
+			if assert.NoError(t, err, "cannot marshal PodScrapeConfig to yaml") {
+				assert.Equal(t, o.want, string(gotBytes))
+			}
 		}
-		gotBytes, err := yaml.Marshal(got)
-		if err != nil {
-			t.Errorf("cannot marshal PodScrapeConfig to yaml: %e", err)
-			return
-		}
-		assert.Equal(t, o.want, string(gotBytes))
 	}
 
 	// simple test

--- a/internal/controller/operator/factory/vmagent/probe_test.go
+++ b/internal/controller/operator/factory/vmagent/probe_test.go
@@ -31,16 +31,12 @@ func Test_generateProbeConfig(t *testing.T) {
 		pos := &parsedObjects{Namespace: o.cr.Namespace}
 		sp := &o.cr.Spec.CommonScrapeParams
 		got, err := generateProbeConfig(ctx, sp, pos, o.sc, ac)
-		if err != nil {
-			t.Errorf("cannot generate ProbeConfig, err: %e", err)
-			return
+		if assert.NoError(t, err, "cannot generate ProbeConfig") {
+			gotBytes, err := yaml.Marshal(got)
+			if assert.NoError(t, err, "cannot decode probe config, it must be in yaml format") {
+				assert.Equal(t, o.want, string(gotBytes))
+			}
 		}
-		gotBytes, err := yaml.Marshal(got)
-		if err != nil {
-			t.Errorf("cannot decode probe config, it must be in yaml format: %e", err)
-			return
-		}
-		assert.Equal(t, o.want, string(gotBytes))
 	}
 
 	// generate static config

--- a/internal/controller/operator/factory/vmagent/servicescrape_test.go
+++ b/internal/controller/operator/factory/vmagent/servicescrape_test.go
@@ -35,16 +35,12 @@ func Test_generateServiceScrapeConfig(t *testing.T) {
 		}
 		sp := &o.cr.Spec.CommonScrapeParams
 		got, err := generateServiceScrapeConfig(ctx, sp, pos, o.sc, o.sc.Spec.Endpoints[0], 0, ac)
-		if err != nil {
-			t.Errorf("cannot generate ServiceScrapeConfig, err: %e", err)
-			return
+		if assert.NoError(t, err, "cannot generate ServiceScrapeConfig") {
+			gotBytes, err := yaml.Marshal(got)
+			if assert.NoError(t, err, "cannot marshal ServiceScrapeConfig to yaml") {
+				assert.Equal(t, o.want, string(gotBytes))
+			}
 		}
-		gotBytes, err := yaml.Marshal(got)
-		if err != nil {
-			t.Errorf("cannot marshal ServiceScrapeConfig to yaml: %e", err)
-			return
-		}
-		assert.Equal(t, o.want, string(gotBytes))
 	}
 
 	// generate simple config

--- a/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_scrapeconfig_test.go
@@ -116,9 +116,7 @@ func TestCreateOrUpdateScrapeConfig(t *testing.T) {
 		}
 		build.AddDefaults(testClient.Scheme())
 		ac := getAssetsCache(ctx, testClient, o.cr)
-		if err := createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac); err != nil {
-			t.Errorf("CreateOrUpdateConfigurationSecret() error = %v", err)
-		}
+		assert.NoError(t, createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac))
 		var expectSecret corev1.Secret
 		assert.NoError(t, testClient.Get(ctx, types.NamespacedName{Namespace: o.cr.Namespace, Name: o.cr.PrefixedName()}, &expectSecret))
 		gotCfg := expectSecret.Data[scrapeGzippedFilename]
@@ -2222,9 +2220,7 @@ scrape_configs: []
 			},
 		}
 		ac := getAssetsCache(ctx, testClient, cr)
-		if err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac); err != nil {
-			t.Errorf("CreateOrUpdateConfigurationSecret() error = %s", err)
-		}
+		assert.NoError(t, createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac))
 		var configSecret corev1.Secret
 		assert.NoError(t, testClient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.PrefixedName()}, &configSecret))
 

--- a/internal/controller/operator/factory/vmagent/vmagent_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_test.go
@@ -1612,9 +1612,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 			Namespace: svc.Namespace,
 		}
 		assert.NoError(t, cl.Get(ctx, nsn, &got))
-		if err := o.want(&got); err != nil {
-			t.Errorf("CreateOrUpdateService() unexpected error: %v", err)
-		}
+		assert.NoError(t, o.want(&got))
 		if o.wantAdditionalService != nil {
 			var additionalSvc corev1.Service
 			assert.NoError(t, cl.Get(ctx, types.NamespacedName{Namespace: o.cr.Namespace, Name: o.cr.Spec.ServiceSpec.NameOrDefault(o.cr.Name)}, &additionalSvc))

--- a/internal/controller/operator/factory/vmalert/rules_test.go
+++ b/internal/controller/operator/factory/vmalert/rules_test.go
@@ -26,10 +26,7 @@ func TestSelectRules(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		_, got, err := selectRules(ctx, fclient, o.cr)
-		if err != nil {
-			t.Errorf("SelectRules() error = %v", err)
-			return
-		}
+		assert.NoError(t, err)
 		for ruleName, content := range got {
 			assert.Equal(t, o.want[ruleName], content)
 		}
@@ -234,11 +231,8 @@ func TestCreateOrUpdateRuleConfigMaps(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		got, err := CreateOrUpdateRuleConfigMaps(context.TODO(), fclient, o.cr, nil)
-		if err != nil {
-			t.Errorf("CreateOrUpdateRuleConfigMaps() error = %v", err)
-			return
-		}
-		assert.Equal(t, got, o.want)
+		assert.NoError(t, err)
+		assert.Equal(t, o.want, got)
 	}
 
 	// base-rules-empty

--- a/internal/controller/operator/factory/vmalert/vmalert_test.go
+++ b/internal/controller/operator/factory/vmalert/vmalert_test.go
@@ -3,7 +3,6 @@ package vmalert
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -33,10 +32,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		ctx := context.TODO()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		err := CreateOrUpdate(ctx, o.cr, fclient, o.cmNames)
-		if err != nil {
-			t.Errorf("CreateOrUpdate() error = %v", err)
-			return
-		}
+		assert.NoError(t, err)
 
 		if o.validate != nil {
 			var generatedDeploment appsv1.Deployment
@@ -471,11 +467,9 @@ func TestBuildNotifiers(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		if got, err := buildNotifiersArgs(o.cr, ac); err != nil {
-			t.Errorf("buildNotifiersArgs(), unexpected error: %s", err)
-		} else if !reflect.DeepEqual(got, o.want) {
-			t.Errorf("BuildNotifiersArgs() = \ngot \n%v, \nwant \n%v", got, o.want)
-		}
+		got, err := buildNotifiersArgs(o.cr, ac)
+		assert.NoError(t, err)
+		assert.Equal(t, o.want, got)
 	}
 
 	// ok build args
@@ -630,9 +624,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 			Namespace: svc.Namespace,
 		}
 		assert.NoError(t, cl.Get(ctx, nsn, &got))
-		if err := o.want(&got); err != nil {
-			t.Errorf("createOrUpdateService() unexpected error: %v", err)
-		}
+		assert.NoError(t, o.want(&got))
 	}
 
 	// base test
@@ -665,15 +657,10 @@ func Test_buildVMAlertArgs(t *testing.T) {
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ac := getAssetsCache(ctx, fclient, o.cr)
-		if err := discoverNotifiersIfNeeded(ctx, fclient, o.cr); err != nil {
-			t.Errorf("discoverNotifiersIfNeeded(): %s", err)
-		}
-		if got, err := buildArgs(o.cr, o.ruleConfigMapNames, ac); err != nil {
-			t.Errorf("buildArgs(), unexpected error: %s", err)
-		} else if !reflect.DeepEqual(got, o.want) {
-			assert.Equal(t, o.want, got)
-			t.Errorf("buildVMAlertArgs() got = \n%v\n, want \n%v\n", got, o.want)
-		}
+		assert.NoError(t, discoverNotifiersIfNeeded(ctx, fclient, o.cr))
+		got, err := buildArgs(o.cr, o.ruleConfigMapNames, ac)
+		assert.NoError(t, err)
+		assert.Equal(t, o.want, got)
 	}
 
 	// basic args

--- a/internal/controller/operator/factory/vmalertmanager/alertmanager_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/alertmanager_test.go
@@ -251,9 +251,8 @@ func Test_createDefaultAMConfig(t *testing.T) {
 		if o.wantErr {
 			assert.Error(t, err)
 			return
-		} else {
-			assert.NoError(t, err)
 		}
+		assert.NoError(t, err)
 		var createdSecret corev1.Secret
 		secretName := o.cr.ConfigSecretName()
 
@@ -262,7 +261,7 @@ func Test_createDefaultAMConfig(t *testing.T) {
 			if k8serrors.IsNotFound(err) && o.secretMustBeMissing {
 				return
 			}
-			t.Fatalf("config for alertmanager not exist, err: %v", err)
+			assert.NoError(t, err, "config for alertmanager not exist")
 		}
 
 		var amcfgs vmv1beta1.VMAlertmanagerConfigList

--- a/internal/controller/operator/factory/vmanomaly/config/config_test.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config_test.go
@@ -42,9 +42,9 @@ func TestLoad(t *testing.T) {
 		loaded, err := Load(o.cr, ac)
 		if o.wantErr {
 			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
+			return
 		}
+		assert.NoError(t, err)
 		expected := strings.TrimSpace(o.expected)
 		got := strings.TrimSpace(string(loaded))
 		assert.Equal(t, got, expected)

--- a/internal/controller/operator/factory/vmanomaly/statefulset_test.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset_test.go
@@ -245,9 +245,8 @@ func Test_createDefaultConfig(t *testing.T) {
 		if o.wantErr {
 			assert.Error(t, err)
 			return
-		} else {
-			assert.NoError(t, err)
 		}
+		assert.NoError(t, err)
 		var createdSecret corev1.Secret
 		secretName := build.ResourceName(build.SecretConfigResourceKind, o.cr)
 
@@ -256,7 +255,9 @@ func Test_createDefaultConfig(t *testing.T) {
 			if k8serrors.IsNotFound(err) && o.secretMustBeMissing {
 				return
 			}
-			t.Fatalf("config for vmanomaly not exist, err: %v", err)
+			if !assert.NoError(t, err, "config for vmanomaly not exist") {
+				return
+			}
 		}
 	}
 

--- a/internal/controller/operator/factory/vmauth/vmauth_test.go
+++ b/internal/controller/operator/factory/vmauth/vmauth_test.go
@@ -45,8 +45,11 @@ func TestCreateOrUpdate(t *testing.T) {
 		}
 		ctx := context.Background()
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
-		if err := CreateOrUpdate(ctx, o.cr, fclient); (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdate() error = %v, wantErr %v", err, o.wantErr)
+		err := CreateOrUpdate(ctx, o.cr, fclient)
+		if o.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 		if o.validate != nil {
 			o.validate(ctx, fclient, o.cr)

--- a/internal/controller/operator/factory/vmauth/vmusers_config_test.go
+++ b/internal/controller/operator/factory/vmauth/vmusers_config_test.go
@@ -790,21 +790,13 @@ func Test_selectVMUserSecrets(t *testing.T) {
 			}
 			return dst.String()
 		}
-		if len(o.wantToCreateSecrets) != len(got) {
-			t.Errorf("not expected count of want=%d and got=%d to create secrets, got=%q", len(o.wantToCreateSecrets), len(got), joinSecretNames(got))
-		}
-		if len(o.wantToUpdateSecrets) != len(got1) {
-			t.Errorf("not expected count of want=%d and got=%d to update secrets, got=%q", len(o.wantToUpdateSecrets), len(got1), joinSecretNames(got1))
-		}
+		assert.Equal(t, len(o.wantToCreateSecrets), len(got), "not expected count of want and got to create secrets, got=%q", joinSecretNames(got))
+		assert.Equal(t, len(o.wantToUpdateSecrets), len(got1), "not expected count of want and got to update secrets, got=%q", joinSecretNames(got1))
 		for _, wantCreateName := range o.wantToCreateSecrets {
-			if !secretFound(got, wantCreateName) {
-				t.Errorf("wanted secret name: %s not found at toCreateSecrets", wantCreateName)
-			}
+			assert.True(t, secretFound(got, wantCreateName), "wanted secret name: %s not found at toCreateSecrets", wantCreateName)
 		}
 		for _, wantExistName := range o.wantToUpdateSecrets {
-			if !secretFound(got1, wantExistName) {
-				t.Errorf("wanted secret name: %s not found at existSecrets", wantExistName)
-			}
+			assert.True(t, secretFound(got1, wantExistName), "wanted secret name: %s not found at existSecrets", wantExistName)
 		}
 	}
 

--- a/internal/controller/operator/factory/vtsingle/vtsingle_test.go
+++ b/internal/controller/operator/factory/vtsingle/vtsingle_test.go
@@ -30,9 +30,10 @@ func TestCreateOrUpdate(t *testing.T) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects(opts.predefinedObjects)
 		err := CreateOrUpdate(context.TODO(), fclient, opts.cr)
-		if (err != nil) != opts.wantErr {
-			t.Errorf("CreateOrUpdate() error = %v, wantErr %v", err, opts.wantErr)
-			return
+		if opts.wantErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 
@@ -155,11 +156,13 @@ func TestCreateOrUpdateService(t *testing.T) {
 	f := func(o opts) {
 		fclient := k8stools.GetTestClientWithObjects(o.predefinedObjects)
 		ctx := context.TODO()
-		svc := build.Service(o.cr, o.cr.Spec.Port, nil)
-		if err := createOrUpdateService(ctx, fclient, o.cr, nil); (err != nil) != o.wantErr {
-			t.Errorf("CreateOrUpdateService() error = %v, wantErr %v", err, o.wantErr)
+		err := createOrUpdateService(ctx, fclient, o.cr, nil)
+		if o.wantErr {
+			assert.Error(t, err)
 			return
 		}
+		assert.NoError(t, err)
+		svc := build.Service(o.cr, o.cr.Spec.Port, nil)
 		var got corev1.Service
 		nsn := types.NamespacedName{
 			Name:      svc.Name,


### PR DESCRIPTION
Testify asserts produce a significantly better output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced most t.Fatalf/t.Errorf in tests with testify assertions for clearer failures and cleaner test code. No functional changes; tests only.

- **Refactors**
  - Switched manual checks to assert.NoError/assert.Error/assert.Equal and related helpers.
  - Replaced reflect.DeepEqual with assert.Equal and removed reflect imports.
  - Standardized validations with assert.Contains/assert.Empty/assert.NotNil/assert.Len/assert.True.
  - Used assertions to simplify control flow instead of manual if/return paths.
  - Applied across v1beta1 API and operator factory tests (build, converter, k8stools, reconcile, vmagent, vmalert, vmalertmanager, vlagent, vlsingle, vtsingle, vmauth, vmanomaly).

<sup>Written for commit e9909ed2ad066068ed83118e6738dd220a687cc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

