### PR TITLE
vmagent: removed rbac migration function

### DIFF
--- a/api/operator/v1/vlagent_types.go
+++ b/api/operator/v1/vlagent_types.go
@@ -469,7 +469,7 @@ func (cr *VLAgent) ProbePort() string {
 	return cr.Spec.Port
 }
 
-func (cr *VLAgent) GetClusterRoleName() string {
+func (cr *VLAgent) GetRBACName() string {
 	return fmt.Sprintf("monitoring:%s:vlagent-%s", cr.Namespace, cr.Name)
 }
 

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -553,7 +553,7 @@ func (cr *VMAgent) IsOwnsServiceAccount() bool {
 	return cr.Spec.ServiceAccountName == ""
 }
 
-func (cr *VMAgent) GetClusterRoleName() string {
+func (cr *VMAgent) GetRBACName() string {
 	return fmt.Sprintf("monitoring:%s:%s", cr.Namespace, cr.PrefixedName())
 }
 

--- a/internal/controller/operator/factory/finalize/vlagent.go
+++ b/internal/controller/operator/factory/finalize/vlagent.go
@@ -49,17 +49,17 @@ func OnVLAgentDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLAgen
 		return err
 	}
 	if config.IsClusterWideAccessAllowed() {
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRoleBinding{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRoleBinding{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRole{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRole{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
-		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.GetNamespace()}}); err != nil {
+		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.GetNamespace()}}); err != nil {
 			return err
 		}
 
-		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.GetNamespace()}}); err != nil {
+		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.GetNamespace()}}); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/finalize/vmagent.go
+++ b/internal/controller/operator/factory/finalize/vmagent.go
@@ -68,24 +68,24 @@ func OnVMAgentDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.V
 	}
 	// remove vmagents service discovery rbac.
 	if config.IsClusterWideAccessAllowed() {
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRoleBinding{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRoleBinding{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRole{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.ClusterRole{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
-		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.GetNamespace()}}); err != nil {
+		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.GetNamespace()}}); err != nil {
 			return err
 		}
 
-		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.GetNamespace()}}); err != nil {
+		if err := SafeDelete(ctx, rclient, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.GetNamespace()}}); err != nil {
 			return err
 		}
 	} else {
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.RoleBinding{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.RoleBinding{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
-		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.Role{}, cr.GetClusterRoleName(), cr.GetNamespace()); err != nil {
+		if err := removeFinalizeObjByName(ctx, rclient, &rbacv1.Role{}, cr.GetRBACName(), cr.GetNamespace()); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/vlagent/rbac.go
+++ b/internal/controller/operator/factory/vlagent/rbac.go
@@ -67,7 +67,7 @@ func ensureCRBExist(ctx context.Context, rclient client.Client, cr, prevCR *vmv1
 func buildCRB(cr *vmv1.VLAgent) *rbacv1.ClusterRoleBinding {
 	o := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.GetClusterRoleName(),
+			Name:        cr.GetRBACName(),
 			Labels:      cr.FinalLabels(),
 			Annotations: cr.FinalAnnotations(),
 			Finalizers:  []string{vmv1beta1.FinalizerName},
@@ -79,7 +79,7 @@ func buildCRB(cr *vmv1.VLAgent) *rbacv1.ClusterRoleBinding {
 		}},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
-			Name:     cr.GetClusterRoleName(),
+			Name:     cr.GetRBACName(),
 			Kind:     "ClusterRole",
 		},
 	}
@@ -93,7 +93,7 @@ func buildCRB(cr *vmv1.VLAgent) *rbacv1.ClusterRoleBinding {
 func buildCR(cr *vmv1.VLAgent) *rbacv1.ClusterRole {
 	o := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.GetClusterRoleName(),
+			Name:        cr.GetRBACName(),
 			Labels:      cr.FinalLabels(),
 			Annotations: cr.FinalAnnotations(),
 			Finalizers:  []string{vmv1beta1.FinalizerName},

--- a/internal/controller/operator/factory/vlagent/vlagent.go
+++ b/internal/controller/operator/factory/vlagent/vlagent.go
@@ -733,7 +733,7 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1.VLAgent
 		}
 	}
 	if (!cr.IsOwnsServiceAccount() || !cr.Spec.K8sCollector.Enabled) && config.IsClusterWideAccessAllowed() {
-		rbacMeta := metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.Namespace}
+		rbacMeta := metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.Namespace}
 		objects := []client.Object{
 			&rbacv1.ClusterRoleBinding{ObjectMeta: rbacMeta},
 			&rbacv1.ClusterRole{ObjectMeta: rbacMeta},

--- a/internal/controller/operator/factory/vmagent/rbac_test.go
+++ b/internal/controller/operator/factory/vmagent/rbac_test.go
@@ -47,7 +47,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.ClusterRole
 			nsn := types.NamespacedName{
-				Name: cr.GetClusterRoleName(),
+				Name: cr.GetRBACName(),
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))
 			assert.Len(t, got.Rules, 6)
@@ -67,7 +67,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.Role
 			nsn := types.NamespacedName{
-				Name:      cr.GetClusterRoleName(),
+				Name:      cr.GetRBACName(),
 				Namespace: cr.Namespace,
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))
@@ -100,7 +100,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.ClusterRole
 			nsn := types.NamespacedName{
-				Name: cr.GetClusterRoleName(),
+				Name: cr.GetRBACName(),
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))
 			assert.Len(t, got.Rules, 1)
@@ -132,7 +132,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.Role
 			nsn := types.NamespacedName{
-				Name:      cr.GetClusterRoleName(),
+				Name:      cr.GetRBACName(),
 				Namespace: cr.Namespace,
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))
@@ -157,7 +157,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.ClusterRole
 			nsn := types.NamespacedName{
-				Name: cr.GetClusterRoleName(),
+				Name: cr.GetRBACName(),
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))
 			assert.Empty(t, got.Rules)
@@ -181,7 +181,7 @@ func TestCreateVMAgentRBAC(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) {
 			var got rbacv1.Role
 			nsn := types.NamespacedName{
-				Name:      cr.GetClusterRoleName(),
+				Name:      cr.GetRBACName(),
 				Namespace: cr.Namespace,
 			}
 			assert.NoError(t, rclient.Get(ctx, nsn, &got))

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -1185,7 +1185,7 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 			return fmt.Errorf("cannot remove serviceaccount: %w", err)
 		}
 
-		rbacMeta := metav1.ObjectMeta{Name: cr.GetClusterRoleName(), Namespace: cr.Namespace}
+		rbacMeta := metav1.ObjectMeta{Name: cr.GetRBACName(), Namespace: cr.Namespace}
 		var objects []client.Object
 		if config.IsClusterWideAccessAllowed() {
 			objects = []client.Object{


### PR DESCRIPTION
removed old style named rbac migration form vmagent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed legacy RBAC migration logic in vmagent and dropped its E2E coverage. Aligned RBAC naming to GetRBACName for vmagent and vlagent.

- **Migration**
  - RBAC objects with the prefix monitoring:vmagent-cluster-access- are no longer auto-removed.
  - Manually delete any leftover Role/RoleBinding or ClusterRole/ClusterRoleBinding with that prefix.

<sup>Written for commit 32a536f402c0eeeee0edb3287392cc06648241ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

