### PR TITLE
docs: updated API templates

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,6 @@ tags:
 - [operator.victoriametrics.com/v1alpha1](#operatorvictoriametricscomv1alpha1)
 - [operator.victoriametrics.com/v1beta1](#operatorvictoriametricscomv1beta1)
 
-
 ## operator.victoriametrics.com/v1
 
 Package v1 contains API Schema definitions for the operator v1 API group
@@ -34,8 +33,6 @@ Package v1 contains API Schema definitions for the operator v1 API group
 - [VTCluster](#vtcluster)
 - [VTSingle](#vtsingle)
 
-
-
 #### FieldsListString
 
 _Underlying type:_ _string_
@@ -44,12 +41,7 @@ FieldsListString represents list of json encoded strings
 ["field"] or ["field1","field2"]
 
 Appears in: [SyslogTCPListener](#syslogtcplistener), [SyslogUDPListener](#syslogudplistener)
-
-
-
 #### OAuth2
-
-
 
 OAuth2 defines OAuth2 configuration parameters
 with optional references to secrets with corresponding sensitive values
@@ -66,10 +58,7 @@ Appears in: [VLAgentRemoteWriteSpec](#vlagentremotewritespec)
 | scopes<a href="#oauth2-scopes" id="oauth2-scopes">#</a><br/>_string array_ | _(Optional)_<br/>Scopes used for the token request |
 | tokenURL<a href="#oauth2-tokenurl" id="oauth2-tokenurl">#</a><br/>_string_ | _(Required)_<br/>TokenURL defines URL to fetch the token from |
 
-
 #### SyslogServerSpec
-
-
 
 SyslogServerSpec defines syslog servers configuration
 
@@ -80,10 +69,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSingleSpec](#
 | tcpListeners<a href="#syslogserverspec-tcplisteners" id="syslogserverspec-tcplisteners">#</a><br/>_[SyslogTCPListener](#syslogtcplistener) array_ | _(Required)_<br/>TCPListeners defines syslog server TCP listener configuration |
 | udpListeners<a href="#syslogserverspec-udplisteners" id="syslogserverspec-udplisteners">#</a><br/>_[SyslogUDPListener](#syslogudplistener) array_ | _(Required)_<br/>UDPListeners defines syslog server UDP listener configuration |
 
-
 #### SyslogTCPListener
-
-
 
 SyslogTCPListener defines configuration for TCP syslog server listen
 
@@ -99,10 +85,7 @@ Appears in: [SyslogServerSpec](#syslogserverspec)
 | tenantID<a href="#syslogtcplistener-tenantid" id="syslogtcplistener-tenantid">#</a><br/>_string_ | _(Optional)_<br/>TenantID for logs ingested in form of accountID:projectID<br />see https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs |
 | tlsConfig<a href="#syslogtcplistener-tlsconfig" id="syslogtcplistener-tlsconfig">#</a><br/>_[TLSServerConfig](#tlsserverconfig)_ | _(Optional)_<br/> |
 
-
 #### SyslogUDPListener
-
-
 
 SyslogUDPListener defines configuration for UDP syslog server listen
 
@@ -117,10 +100,7 @@ Appears in: [SyslogServerSpec](#syslogserverspec)
 | streamFields<a href="#syslogudplistener-streamfields" id="syslogudplistener-streamfields">#</a><br/>_[FieldsListString](#fieldsliststring)_ | _(Optional)_<br/>StreamFields to use as log stream labels<br />see https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields |
 | tenantID<a href="#syslogudplistener-tenantid" id="syslogudplistener-tenantid">#</a><br/>_string_ | _(Optional)_<br/>TenantID for logs ingested in form of accountID:projectID<br />see https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs |
 
-
 #### TLSConfig
-
-
 
 TLSConfig specifies TLS configuration parameters
 with optional references to secrets with corresponding sensitive values
@@ -138,10 +118,7 @@ Appears in: [VLAgentRemoteWriteSpec](#vlagentremotewritespec)
 | keySecretKeyRef<a href="#tlsconfig-keysecretkeyref" id="tlsconfig-keysecretkeyref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>CertSecret defines secret reference with TLS key by given key |
 | serverName<a href="#tlsconfig-servername" id="tlsconfig-servername">#</a><br/>_string_ | _(Optional)_<br/>Used to verify the hostname for the targets. |
 
-
 #### TLSServerConfig
-
-
 
 TLSServerConfig defines VictoriaMetrics TLS configuration for the application's server
 
@@ -154,14 +131,9 @@ Appears in: [SyslogTCPListener](#syslogtcplistener)
 | keyFile<a href="#tlsserverconfig-keyfile" id="tlsserverconfig-keyfile">#</a><br/>_string_ | _(Optional)_<br/>KeyFile defines path to the pre-mounted file with certificate key<br />mutually exclusive with KeySecretRef |
 | keySecret<a href="#tlsserverconfig-keysecret" id="tlsserverconfig-keysecret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Key defines reference for secret with certificate key content under given key<br />mutually exclusive with KeyFile |
 
-
 #### VLAgent
 
-
-
 VLAgent - is a tiny but brave agent, which helps you collect logs from various sources and stores them in VictoriaLogs.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -170,12 +142,7 @@ VLAgent - is a tiny but brave agent, which helps you collect logs from various s
 | metadata<a href="#vlagent-metadata" id="vlagent-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vlagent-spec" id="vlagent-spec">#</a><br/>_[VLAgentSpec](#vlagentspec)_ | _(Required)_<br/> |
 
-
 #### VLAgentK8sCollector
-
-
-
-
 
 Appears in: [VLAgentSpec](#vlagentspec)
 
@@ -197,10 +164,7 @@ Appears in: [VLAgentSpec](#vlagentspec)
 | tenantID<a href="#vlagentk8scollector-tenantid" id="vlagentk8scollector-tenantid">#</a><br/>_string_ | _(Required)_<br/>TenantID defines default tenant ID to use for logs collected from pods in format: <accountID>:<projectID> |
 | timeFields<a href="#vlagentk8scollector-timefields" id="vlagentk8scollector-timefields">#</a><br/>_string array_ | _(Required)_<br/>TimeFields defines fields that may contain the _time field |
 
-
 #### VLAgentRemoteWriteSettings
-
-
 
 VLAgentRemoteWriteSettings - defines global settings for all remoteWrite urls.
 
@@ -215,10 +179,7 @@ Appears in: [VLAgentSpec](#vlagentspec)
 | showURL<a href="#vlagentremotewritesettings-showurl" id="vlagentremotewritesettings-showurl">#</a><br/>_boolean_ | _(Optional)_<br/>Whether to show -remoteWrite.url in the exported metrics. It is hidden by default, since it can contain sensitive auth info |
 | tmpDataPath<a href="#vlagentremotewritesettings-tmpdatapath" id="vlagentremotewritesettings-tmpdatapath">#</a><br/>_string_ | _(Optional)_<br/>Path to directory where temporary data for remote write component is stored.<br />Defaults to /vlagent-data/vlagent-remotewrite-data or /var/lib/vlagent-data/vlagent-remotewrite-data in collector mode |
 
-
 #### VLAgentRemoteWriteSpec
-
-
 
 VLAgentRemoteWriteSpec defines the remote storage configuration for VmAgent
 
@@ -236,10 +197,7 @@ Appears in: [VLAgentSpec](#vlagentspec)
 | tlsConfig<a href="#vlagentremotewritespec-tlsconfig" id="vlagentremotewritespec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig describes tls configuration for remote write target |
 | url<a href="#vlagentremotewritespec-url" id="vlagentremotewritespec-url">#</a><br/>_string_ | _(Required)_<br/>URL of the endpoint to send samples to. |
 
-
 #### VLAgentSpec
-
-
 
 VLAgentSpec defines the desired state of VLAgent
 
@@ -302,14 +260,9 @@ Appears in: [VLAgent](#vlagent)
 | volumeMounts<a href="#vlagentspec-volumemounts" id="vlagentspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vlagentspec-volumes" id="vlagentspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VLCluster
 
-
-
 VLCluster is fast, cost-effective and scalable logs database.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -318,10 +271,7 @@ VLCluster is fast, cost-effective and scalable logs database.
 | metadata<a href="#vlcluster-metadata" id="vlcluster-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vlcluster-spec" id="vlcluster-spec">#</a><br/>_[VLClusterSpec](#vlclusterspec)_ | _(Required)_<br/> |
 
-
 #### VLClusterSpec
-
-
 
 VLClusterSpec defines the desired state of VLCluster
 
@@ -342,10 +292,7 @@ Appears in: [VLCluster](#vlcluster)
 | vlselect<a href="#vlclusterspec-vlselect" id="vlclusterspec-vlselect">#</a><br/>_[VLSelect](#vlselect)_ | _(Required)_<br/> |
 | vlstorage<a href="#vlclusterspec-vlstorage" id="vlclusterspec-vlstorage">#</a><br/>_[VLStorage](#vlstorage)_ | _(Required)_<br/> |
 
-
 #### VLInsert
-
-
 
 VLInsert defines vlinsert component configuration at victoria-logs cluster
 
@@ -401,10 +348,7 @@ Appears in: [VLClusterSpec](#vlclusterspec)
 | volumes<a href="#vlinsert-volumes" id="vlinsert-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vlinsert-vpa" id="vlinsert-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VLSelect
-
-
 
 VLSelect defines vlselect component configuration at victoria-logs cluster
 
@@ -460,15 +404,10 @@ Appears in: [VLClusterSpec](#vlclusterspec)
 | volumes<a href="#vlselect-volumes" id="vlselect-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vlselect-vpa" id="vlselect-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VLSingle
-
-
 
 VLSingle is fast, cost-effective and scalable logs database.
 VLSingle is the Schema for the API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -477,10 +416,7 @@ VLSingle is the Schema for the API
 | metadata<a href="#vlsingle-metadata" id="vlsingle-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vlsingle-spec" id="vlsingle-spec">#</a><br/>_[VLSingleSpec](#vlsinglespec)_ | _(Required)_<br/> |
 
-
 #### VLSingleSpec
-
-
 
 VLSingleSpec defines the desired state of VLSingle
 
@@ -542,10 +478,7 @@ Appears in: [VLSingle](#vlsingle)
 | volumeMounts<a href="#vlsinglespec-volumemounts" id="vlsinglespec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vlsinglespec-volumes" id="vlsinglespec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VLStorage
-
-
 
 VLStorage defines vlstorage component configuration at victoria-logs cluster
 
@@ -611,10 +544,7 @@ Appears in: [VLClusterSpec](#vlclusterspec)
 | volumes<a href="#vlstorage-volumes" id="vlstorage-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vlstorage-vpa" id="vlstorage-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VLStorageNode
-
-
 
 VLStorageNode defines slice of additional vlstorage nodes
 
@@ -624,14 +554,9 @@ Appears in: [VLSelect](#vlselect)
 | --- | --- |
 | addr<a href="#vlstoragenode-addr" id="vlstoragenode-addr">#</a><br/>_string_ | _(Required)_<br/>Addr defines storage node address |
 
-
 #### VMAnomaly
 
-
-
 VMAnomaly is the Schema for the vmanomalies API.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -640,10 +565,7 @@ VMAnomaly is the Schema for the vmanomalies API.
 | metadata<a href="#vmanomaly-metadata" id="vmanomaly-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmanomaly-spec" id="vmanomaly-spec">#</a><br/>_[VMAnomalySpec](#vmanomalyspec)_ | _(Required)_<br/> |
 
-
 #### VMAnomalyHTTPClientSpec
-
-
 
 VMAnomalyHTTPClientSpec defines the desired state of VMAnomalyHTTPClient
 
@@ -658,10 +580,7 @@ Appears in: [VMAnomalyMonitoringPushSpec](#vmanomalymonitoringpushspec), [VMAnom
 | timeout<a href="#vmanomalyhttpclientspec-timeout" id="vmanomalyhttpclientspec-timeout">#</a><br/>_string_ | _(Required)_<br/>Timeout for the requests, passed as a string |
 | tlsConfig<a href="#vmanomalyhttpclientspec-tlsconfig" id="vmanomalyhttpclientspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Required)_<br/>TLSConfig defines tls connection configuration |
 
-
 #### VMAnomalyMonitoringPullSpec
-
-
 
 VMAnomalyMonitoringPullSpec defines pull monitoring configuration
 which is enabled by default and served at POD_IP:8490/metrics
@@ -672,10 +591,7 @@ Appears in: [VMAnomalyMonitoringSpec](#vmanomalymonitoringspec)
 | --- | --- |
 | port<a href="#vmanomalymonitoringpullspec-port" id="vmanomalymonitoringpullspec-port">#</a><br/>_string_ | _(Required)_<br/>Port defines a port for metrics scrape |
 
-
 #### VMAnomalyMonitoringPushSpec
-
-
 
 VMAnomalyMonitoringPushSpec defines metrics push configuration
 
@@ -695,10 +611,7 @@ Appears in: [VMAnomalyMonitoringSpec](#vmanomalymonitoringspec)
 | tlsConfig<a href="#vmanomalymonitoringpushspec-tlsconfig" id="vmanomalymonitoringpushspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Required)_<br/>TLSConfig defines tls connection configuration |
 | url<a href="#vmanomalymonitoringpushspec-url" id="vmanomalymonitoringpushspec-url">#</a><br/>_string_ | _(Required)_<br/>defines target url for push requests |
 
-
 #### VMAnomalyMonitoringSpec
-
-
 
 VMAnomalyMonitoringSpec defines configuration for VMAnomaly monitoring
 See https://docs.victoriametrics.com/anomaly-detection/components/monitoring/
@@ -710,10 +623,7 @@ Appears in: [VMAnomalySpec](#vmanomalyspec)
 | pull<a href="#vmanomalymonitoringspec-pull" id="vmanomalymonitoringspec-pull">#</a><br/>_[VMAnomalyMonitoringPullSpec](#vmanomalymonitoringpullspec)_ | _(Required)_<br/> |
 | push<a href="#vmanomalymonitoringspec-push" id="vmanomalymonitoringspec-push">#</a><br/>_[VMAnomalyMonitoringPushSpec](#vmanomalymonitoringpushspec)_ | _(Required)_<br/> |
 
-
 #### VMAnomalyReadersSpec
-
-
 
 VMAnomalyReadersSpec defines reader configuration for VMAnomaly
 
@@ -737,10 +647,7 @@ Appears in: [VMAnomalySpec](#vmanomalyspec)
 | tlsConfig<a href="#vmanomalyreadersspec-tlsconfig" id="vmanomalyreadersspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Required)_<br/>TLSConfig defines tls connection configuration |
 | tz<a href="#vmanomalyreadersspec-tz" id="vmanomalyreadersspec-tz">#</a><br/>_string_ | _(Required)_<br/>Optional argumentspecifies the IANA timezone to account for local shifts, like DST, in models sensitive to seasonal patterns |
 
-
 #### VMAnomalyServerSpec
-
-
 
 VMAnomalyServerSpec defines HTTP server configuration for VMAnomaly
 See docs: https://docs.victoriametrics.com/anomaly-detection/components/server/
@@ -755,10 +662,7 @@ Appears in: [VMAnomalySpec](#vmanomalyspec)
 | port<a href="#vmanomalyserverspec-port" id="vmanomalyserverspec-port">#</a><br/>_string_ | _(Optional)_<br/>Port defines port to listen on |
 | uiDefaultState<a href="#vmanomalyserverspec-uidefaultstate" id="vmanomalyserverspec-uidefaultstate">#</a><br/>_string_ | _(Optional)_<br/>UIDefaultState defines default query state for anomaly UI |
 
-
 #### VMAnomalySpec
-
-
 
 VMAnomalySpec defines the desired state of VMAnomaly.
 
@@ -821,10 +725,7 @@ Appears in: [VMAnomaly](#vmanomaly)
 | volumes<a href="#vmanomalyspec-volumes" id="vmanomalyspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | writer<a href="#vmanomalyspec-writer" id="vmanomalyspec-writer">#</a><br/>_[VMAnomalyWritersSpec](#vmanomalywritersspec)_ | _(Required)_<br/>Metrics destination for VMAnomaly<br />See https://docs.victoriametrics.com/anomaly-detection/components/writer/ |
 
-
 #### VMAnomalyVMWriterMetricFormatSpec
-
-
 
 VMAnomalyVMWriterMetricFormatSpec defines the desired state of VMAnomalyVMWriterMetricFormat
 
@@ -836,10 +737,7 @@ Appears in: [VMAnomalyWritersSpec](#vmanomalywritersspec)
 | extraLabels<a href="#vmanomalyvmwritermetricformatspec-extralabels" id="vmanomalyvmwritermetricformatspec-extralabels">#</a><br/>_object (keys:string, values:string)_ | _(Required)_<br/>ExtraLabels defines additional labels to be added to the resulting metrics |
 | for<a href="#vmanomalyvmwritermetricformatspec-for" id="vmanomalyvmwritermetricformatspec-for">#</a><br/>_string_ | _(Required)_<br/>For is a special label with $QUERY_KEY placeholder |
 
-
 #### VMAnomalyWritersSpec
-
-
 
 VMAnomalyWritersSpec defines writer configuration for VMAnomaly
 
@@ -856,14 +754,9 @@ Appears in: [VMAnomalySpec](#vmanomalyspec)
 | timeout<a href="#vmanomalywritersspec-timeout" id="vmanomalywritersspec-timeout">#</a><br/>_string_ | _(Required)_<br/>Timeout for the requests, passed as a string |
 | tlsConfig<a href="#vmanomalywritersspec-tlsconfig" id="vmanomalywritersspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Required)_<br/>TLSConfig defines tls connection configuration |
 
-
 #### VTCluster
 
-
-
 VTCluster is fast, cost-effective and scalable traces database.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -872,10 +765,7 @@ VTCluster is fast, cost-effective and scalable traces database.
 | metadata<a href="#vtcluster-metadata" id="vtcluster-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vtcluster-spec" id="vtcluster-spec">#</a><br/>_[VTClusterSpec](#vtclusterspec)_ | _(Required)_<br/> |
 
-
 #### VTClusterSpec
-
-
 
 VTClusterSpec defines the desired state of VTCluster
 
@@ -895,10 +785,7 @@ Appears in: [VTCluster](#vtcluster)
 | storage<a href="#vtclusterspec-storage" id="vtclusterspec-storage">#</a><br/>_[VTStorage](#vtstorage)_ | _(Required)_<br/> |
 | useStrictSecurity<a href="#vtclusterspec-usestrictsecurity" id="vtclusterspec-usestrictsecurity">#</a><br/>_boolean_ | _(Optional)_<br/>UseStrictSecurity enables strict security mode for component<br />it restricts disk writes access<br />uses non-root user out of the box<br />drops not needed security permissions |
 
-
 #### VTInsert
-
-
 
 VTInsert defines vtinsert component configuration at victoria-traces cluster
 
@@ -953,10 +840,7 @@ Appears in: [VTClusterSpec](#vtclusterspec)
 | volumes<a href="#vtinsert-volumes" id="vtinsert-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vtinsert-vpa" id="vtinsert-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VTSelect
-
-
 
 VTSelect defines vtselect component configuration at victoria-traces cluster
 
@@ -1012,15 +896,10 @@ Appears in: [VTClusterSpec](#vtclusterspec)
 | volumes<a href="#vtselect-volumes" id="vtselect-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vtselect-vpa" id="vtselect-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VTSingle
-
-
 
 VTSingle is fast, cost-effective and scalable traces database.
 VTSingle is the Schema for the API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -1029,10 +908,7 @@ VTSingle is the Schema for the API
 | metadata<a href="#vtsingle-metadata" id="vtsingle-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vtsingle-spec" id="vtsingle-spec">#</a><br/>_[VTSingleSpec](#vtsinglespec)_ | _(Required)_<br/> |
 
-
 #### VTSingleSpec
-
-
 
 VTSingleSpec defines the desired state of VTSingle
 
@@ -1092,10 +968,7 @@ Appears in: [VTSingle](#vtsingle)
 | volumeMounts<a href="#vtsinglespec-volumemounts" id="vtsinglespec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vtsinglespec-volumes" id="vtsinglespec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VTStorage
-
-
 
 VTStorage defines vtstorage component configuration at victoria-traces cluster
 
@@ -1161,10 +1034,7 @@ Appears in: [VTClusterSpec](#vtclusterspec)
 | volumes<a href="#vtstorage-volumes" id="vtstorage-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vtstorage-vpa" id="vtstorage-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VTStorageNode
-
-
 
 VTStorageNode defines slice of additional vtstorage nodes
 
@@ -1175,7 +1045,6 @@ Appears in: [VTSelect](#vtselect)
 | addr<a href="#vtstoragenode-addr" id="vtstoragenode-addr">#</a><br/>_string_ | _(Required)_<br/>Addr defines storage node address |
 
 
-
 ## operator.victoriametrics.com/v1alpha1
 
 Package v1alpha1 contains API Schema definitions for the operator v1alpha1 API group.
@@ -1183,15 +1052,9 @@ Package v1alpha1 contains API Schema definitions for the operator v1alpha1 API g
 ### Resource Types
 - [VMDistributed](#vmdistributed)
 
-
-
 #### VMDistributed
 
-
-
 VMDistributed is progressively rolling out updates to multiple zone components.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -1200,10 +1063,7 @@ VMDistributed is progressively rolling out updates to multiple zone components.
 | metadata<a href="#vmdistributed-metadata" id="vmdistributed-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Optional)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmdistributed-spec" id="vmdistributed-spec">#</a><br/>_[VMDistributedSpec](#vmdistributedspec)_ | _(Required)_<br/>spec defines the desired state of VMDistributed |
 
-
 #### VMDistributedAuth
-
-
 
 VMDistributedAuth defines a VMAuth by name or inline spec
 
@@ -1214,10 +1074,7 @@ Appears in: [VMDistributedSpec](#vmdistributedspec)
 | name<a href="#vmdistributedauth-name" id="vmdistributedauth-name">#</a><br/>_string_ | _(Optional)_<br/>Name specifies the static name to be used for the VMDistributedAuth when Spec is provided. |
 | spec<a href="#vmdistributedauth-spec" id="vmdistributedauth-spec">#</a><br/>_[VMAuthSpec](#vmauthspec)_ | _(Optional)_<br/>Spec defines the desired state of a new VMAuth. |
 
-
 #### VMDistributedSpec
-
-
 
 VMDistributedSpec defines configurable parameters for VMDistributed CR
 
@@ -1232,10 +1089,7 @@ Appears in: [VMDistributed](#vmdistributed)
 | zoneCommon<a href="#vmdistributedspec-zonecommon" id="vmdistributedspec-zonecommon">#</a><br/>_[VMDistributedZoneCommon](#vmdistributedzonecommon)_ | _(Optional)_<br/>ZoneCommon defines common properties for all zones |
 | zones<a href="#vmdistributedspec-zones" id="vmdistributedspec-zones">#</a><br/>_[VMDistributedZone](#vmdistributedzone) array_ | _(Required)_<br/>Zones is a list of zones to update. Each item in the list represents a "zone" within the distributed setup. |
 
-
 #### VMDistributedZone
-
-
 
 VMDistributedZone defines items within a single zone to update.
 
@@ -1248,10 +1102,7 @@ Appears in: [VMDistributedSpec](#vmdistributedspec)
 | vmagent<a href="#vmdistributedzone-vmagent" id="vmdistributedzone-vmagent">#</a><br/>_[VMDistributedZoneAgent](#vmdistributedzoneagent)_ | _(Optional)_<br/>VMAgent defines VMAgent to balance incoming traffic between VMClusters. |
 | vmcluster<a href="#vmdistributedzone-vmcluster" id="vmdistributedzone-vmcluster">#</a><br/>_[VMDistributedZoneCluster](#vmdistributedzonecluster)_ | _(Optional)_<br/>VMCluster defines a new inline or referencing existing one VMCluster |
 
-
 #### VMDistributedZoneAgent
-
-
 
 VMDistributedZoneAgent is a name and a specification of a new VMAgent.
 
@@ -1262,10 +1113,7 @@ Appears in: [VMDistributedZone](#vmdistributedzone), [VMDistributedZoneCommon](#
 | name<a href="#vmdistributedzoneagent-name" id="vmdistributedzoneagent-name">#</a><br/>_string_ | _(Optional)_<br/>Name specifies the static name to be used for the VMAgent when Spec is provided. |
 | spec<a href="#vmdistributedzoneagent-spec" id="vmdistributedzoneagent-spec">#</a><br/>_[VMDistributedZoneAgentSpec](#vmdistributedzoneagentspec)_ | _(Optional)_<br/>Spec defines the desired state of a new VMAgent. |
 
-
 #### VMDistributedZoneAgentSpec
-
-
 
 VMDistributedZoneAgentSpec is a customized specification of a new VMAgent.
 It includes selected options from the original VMAgentSpec.
@@ -1326,10 +1174,7 @@ Appears in: [VMDistributedZoneAgent](#vmdistributedzoneagent)
 | volumeMounts<a href="#vmdistributedzoneagentspec-volumemounts" id="vmdistributedzoneagentspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vmdistributedzoneagentspec-volumes" id="vmdistributedzoneagentspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMDistributedZoneCluster
-
-
 
 VMDistributedZoneCluster defines the name and specification of a VMCluster to be created or updated.
 
@@ -1340,10 +1185,7 @@ Appears in: [VMDistributedZone](#vmdistributedzone), [VMDistributedZoneCommon](#
 | name<a href="#vmdistributedzonecluster-name" id="vmdistributedzonecluster-name">#</a><br/>_string_ | _(Optional)_<br/>Name specifies the static name to be used for the new VMCluster. |
 | spec<a href="#vmdistributedzonecluster-spec" id="vmdistributedzonecluster-spec">#</a><br/>_[VMClusterSpec](#vmclusterspec)_ | _(Optional)_<br/>Spec defines the desired state of a new or update spec for existing VMCluster. |
 
-
 #### VMDistributedZoneCommon
-
-
 
 VMDistributedZoneCommon defines items, that are common for all zones
 
@@ -1357,10 +1199,7 @@ Appears in: [VMDistributedSpec](#vmdistributedspec)
 | vmagent<a href="#vmdistributedzonecommon-vmagent" id="vmdistributedzonecommon-vmagent">#</a><br/>_[VMDistributedZoneAgent](#vmdistributedzoneagent)_ | _(Optional)_<br/>VMAgent defines VMAgent to balance incoming traffic between VMClusters. |
 | vmcluster<a href="#vmdistributedzonecommon-vmcluster" id="vmdistributedzonecommon-vmcluster">#</a><br/>_[VMDistributedZoneCluster](#vmdistributedzonecluster)_ | _(Optional)_<br/>VMCluster defines VictoriaMetrics cluster database |
 
-
 #### VMDistributedZoneRemoteWriteSpec
-
-
 
 VMDistributedZoneRemoteWriteSpec is a copy of VMAgentRemoteWriteSpec, which allows empty URLs and has no relabeling or stream aggregation
 These urls will be overwritten by the controller
@@ -1379,7 +1218,6 @@ Appears in: [VMDistributedZone](#vmdistributedzone), [VMDistributedZoneCommon](#
 | proxyURL<a href="#vmdistributedzoneremotewritespec-proxyurl" id="vmdistributedzoneremotewritespec-proxyurl">#</a><br/>_string_ | _(Optional)_<br/>ProxyURL for -remoteWrite.url. Supported proxies: http, https, socks5. Example: socks5://proxy:1234 |
 | sendTimeout<a href="#vmdistributedzoneremotewritespec-sendtimeout" id="vmdistributedzoneremotewritespec-sendtimeout">#</a><br/>_string_ | _(Optional)_<br/>Timeout for sending a single block of data to -remoteWrite.url (default 1m0s) |
 | tlsConfig<a href="#vmdistributedzoneremotewritespec-tlsconfig" id="vmdistributedzoneremotewritespec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig describes tls configuration for remote write target |
-
 
 
 ## operator.victoriametrics.com/v1beta1
@@ -1404,11 +1242,7 @@ Package v1beta1 contains API Schema definitions for the victoriametrics v1beta1 
 - [VMStaticScrape](#vmstaticscrape)
 - [VMUser](#vmuser)
 
-
-
 #### APIServerConfig
-
-
 
 APIServerConfig defines a host and auth methods to access apiserver.
 
@@ -1423,10 +1257,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMSingleSpec](#vmsinglespec)
 | host<a href="#apiserverconfig-host" id="apiserverconfig-host">#</a><br/>_string_ | _(Required)_<br/>Host of apiserver.<br />A valid string consisting of a hostname or IP followed by an optional port number |
 | tlsConfig<a href="#apiserverconfig-tlsconfig" id="apiserverconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig Config to use for accessing apiserver. |
 
-
 #### AWS
-
-
 
 AWS defines AWS cloud auth specific params
 
@@ -1441,10 +1272,7 @@ Appears in: [VMAgentRemoteWriteSpec](#vmagentremotewritespec), [VMDistributedZon
 | stsEndpoint<a href="#aws-stsendpoint" id="aws-stsendpoint">#</a><br/>_string_ | _(Required)_<br/>STSEndpoint is an optional AWS STS API endpoint to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set |
 | useSigv4<a href="#aws-usesigv4" id="aws-usesigv4">#</a><br/>_boolean_ | _(Required)_<br/>UseSigv4 enables SigV4 request signing for the corresponding -remoteWrite.url |
 
-
 #### AdditionalServiceSpec
-
-
 
 ServiceSpec defines additional service for CRD with user-defined params.
 by default, some of fields can be inherited from default service definition for the CRD:
@@ -1460,10 +1288,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | spec<a href="#additionalservicespec-spec" id="additionalservicespec-spec">#</a><br/>_[ServiceSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#servicespec-v1-core)_ | _(Required)_<br/>ServiceSpec describes the attributes that a user creates on a service.<br />More info: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | useAsDefault<a href="#additionalservicespec-useasdefault" id="additionalservicespec-useasdefault">#</a><br/>_boolean_ | _(Optional)_<br/>UseAsDefault applies changes from given service definition to the main object Service<br />Changing from headless service to clusterIP or loadbalancer may break cross-component communication |
 
-
 #### ArbitraryFSAccessThroughSMsConfig
-
-
 
 ArbitraryFSAccessThroughSMsConfig enables users to configure, whether
 a service scrape selected by the vmagent instance is allowed to use
@@ -1480,10 +1305,7 @@ Appears in: [CommonScrapeParams](#commonscrapeparams), [CommonScrapeSecurityEnfo
 | --- | --- |
 | deny<a href="#arbitraryfsaccessthroughsmsconfig-deny" id="arbitraryfsaccessthroughsmsconfig-deny">#</a><br/>_boolean_ | _(Required)_<br/> |
 
-
 #### AttachMetadata
-
-
 
 AttachMetadata configures metadata attachment
 
@@ -1494,10 +1316,7 @@ Appears in: [Endpoint](#endpoint), [KubernetesSDConfig](#kubernetessdconfig), [P
 | namespace<a href="#attachmetadata-namespace" id="attachmetadata-namespace">#</a><br/>_boolean_ | _(Required)_<br/>Namespace instructs vmagent or vmsingle to add namespace specific metadata from service discovery<br />Valid for roles: pod, service, endpoints, endpointslice, ingress. |
 | node<a href="#attachmetadata-node" id="attachmetadata-node">#</a><br/>_boolean_ | _(Optional)_<br/>Node instructs vmagent or vmsingle to add node specific metadata from service discovery<br />Valid for roles: pod, endpoints, endpointslice. |
 
-
 #### Authorization
-
-
 
 Authorization configures generic authorization params
 
@@ -1509,10 +1328,7 @@ Appears in: [APIServerConfig](#apiserverconfig), [ConsulSDConfig](#consulsdconfi
 | credentialsFile<a href="#authorization-credentialsfile" id="authorization-credentialsfile">#</a><br/>_string_ | _(Optional)_<br/>File with value for authorization |
 | type<a href="#authorization-type" id="authorization-type">#</a><br/>_string_ | _(Optional)_<br/>Type of authorization, default to bearer |
 
-
 #### AzureSDConfig
-
-
 
 AzureSDConfig allow retrieving scrape targets from Azure VMs.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#azure_sd_configs)
@@ -1530,10 +1346,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | subscriptionID<a href="#azuresdconfig-subscriptionid" id="azuresdconfig-subscriptionid">#</a><br/>_string_ | _(Required)_<br/>The subscription ID. Always required. |
 | tenantID<a href="#azuresdconfig-tenantid" id="azuresdconfig-tenantid">#</a><br/>_string_ | _(Optional)_<br/>Optional tenant ID. Only required with the OAuth authentication method. |
 
-
 #### BasicAuth
-
-
 
 BasicAuth allow an endpoint to authenticate over basic authentication
 
@@ -1545,10 +1358,7 @@ Appears in: [APIServerConfig](#apiserverconfig), [ConsulSDConfig](#consulsdconfi
 | password_file<a href="#basicauth-password_file" id="basicauth-password_file">#</a><br/>_string_ | _(Optional)_<br/>PasswordFile defines path to password file at disk<br />must be pre-mounted |
 | username<a href="#basicauth-username" id="basicauth-username">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Username defines reference for secret with username value<br />The secret needs to be in the same namespace as scrape object |
 
-
 #### BearerAuth
-
-
 
 BearerAuth defines auth with bearer token
 
@@ -1559,7 +1369,6 @@ Appears in: [HTTPAuth](#httpauth), [VMAlertDatasourceSpec](#vmalertdatasourcespe
 | bearerTokenFile<a href="#bearerauth-bearertokenfile" id="bearerauth-bearertokenfile">#</a><br/>_string_ | _(Optional)_<br/>Path to bearer token file |
 | bearerTokenSecret<a href="#bearerauth-bearertokensecret" id="bearerauth-bearertokensecret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Optional bearer auth token to use for -remoteWrite.url |
 
-
 #### BytesString
 
 _Underlying type:_ _string_
@@ -1568,12 +1377,7 @@ BytesString represents bytes value defined directly as integer
 or as a string with suffix - kb,mb,gb,tb,KiB,MiB,GiB,TiB
 
 Appears in: [VLAgentRemoteWriteSettings](#vlagentremotewritesettings), [VLAgentRemoteWriteSpec](#vlagentremotewritespec), [VLSingleSpec](#vlsinglespec), [VLStorage](#vlstorage), [VMAgentRemoteWriteSettings](#vmagentremotewritesettings), [VMAgentRemoteWriteSpec](#vmagentremotewritespec), [VMDistributedZoneRemoteWriteSpec](#vmdistributedzoneremotewritespec), [VTSingleSpec](#vtsinglespec), [VTStorage](#vtstorage)
-
-
-
 #### CRDRef
-
-
 
 CRDRef describe CRD target reference.
 
@@ -1585,10 +1389,7 @@ Appears in: [TargetRef](#targetref)
 | name<a href="#crdref-name" id="crdref-name">#</a><br/>_string_ | _(Required)_<br/>Name target CRD object name |
 | namespace<a href="#crdref-namespace" id="crdref-namespace">#</a><br/>_string_ | _(Required)_<br/>Namespace target CRD object namespace. |
 
-
 #### Certs
-
-
 
 Certs defines TLS certs configuration
 
@@ -1602,11 +1403,7 @@ Appears in: [TLSClientConfig](#tlsclientconfig), [TLSServerConfig](#tlsservercon
 | key_secret_ref<a href="#certs-key_secret_ref" id="certs-key_secret_ref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Key defines reference for secret with certificate key content under given key<br />mutually exclusive with KeyFile |
 
 
-
-
 #### CommonApplicationDeploymentParams
-
-
 
 CommonApplicationDeploymentParams defines common params
 for deployment and statefulset specifications
@@ -1646,12 +1443,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | volumeMounts<a href="#commonapplicationdeploymentparams-volumemounts" id="commonapplicationdeploymentparams-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#commonapplicationdeploymentparams-volumes" id="commonapplicationdeploymentparams-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### CommonConfigReloaderParams
-
-
-
-
 
 Appears in: [VMAgentSpec](#vmagentspec), [VMAlertSpec](#vmalertspec), [VMAlertmanagerSpec](#vmalertmanagerspec), [VMAuthLoadBalancerSpec](#vmauthloadbalancerspec), [VMAuthSpec](#vmauthspec), [VMSingleSpec](#vmsinglespec)
 
@@ -1664,10 +1456,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMAlertSpec](#vmalertspec), [VMAlertma
 | configReloaderResources<a href="#commonconfigreloaderparams-configreloaderresources" id="commonconfigreloaderparams-configreloaderresources">#</a><br/>_[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#resourcerequirements-v1-core)_ | _(Optional)_<br/>ConfigReloaderResources config-reloader container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br />if not defined default resources from operator config will be used |
 | useVMConfigReloader<a href="#commonconfigreloaderparams-usevmconfigreloader" id="commonconfigreloaderparams-usevmconfigreloader">#</a><br/>_boolean_ | _(Optional)_<br/>UseVMConfigReloader replaces prometheus-like config-reloader<br />with vm one. It uses secrets watch instead of file watch<br />which greatly increases speed of config updates<br />Removed since v0.67.0: this property is ignored and no longer needed |
 
-
 #### CommonDefaultableParams
-
-
 
 CommonDefaultableParams contains Application settings
 with known values populated from operator configuration
@@ -1683,10 +1472,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | useDefaultResources<a href="#commondefaultableparams-usedefaultresources" id="commondefaultableparams-usedefaultresources">#</a><br/>_boolean_ | _(Optional)_<br/>UseDefaultResources controls resource settings<br />By default, operator sets built-in resource requirements |
 | useStrictSecurity<a href="#commondefaultableparams-usestrictsecurity" id="commondefaultableparams-usestrictsecurity">#</a><br/>_boolean_ | _(Optional)_<br/>UseStrictSecurity enables strict security mode for component<br />it restricts disk writes access<br />uses non-root user out of the box<br />drops not needed security permissions |
 
-
 #### CommonRelabelParams
-
-
 
 CommonRelabelParams defines params for relabelling
 
@@ -1697,12 +1483,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMSingleSpec](#vmsinglespec)
 | inlineRelabelConfig<a href="#commonrelabelparams-inlinerelabelconfig" id="commonrelabelparams-inlinerelabelconfig">#</a><br/>_[RelabelConfig](#relabelconfig) array_ | _(Optional)_<br/>InlineRelabelConfig - defines GlobalRelabelConfig for vmagent, can be defined directly at CRD. |
 | relabelConfig<a href="#commonrelabelparams-relabelconfig" id="commonrelabelparams-relabelconfig">#</a><br/>_[ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core)_ | _(Optional)_<br/>RelabelConfig ConfigMap with global relabel config -remoteWrite.relabelConfig<br />This relabeling is applied to all the collected metrics before sending them to remote storage. |
 
-
 #### CommonScrapeParams
-
-
-
-
 
 Appears in: [VMAgentSpec](#vmagentspec), [VMSingleSpec](#vmsinglespec)
 
@@ -1748,10 +1529,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMSingleSpec](#vmsinglespec)
 | staticScrapeSelector<a href="#commonscrapeparams-staticscrapeselector" id="commonscrapeparams-staticscrapeselector">#</a><br/>_[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | _(Optional)_<br/>StaticScrapeSelector defines VMStaticScrape to be selected for target discovery.<br />Works in combination with NamespaceSelector.<br />If both nil - match everything.<br />NamespaceSelector nil - only objects at VMAgent or VMSingle namespace.<br />Selector nil - only objects at NamespaceSelector namespaces. |
 | vmAgentExternalLabelName<a href="#commonscrapeparams-vmagentexternallabelname" id="commonscrapeparams-vmagentexternallabelname">#</a><br/>_string_ | _(Optional)_<br/>VMAgentExternalLabelName Name of vmAgent external label used to denote vmAgent instance<br />name. Defaults to the value of `prometheus`. External label will<br />_not_ be added when value is set to empty string (`""`).<br/><b>Deprecated: </b>since version <a href="https://docs.victoriametrics.com/operator/changelog/#v0670">v0.67.0</a> will be removed in <a href="https://docs.victoriametrics.com/operator/changelog/#v0690">v0.69.0</a> use <a href="#commonscrapeparams-externallabelname">externalLabelName</a> instead<br/> |
 
-
 #### CommonScrapeSecurityEnforcements
-
-
 
 CommonScrapeSecurityEnforcements defines security configuration for endpoint scrapping
 
@@ -1765,10 +1543,7 @@ Appears in: [CommonScrapeParams](#commonscrapeparams), [VMAgentSpec](#vmagentspe
 | overrideHonorLabels<a href="#commonscrapesecurityenforcements-overridehonorlabels" id="commonscrapesecurityenforcements-overridehonorlabels">#</a><br/>_boolean_ | _(Optional)_<br/>OverrideHonorLabels if set to true overrides all user configured honor_labels.<br />If HonorLabels is set in scrape objects to true, this overrides honor_labels to false. |
 | overrideHonorTimestamps<a href="#commonscrapesecurityenforcements-overridehonortimestamps" id="commonscrapesecurityenforcements-overridehonortimestamps">#</a><br/>_boolean_ | _(Optional)_<br/>OverrideHonorTimestamps allows to globally enforce honoring timestamps in all scrape configs. |
 
-
 #### ConfigMapKeyReference
-
-
 
 ConfigMapKeyReference refers to a key in a ConfigMap.
 
@@ -1779,10 +1554,7 @@ Appears in: [VMAlertmanagerSpec](#vmalertmanagerspec)
 | key<a href="#configmapkeyreference-key" id="configmapkeyreference-key">#</a><br/>_string_ | _(Required)_<br/>The ConfigMap key to refer to. |
 | name<a href="#configmapkeyreference-name" id="configmapkeyreference-name">#</a><br/>_string_ | _(Optional)_<br/>Name of the referent.<br />This field is effectively required, but due to backwards compatibility is<br />allowed to be empty. Instances of this type with an empty value here are<br />almost certainly wrong.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |
 
-
 #### ConsulSDConfig
-
-
 
 ConsulSDConfig defines a Consul service discovery configuration.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#consul_sd_configs)
@@ -1811,10 +1583,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | tlsConfig<a href="#consulsdconfig-tlsconfig" id="consulsdconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration to use on every scrape request |
 | tokenRef<a href="#consulsdconfig-tokenref" id="consulsdconfig-tokenref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Consul ACL TokenRef, if not provided it will use the ACL from the local Consul Agent. |
 
-
 #### ContainerSecurityContext
-
-
 
 ContainerSecurityContext defines security context for each application container
 
@@ -1828,10 +1597,7 @@ Appears in: [SecurityContext](#securitycontext)
 | procMount<a href="#containersecuritycontext-procmount" id="containersecuritycontext-procmount">#</a><br/>_[ProcMountType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#procmounttype-v1-core)_ | _(Optional)_<br/>procMount denotes the type of proc mount to use for the containers.<br />The default is DefaultProcMount which uses the container runtime defaults for<br />readonly paths and masked paths.<br />This requires the ProcMountType feature flag to be enabled.<br />Note that this field cannot be set when spec.os.name is windows. |
 | readOnlyRootFilesystem<a href="#containersecuritycontext-readonlyrootfilesystem" id="containersecuritycontext-readonlyrootfilesystem">#</a><br/>_boolean_ | _(Optional)_<br/>Whether this containers has a read-only root filesystem.<br />Default is false.<br />Note that this field cannot be set when spec.os.name is windows. |
 
-
 #### DNSSDConfig
-
-
 
 DNSSDConfig allows specifying a set of DNS domain names which are periodically queried to discover a list of targets.
 The DNS servers to be contacted are read from /etc/resolv.conf.
@@ -1845,10 +1611,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | port<a href="#dnssdconfig-port" id="dnssdconfig-port">#</a><br/>_integer_ | _(Optional)_<br/>The port number used if the query type is not SRV<br />Ignored for SRV records |
 | type<a href="#dnssdconfig-type" id="dnssdconfig-type">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### DigitalOceanSDConfig
-
-
 
 DigitalOceanSDConfig allow retrieving scrape targets from DigitalOcean's Droplets API.
 This service discovery uses the public IPv4 address by default, by that can be changed with relabeling.
@@ -1866,12 +1629,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | proxy_client_config<a href="#digitaloceansdconfig-proxy_client_config" id="digitaloceansdconfig-proxy_client_config">#</a><br/>_[ProxyAuth](#proxyauth)_ | _(Optional)_<br/>ProxyClientConfig configures proxy auth settings for scraping<br />See [feature description](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-targets-via-a-proxy) |
 | tlsConfig<a href="#digitaloceansdconfig-tlsconfig" id="digitaloceansdconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration to use on every scrape request |
 
-
 #### DiscordConfig
-
-
-
-
 
 Appears in: [Receiver](#receiver)
 
@@ -1887,10 +1645,7 @@ Appears in: [Receiver](#receiver)
 | webhook_url<a href="#discordconfig-webhook_url" id="discordconfig-webhook_url">#</a><br/>_string_ | _(Optional)_<br/>The discord webhook URL<br />one of `urlSecret` and `url` must be defined. |
 | webhook_url_secret<a href="#discordconfig-webhook_url_secret" id="discordconfig-webhook_url_secret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>URLSecret defines secret name and key at the CRD namespace.<br />It must contain the webhook URL.<br />one of `urlSecret` and `url` must be defined. |
 
-
 #### DiscoverySelector
-
-
 
 DiscoverySelector can be used at CRD components discovery
 
@@ -1901,10 +1656,7 @@ Appears in: [VMAlertNotifierSpec](#vmalertnotifierspec)
 | labelSelector<a href="#discoveryselector-labelselector" id="discoveryselector-labelselector">#</a><br/>_[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | _(Required)_<br/> |
 | namespaceSelector<a href="#discoveryselector-namespaceselector" id="discoveryselector-namespaceselector">#</a><br/>_[NamespaceSelector](#namespaceselector)_ | _(Required)_<br/> |
 
-
 #### EC2Filter
-
-
 
 EC2Filter is the configuration for filtering EC2 instances.
 
@@ -1915,10 +1667,7 @@ Appears in: [EC2SDConfig](#ec2sdconfig)
 | name<a href="#ec2filter-name" id="ec2filter-name">#</a><br/>_string_ | _(Required)_<br/> |
 | values<a href="#ec2filter-values" id="ec2filter-values">#</a><br/>_string array_ | _(Required)_<br/> |
 
-
 #### EC2SDConfig
-
-
 
 EC2SDConfig allow retrieving scrape targets from AWS EC2 instances.
 The private IP address is used by default, but may be changed to the public IP address with relabeling.
@@ -1936,10 +1685,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | roleARN<a href="#ec2sdconfig-rolearn" id="ec2sdconfig-rolearn">#</a><br/>_string_ | _(Optional)_<br/>AWS Role ARN, an alternative to using AWS API keys. |
 | secretKey<a href="#ec2sdconfig-secretkey" id="ec2sdconfig-secretkey">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>SecretKey is the AWS API secret. |
 
-
 #### EmailConfig
-
-
 
 EmailConfig configures notifications via Email.
 
@@ -1962,10 +1708,7 @@ Appears in: [Receiver](#receiver)
 | tls_config<a href="#emailconfig-tls_config" id="emailconfig-tls_config">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration |
 | to<a href="#emailconfig-to" id="emailconfig-to">#</a><br/>_string_ | _(Optional)_<br/>The email address to send notifications to. |
 
-
 #### EmbeddedHPA
-
-
 
 EmbeddedHPA embeds HorizontalPodAutoScaler spec v2.
 https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/
@@ -1979,10 +1722,7 @@ Appears in: [VLInsert](#vlinsert), [VLSelect](#vlselect), [VLStorage](#vlstorage
 | metrics<a href="#embeddedhpa-metrics" id="embeddedhpa-metrics">#</a><br/>_[MetricSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#metricspec-v2-autoscaling) array_ | _(Required)_<br/> |
 | minReplicas<a href="#embeddedhpa-minreplicas" id="embeddedhpa-minreplicas">#</a><br/>_integer_ | _(Required)_<br/> |
 
-
 #### EmbeddedHTTPRoute
-
-
 
 EmbeddedHTTPRoute describes httproute configuration options.
 
@@ -2000,10 +1740,7 @@ Appears in: [VMAuthSpec](#vmauthspec)
 | name<a href="#embeddedhttproute-name" id="embeddedhttproute-name">#</a><br/>_string_ | _(Optional)_<br/>Name must be unique within a namespace. Is required when creating resources, although<br />some resources may allow a client to request the generation of an appropriate name<br />automatically. Name is primarily intended for creation idempotence and configuration<br />definition.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names |
 | parentRefs<a href="#embeddedhttproute-parentrefs" id="embeddedhttproute-parentrefs">#</a><br/>_ParentReference array_ | _(Required)_<br/>ParentRefs references the resources (usually Gateways) that a Route wants to be attached to. |
 
-
 #### EmbeddedIngress
-
-
 
 EmbeddedIngress describes ingress configuration options.
 
@@ -2022,10 +1759,7 @@ Appears in: [VMAuthSpec](#vmauthspec)
 | tlsHosts<a href="#embeddedingress-tlshosts" id="embeddedingress-tlshosts">#</a><br/>_string array_ | _(Required)_<br/>TlsHosts configures TLS access for ingress, tlsSecretName must be defined for it. |
 | tlsSecretName<a href="#embeddedingress-tlssecretname" id="embeddedingress-tlssecretname">#</a><br/>_string_ | _(Optional)_<br/>TlsSecretName defines secretname at the VMAuth namespace with cert and key<br />https://kubernetes.io/docs/concepts/services-networking/ingress/#tls |
 
-
 #### EmbeddedObjectMetadata
-
-
 
 EmbeddedObjectMetadata contains a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta
 Only fields which are relevant to embedded resources are included.
@@ -2038,10 +1772,7 @@ Appears in: [AdditionalServiceSpec](#additionalservicespec), [EmbeddedHTTPRoute]
 | labels<a href="#embeddedobjectmetadata-labels" id="embeddedobjectmetadata-labels">#</a><br/>_object (keys:string, values:string)_ | _(Optional)_<br/>Labels Map of string keys and values that can be used to organize and categorize<br />(scope and select) objects. May match selectors of replication controllers<br />and services.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels |
 | name<a href="#embeddedobjectmetadata-name" id="embeddedobjectmetadata-name">#</a><br/>_string_ | _(Optional)_<br/>Name must be unique within a namespace. Is required when creating resources, although<br />some resources may allow a client to request the generation of an appropriate name<br />automatically. Name is primarily intended for creation idempotence and configuration<br />definition.<br />Cannot be updated.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names |
 
-
 #### EmbeddedPersistentVolumeClaim
-
-
 
 EmbeddedPersistentVolumeClaim is an embedded version of k8s.io/api/core/v1.PersistentVolumeClaim.
 It contains TypeMeta and a reduced ObjectMeta.
@@ -2053,12 +1784,7 @@ Appears in: [StorageSpec](#storagespec)
 | metadata<a href="#embeddedpersistentvolumeclaim-metadata" id="embeddedpersistentvolumeclaim-metadata">#</a><br/>_[EmbeddedObjectMetadata](#embeddedobjectmetadata)_ | _(Optional)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#embeddedpersistentvolumeclaim-spec" id="embeddedpersistentvolumeclaim-spec">#</a><br/>_[PersistentVolumeClaimSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaimspec-v1-core)_ | _(Optional)_<br/>Spec defines the desired characteristics of a volume requested by a pod author.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |
 
-
 #### EmbeddedPodDisruptionBudgetSpec
-
-
-
-
 
 Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlselect), [VLStorage](#vlstorage), [VMAgentSpec](#vmagentspec), [VMAlertSpec](#vmalertspec), [VMAlertmanagerSpec](#vmalertmanagerspec), [VMAnomalySpec](#vmanomalyspec), [VMAuthLoadBalancerSpec](#vmauthloadbalancerspec), [VMAuthSpec](#vmauthspec), [VMDistributedZoneAgentSpec](#vmdistributedzoneagentspec), [VMInsert](#vminsert), [VMSelect](#vmselect), [VMStorage](#vmstorage), [VTInsert](#vtinsert), [VTSelect](#vtselect), [VTStorage](#vtstorage)
 
@@ -2069,10 +1795,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | selectorLabels<a href="#embeddedpoddisruptionbudgetspec-selectorlabels" id="embeddedpoddisruptionbudgetspec-selectorlabels">#</a><br/>_object (keys:string, values:string)_ | _(Optional)_<br/>replaces default labels selector generated by operator<br />it's useful when you need to create custom budget |
 | unhealthyPodEvictionPolicy<a href="#embeddedpoddisruptionbudgetspec-unhealthypodevictionpolicy" id="embeddedpoddisruptionbudgetspec-unhealthypodevictionpolicy">#</a><br/>_string_ | _(Optional)_<br/>UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods<br />Valid policies are IfHealthyBudget and AlwaysAllow.<br />If no policy is specified, the default behavior will be used,<br />which corresponds to the IfHealthyBudget policy.<br />Available from operator v0.64.0 |
 
-
 #### EmbeddedProbes
-
-
 
 EmbeddedProbes - it allows to override some probe params.
 its not necessary to specify all options,
@@ -2086,10 +1809,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | readinessProbe<a href="#embeddedprobes-readinessprobe" id="embeddedprobes-readinessprobe">#</a><br/>_[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#probe-v1-core)_ | _(Optional)_<br/>ReadinessProbe that will be added CRD pod |
 | startupProbe<a href="#embeddedprobes-startupprobe" id="embeddedprobes-startupprobe">#</a><br/>_[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#probe-v1-core)_ | _(Optional)_<br/>StartupProbe that will be added to CRD pod |
 
-
 #### EmbeddedVPA
-
-
 
 EmbeddedVPA embeds VerticalPodAutoscaler spec v1.
 https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
@@ -2102,10 +1822,7 @@ Appears in: [VLInsert](#vlinsert), [VLSelect](#vlselect), [VLStorage](#vlstorage
 | resourcePolicy<a href="#embeddedvpa-resourcepolicy" id="embeddedvpa-resourcepolicy">#</a><br/>_[PodResourcePolicy](#podresourcepolicy)_ | _(Required)_<br/>ResourcePolicy controls how the autoscaler computes recommended resources per container. |
 | updatePolicy<a href="#embeddedvpa-updatepolicy" id="embeddedvpa-updatepolicy">#</a><br/>_[PodUpdatePolicy](#podupdatepolicy)_ | _(Required)_<br/>UpdatePolicy controls how the autoscaler applies changes to pod resources. |
 
-
 #### Endpoint
-
-
 
 Endpoint defines a scrapeable endpoint serving metrics.
 
@@ -2139,10 +1856,7 @@ Appears in: [VMServiceScrapeSpec](#vmservicescrapespec)
 | tlsConfig<a href="#endpoint-tlsconfig" id="endpoint-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 | vm_scrape_params<a href="#endpoint-vm_scrape_params" id="endpoint-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### EndpointAuth
-
-
 
 EndpointAuth defines target endpoint authorization options for scrapping
 
@@ -2157,10 +1871,7 @@ Appears in: [Endpoint](#endpoint), [PodMetricsEndpoint](#podmetricsendpoint), [S
 | oauth2<a href="#endpointauth-oauth2" id="endpointauth-oauth2">#</a><br/>_[OAuth2](#oauth2)_ | _(Optional)_<br/>OAuth2 defines auth configuration |
 | tlsConfig<a href="#endpointauth-tlsconfig" id="endpointauth-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 
-
 #### EndpointRelabelings
-
-
 
 EndpointRelabelings defines service discovery and metrics relabeling configuration for endpoints
 
@@ -2171,10 +1882,7 @@ Appears in: [Endpoint](#endpoint), [PodMetricsEndpoint](#podmetricsendpoint), [S
 | metricRelabelConfigs<a href="#endpointrelabelings-metricrelabelconfigs" id="endpointrelabelings-metricrelabelconfigs">#</a><br/>_[RelabelConfig](#relabelconfig) array_ | _(Optional)_<br/>MetricRelabelConfigs to apply to samples after scrapping. |
 | relabelConfigs<a href="#endpointrelabelings-relabelconfigs" id="endpointrelabelings-relabelconfigs">#</a><br/>_[RelabelConfig](#relabelconfig) array_ | _(Optional)_<br/>RelabelConfigs to apply to samples during service discovery. |
 
-
 #### EndpointScrapeParams
-
-
 
 ScrapeTargetParams defines common configuration params for all scrape endpoint targets
 
@@ -2197,10 +1905,7 @@ Appears in: [Endpoint](#endpoint), [PodMetricsEndpoint](#podmetricsendpoint), [T
 | seriesLimit<a href="#endpointscrapeparams-serieslimit" id="endpointscrapeparams-serieslimit">#</a><br/>_integer_ | _(Optional)_<br/>SeriesLimit defines per-scrape limit on number of unique time series<br />a single target can expose during all the scrapes on the time window of 24h. |
 | vm_scrape_params<a href="#endpointscrapeparams-vm_scrape_params" id="endpointscrapeparams-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### ExternalConfig
-
-
 
 ExternalConfig defines external source of configuration
 
@@ -2211,10 +1916,7 @@ Appears in: [VMAuthSpec](#vmauthspec)
 | localPath<a href="#externalconfig-localpath" id="externalconfig-localpath">#</a><br/>_string_ | _(Optional)_<br/>LocalPath contains static path to a config, which is managed externally for cases<br />when using secrets is not applicable, e.g.: Vault sidecar. |
 | secretRef<a href="#externalconfig-secretref" id="externalconfig-secretref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>SecretRef defines selector for externally managed secret which contains configuration |
 
-
 #### FileSDConfig
-
-
 
 FileSDConfig defines a file service discovery configuration.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#file_sd_configs)
@@ -2225,10 +1927,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | --- | --- |
 | files<a href="#filesdconfig-files" id="filesdconfig-files">#</a><br/>_string array_ | _(Required)_<br/>List of files to be used for file discovery. |
 
-
 #### GCESDConfig
-
-
 
 GCESDConfig configures scrape targets from GCP GCE instances.
 The private IP address is used by default, but may be changed to
@@ -2249,10 +1948,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | tagSeparator<a href="#gcesdconfig-tagseparator" id="gcesdconfig-tagseparator">#</a><br/>_string_ | _(Optional)_<br/>The tag separator is used to separate the tags on concatenation |
 | zone<a href="#gcesdconfig-zone" id="gcesdconfig-zone">#</a><br/>_[StringOrArray](#stringorarray)_ | _(Required)_<br/>The zone of the scrape targets. If you need multiple zones use multiple GCESDConfigs. |
 
-
 #### HTTPAuth
-
-
 
 HTTPAuth generic auth used with http protocols
 
@@ -2265,10 +1961,7 @@ Appears in: [VMAlertDatasourceSpec](#vmalertdatasourcespec), [VMAlertNotifierSpe
 | oauth2<a href="#httpauth-oauth2" id="httpauth-oauth2">#</a><br/>_[OAuth2](#oauth2)_ | _(Optional)_<br/> |
 | tlsConfig<a href="#httpauth-tlsconfig" id="httpauth-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/> |
 
-
 #### HTTPConfig
-
-
 
 HTTPConfig defines a client HTTP configuration for VMAlertmanagerConfig objects
 See https://prometheus.io/docs/alerting/latest/configuration/#http_config
@@ -2285,10 +1978,7 @@ Appears in: [DiscordConfig](#discordconfig), [IncidentIOConfig](#incidentioconfi
 | proxyURL<a href="#httpconfig-proxyurl" id="httpconfig-proxyurl">#</a><br/>_string_ | _(Optional)_<br/>Optional proxy URL. |
 | tls_config<a href="#httpconfig-tls_config" id="httpconfig-tls_config">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration for the client. |
 
-
 #### HTTPSDConfig
-
-
 
 HTTPSDConfig defines a HTTP service discovery configuration.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#http_sd_configs)
@@ -2304,10 +1994,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | tlsConfig<a href="#httpsdconfig-tlsconfig" id="httpsdconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration to use on every scrape request |
 | url<a href="#httpsdconfig-url" id="httpsdconfig-url">#</a><br/>_string_ | _(Required)_<br/>URL from which the targets are fetched. |
 
-
 #### Image
-
-
 
 Image defines docker image settings
 
@@ -2319,10 +2006,7 @@ Appears in: [CommonDefaultableParams](#commondefaultableparams), [VLAgentSpec](#
 | repository<a href="#image-repository" id="image-repository">#</a><br/>_string_ | _(Required)_<br/>Repository contains name of docker image + it's repository if needed |
 | tag<a href="#image-tag" id="image-tag">#</a><br/>_string_ | _(Required)_<br/>Tag contains desired docker image version |
 
-
 #### ImageConfig
-
-
 
 ImageConfig is used to attach images to the incident.
 See https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#the-images-property
@@ -2336,10 +2020,7 @@ Appears in: [PagerDutyConfig](#pagerdutyconfig)
 | href<a href="#imageconfig-href" id="imageconfig-href">#</a><br/>_string_ | _(Optional)_<br/> |
 | source<a href="#imageconfig-source" id="imageconfig-source">#</a><br/>_string_ | _(Required)_<br/> |
 
-
 #### IncidentIOConfig
-
-
 
 IncidentIOConfig configures notifications via incident.io.
 https://prometheus.io/docs/alerting/latest/configuration/#incidentio_config
@@ -2357,10 +2038,7 @@ Appears in: [Receiver](#receiver)
 | timeout<a href="#incidentioconfig-timeout" id="incidentioconfig-timeout">#</a><br/>_string_ | _(Optional)_<br/>Timeout is the maximum time allowed to invoke incident.io |
 | url<a href="#incidentioconfig-url" id="incidentioconfig-url">#</a><br/>_string_ | _(Required)_<br/>The URL to send the incident.io alert. This would typically be provided by the<br />incident.io team when setting up an alert source. |
 
-
 #### InhibitRule
-
-
 
 InhibitRule defines an inhibition rule that allows to mute alerts when other
 alerts are already firing.
@@ -2375,12 +2053,7 @@ Appears in: [VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)
 | source_matchers<a href="#inhibitrule-source_matchers" id="inhibitrule-source_matchers">#</a><br/>_string array_ | _(Optional)_<br/>SourceMatchers defines a list of matchers for which one or more alerts have<br />to exist for the inhibition to take effect. |
 | target_matchers<a href="#inhibitrule-target_matchers" id="inhibitrule-target_matchers">#</a><br/>_string array_ | _(Optional)_<br/>TargetMatchers defines a list of matchers that have to be fulfilled by the target<br />alerts to be muted. |
 
-
 #### InsertPorts
-
-
-
-
 
 Appears in: [VMAgentSpec](#vmagentspec), [VMInsert](#vminsert), [VMSingleSpec](#vmsinglespec)
 
@@ -2391,10 +2064,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMInsert](#vminsert), [VMSingleSpec](#
 | openTSDBHTTPPort<a href="#insertports-opentsdbhttpport" id="insertports-opentsdbhttpport">#</a><br/>_string_ | _(Optional)_<br/>OpenTSDBHTTPPort for http connections. |
 | openTSDBPort<a href="#insertports-opentsdbport" id="insertports-opentsdbport">#</a><br/>_string_ | _(Optional)_<br/>OpenTSDBPort for tcp and udp listen |
 
-
 #### JiraConfig
-
-
 
 JiraConfig represent alertmanager's jira_config entry
 https://prometheus.io/docs/alerting/latest/configuration/#jira_config
@@ -2420,10 +2090,7 @@ Appears in: [Receiver](#receiver)
 | summary<a href="#jiraconfig-summary" id="jiraconfig-summary">#</a><br/>_string_ | _(Optional)_<br/>Issue summary template |
 | wont_fix_resolution<a href="#jiraconfig-wont_fix_resolution" id="jiraconfig-wont_fix_resolution">#</a><br/>_string_ | _(Required)_<br/>If reopen_transition is defined, ignore issues with that resolution. |
 
-
 #### K8SSelectorConfig
-
-
 
 K8SSelectorConfig is Kubernetes Selector Config
 
@@ -2436,11 +2103,7 @@ Appears in: [KubernetesSDConfig](#kubernetessdconfig)
 | role<a href="#k8sselectorconfig-role" id="k8sselectorconfig-role">#</a><br/>_string_ | _(Required)_<br/> |
 
 
-
-
 #### KubernetesSDConfig
-
-
 
 KubernetesSDConfig allows retrieving scrape targets from Kubernetes' REST API.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#kubernetes_sd_configs)
@@ -2462,10 +2125,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | selectors<a href="#kubernetessdconfig-selectors" id="kubernetessdconfig-selectors">#</a><br/>_[K8SSelectorConfig](#k8sselectorconfig) array_ | _(Optional)_<br/>Selector to select objects. |
 | tlsConfig<a href="#kubernetessdconfig-tlsconfig" id="kubernetessdconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration to use on every scrape request |
 
-
 #### License
-
-
 
 License holds license key for enterprise features.
 Using license key is supported starting from VictoriaMetrics corev1.94.0.
@@ -2480,10 +2140,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLClusterSpec](#vlclusterspec), [VLSin
 | keyRef<a href="#license-keyref" id="license-keyref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Required)_<br/>KeyRef is reference to secret with license key for enterprise features. |
 | reloadInterval<a href="#license-reloadinterval" id="license-reloadinterval">#</a><br/>_string_ | _(Required)_<br/>Interval to be used for checking for license key changes. Note that this is only applicable when using KeyRef. |
 
-
 #### LinkConfig
-
-
 
 LinkConfig is used to attach text links to the incident.
 See https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#the-links-property
@@ -2496,12 +2153,7 @@ Appears in: [PagerDutyConfig](#pagerdutyconfig)
 | href<a href="#linkconfig-href" id="linkconfig-href">#</a><br/>_string_ | _(Required)_<br/> |
 | text<a href="#linkconfig-text" id="linkconfig-text">#</a><br/>_string_ | _(Required)_<br/> |
 
-
 #### MSTeamsConfig
-
-
-
-
 
 Appears in: [Receiver](#receiver)
 
@@ -2514,10 +2166,7 @@ Appears in: [Receiver](#receiver)
 | webhook_url<a href="#msteamsconfig-webhook_url" id="msteamsconfig-webhook_url">#</a><br/>_string_ | _(Optional)_<br/>The incoming webhook URL<br />one of `urlSecret` and `url` must be defined. |
 | webhook_url_secret<a href="#msteamsconfig-webhook_url_secret" id="msteamsconfig-webhook_url_secret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>URLSecret defines secret name and key at the CRD namespace.<br />It must contain the webhook URL.<br />one of `urlSecret` and `url` must be defined. |
 
-
 #### MSTeamsV2Config
-
-
 
 MSTeamsV2Config sends notifications using the new message format with adaptive cards as required by flows.
 https://support.microsoft.com/en-gb/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498
@@ -2535,10 +2184,7 @@ Appears in: [Receiver](#receiver)
 | webhook_url<a href="#msteamsv2config-webhook_url" id="msteamsv2config-webhook_url">#</a><br/>_string_ | _(Optional)_<br/>The incoming webhook URL<br />one of `urlSecret` and `url` must be defined. |
 | webhook_url_secret<a href="#msteamsv2config-webhook_url_secret" id="msteamsv2config-webhook_url_secret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>URLSecret defines secret name and key at the CRD namespace.<br />It must contain the webhook URL.<br />one of `webhook_url` or `webhook_url_secret` must be defined. |
 
-
 #### ManagedObjectsMetadata
-
-
 
 ManagedObjectsMetadata contains Labels and Annotations
 
@@ -2549,10 +2195,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLClusterSpec](#vlclusterspec), [VLSin
 | annotations<a href="#managedobjectsmetadata-annotations" id="managedobjectsmetadata-annotations">#</a><br/>_object (keys:string, values:string)_ | _(Required)_<br/>Annotations is an unstructured key value map stored with a resource that may be<br />set by external tools to store and retrieve arbitrary metadata. They are not<br />queryable and should be preserved when modifying objects.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations |
 | labels<a href="#managedobjectsmetadata-labels" id="managedobjectsmetadata-labels">#</a><br/>_object (keys:string, values:string)_ | _(Required)_<br/>Labels Map of string keys and values that can be used to organize and categorize<br />(scope and select) objects.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels |
 
-
 #### NamespaceDiscovery
-
-
 
 NamespaceDiscovery is the configuration for discovering
 Kubernetes namespaces.
@@ -2564,10 +2207,7 @@ Appears in: [KubernetesSDConfig](#kubernetessdconfig)
 | names<a href="#namespacediscovery-names" id="namespacediscovery-names">#</a><br/>_string array_ | _(Optional)_<br/>List of namespaces where to watch for resources.<br />If empty and `ownNamespace` isn't true, watch for resources in all namespaces. |
 | ownNamespace<a href="#namespacediscovery-ownnamespace" id="namespacediscovery-ownnamespace">#</a><br/>_boolean_ | _(Optional)_<br/>Includes the namespace in which the pod exists to the list of watched namespaces. |
 
-
 #### NamespaceSelector
-
-
 
 NamespaceSelector is a selector for selecting either all namespaces or a
 list of namespaces.
@@ -2579,10 +2219,7 @@ Appears in: [DiscoverySelector](#discoveryselector), [VMPodScrapeSpec](#vmpodscr
 | any<a href="#namespaceselector-any" id="namespaceselector-any">#</a><br/>_boolean_ | _(Optional)_<br/>Boolean describing whether all namespaces are selected in contrast to a<br />list restricting them. |
 | matchNames<a href="#namespaceselector-matchnames" id="namespaceselector-matchnames">#</a><br/>_string array_ | _(Optional)_<br/>List of namespace names. |
 
-
 #### NomadSDConfig
-
-
 
 NomadSDConfig configurations allow retrieving scrape targets from Nomad's Service API.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#nomad_sd_configs)
@@ -2604,10 +2241,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | tagSeparator<a href="#nomadsdconfig-tagseparator" id="nomadsdconfig-tagseparator">#</a><br/>_string_ | _(Optional)_<br/>The string by which Nomad tags are joined into the tag label.<br />If unset, use its default value. |
 | tlsConfig<a href="#nomadsdconfig-tlsconfig" id="nomadsdconfig-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLS configuration to use on every scrape request |
 
-
 #### OAuth2
-
-
 
 OAuth2 defines OAuth2 configuration
 
@@ -2624,10 +2258,7 @@ Appears in: [ConsulSDConfig](#consulsdconfig), [DigitalOceanSDConfig](#digitaloc
 | tls_config<a href="#oauth2-tls_config" id="oauth2-tls_config">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig for token_url connection<br />( available from v0.55.0).<br />Is only supported by Scrape objects family |
 | token_url<a href="#oauth2-token_url" id="oauth2-token_url">#</a><br/>_string_ | _(Required)_<br/>The URL to fetch the token from |
 
-
 #### OpenStackSDConfig
-
-
 
 OpenStackSDConfig allow retrieving scrape targets from OpenStack Nova instances.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#openstack_sd_configs)
@@ -2654,10 +2285,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | userid<a href="#openstacksdconfig-userid" id="openstacksdconfig-userid">#</a><br/>_string_ | _(Optional)_<br/>UserID |
 | username<a href="#openstacksdconfig-username" id="openstacksdconfig-username">#</a><br/>_string_ | _(Optional)_<br/>Username is required if using Identity V2 API. Consult with your provider's<br />control panel to discover your account's username.<br />In Identity V3, either userid or a combination of username<br />and domainId or domainName are needed |
 
-
 #### OpsGenieConfig
-
-
 
 OpsGenieConfig configures notifications via OpsGenie.
 See https://prometheus.io/docs/alerting/latest/configuration/#opsgenie_config
@@ -2682,10 +2310,7 @@ Appears in: [Receiver](#receiver)
 | tags<a href="#opsgenieconfig-tags" id="opsgenieconfig-tags">#</a><br/>_string_ | _(Optional)_<br/>Comma separated list of tags attached to the notifications. |
 | update_alerts<a href="#opsgenieconfig-update_alerts" id="opsgenieconfig-update_alerts">#</a><br/>_boolean_ | _(Required)_<br/>Whether to update message and description of the alert in OpsGenie if it already exists<br />By default, the alert is never updated in OpsGenie, the new message only appears in activity log. |
 
-
 #### OpsGenieConfigResponder
-
-
 
 OpsGenieConfigResponder defines a responder to an incident.
 One of `id`, `name` or `username` has to be defined.
@@ -2699,10 +2324,7 @@ Appears in: [OpsGenieConfig](#opsgenieconfig)
 | type<a href="#opsgenieconfigresponder-type" id="opsgenieconfigresponder-type">#</a><br/>_string_ | _(Required)_<br/>Type of responder. |
 | username<a href="#opsgenieconfigresponder-username" id="opsgenieconfigresponder-username">#</a><br/>_string_ | _(Optional)_<br/>Username of the responder. |
 
-
 #### PagerDutyConfig
-
-
 
 PagerDutyConfig configures notifications via PagerDuty.
 See https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
@@ -2727,10 +2349,7 @@ Appears in: [Receiver](#receiver)
 | severity<a href="#pagerdutyconfig-severity" id="pagerdutyconfig-severity">#</a><br/>_string_ | _(Optional)_<br/>Severity of the incident. |
 | url<a href="#pagerdutyconfig-url" id="pagerdutyconfig-url">#</a><br/>_string_ | _(Optional)_<br/>The URL to send requests to. |
 
-
 #### PodMetricsEndpoint
-
-
 
 PodMetricsEndpoint defines a scrapeable endpoint of a Kubernetes Pod serving metrics.
 
@@ -2766,10 +2385,7 @@ Appears in: [VMPodScrapeSpec](#vmpodscrapespec)
 | tlsConfig<a href="#podmetricsendpoint-tlsconfig" id="podmetricsendpoint-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 | vm_scrape_params<a href="#podmetricsendpoint-vm_scrape_params" id="podmetricsendpoint-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### ProxyAuth
-
-
 
 ProxyAuth represent proxy auth config
 Only VictoriaMetrics scrapers supports it.
@@ -2784,10 +2400,7 @@ Appears in: [ConsulSDConfig](#consulsdconfig), [DigitalOceanSDConfig](#digitaloc
 | bearer_token_file<a href="#proxyauth-bearer_token_file" id="proxyauth-bearer_token_file">#</a><br/>_string_ | _(Required)_<br/> |
 | tls_config<a href="#proxyauth-tls_config" id="proxyauth-tls_config">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Required)_<br/> |
 
-
 #### PushoverConfig
-
-
 
 PushoverConfig configures notifications via Pushover.
 See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
@@ -2810,10 +2423,7 @@ Appears in: [Receiver](#receiver)
 | url_title<a href="#pushoverconfig-url_title" id="pushoverconfig-url_title">#</a><br/>_string_ | _(Optional)_<br/>A title for supplementary URL, otherwise just the URL is shown |
 | user_key<a href="#pushoverconfig-user_key" id="pushoverconfig-user_key">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Required)_<br/>The secret's key that contains the recipient user’s user key.<br />It must be at them same namespace as CRD |
 
-
 #### QueryArg
-
-
 
 QueryArg defines item for query arguments
 
@@ -2824,10 +2434,7 @@ Appears in: [TargetRef](#targetref)
 | name<a href="#queryarg-name" id="queryarg-name">#</a><br/>_string_ | _(Required)_<br/>Name of query argument |
 | values<a href="#queryarg-values" id="queryarg-values">#</a><br/>_string array_ | _(Required)_<br/>Values of query argument |
 
-
 #### Receiver
-
-
 
 Receiver defines one or more notification integrations.
 
@@ -2854,10 +2461,7 @@ Appears in: [VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)
 | webhook_configs<a href="#receiver-webhook_configs" id="receiver-webhook_configs">#</a><br/>_[WebhookConfig](#webhookconfig) array_ | _(Optional)_<br/>WebhookConfigs defines webhook notification configurations. |
 | wechat_configs<a href="#receiver-wechat_configs" id="receiver-wechat_configs">#</a><br/>_[WeChatConfig](#wechatconfig) array_ | _(Optional)_<br/>WeChatConfigs defines wechat notification configurations. |
 
-
 #### RelabelConfig
-
-
 
 RelabelConfig allows dynamic rewriting of the label set
 More info: https://docs.victoriametrics.com/victoriametrics/#relabeling
@@ -2879,10 +2483,7 @@ Appears in: [CommonRelabelParams](#commonrelabelparams), [CommonScrapeParams](#c
 | targetLabel<a href="#relabelconfig-targetlabel" id="relabelconfig-targetlabel">#</a><br/>_string_ | _(Optional)_<br/>Label to which the resulting value is written in a replace action.<br />It is mandatory for replace actions. Regex capture groups are available. |
 | target_label<a href="#relabelconfig-target_label" id="relabelconfig-target_label">#</a><br/>_string_ | _(Optional)_<br/>UnderScoreTargetLabel - additional form of target label - target_label<br />for compatibility with original relabel config.<br />if set both targetLabel and target_label, targetLabel has priority.<br />for details https://github.com/VictoriaMetrics/operator/issues/131 |
 
-
 #### RocketchatAttachmentAction
-
-
 
 RocketchatAttachmentAction defines message attachments
 https://github.com/RocketChat/Rocket.Chat.Go.SDK/blob/master/models/message.go
@@ -2896,10 +2497,7 @@ Appears in: [RocketchatConfig](#rocketchatconfig)
 | type<a href="#rocketchatattachmentaction-type" id="rocketchatattachmentaction-type">#</a><br/>_string_ | _(Optional)_<br/> |
 | url<a href="#rocketchatattachmentaction-url" id="rocketchatattachmentaction-url">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### RocketchatAttachmentField
-
-
 
 RocketchatAttachmentField defines API fields
 https://developer.rocket.chat/reference/api/rest-api/endpoints/messaging/chat-endpoints/postmessage#attachment-field-objects
@@ -2912,10 +2510,7 @@ Appears in: [RocketchatConfig](#rocketchatconfig)
 | title<a href="#rocketchatattachmentfield-title" id="rocketchatattachmentfield-title">#</a><br/>_string_ | _(Optional)_<br/> |
 | value<a href="#rocketchatattachmentfield-value" id="rocketchatattachmentfield-value">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### RocketchatConfig
-
-
 
 RocketchatConfig configures notifications via Rocketchat.
 https://prometheus.io/docs/alerting/latest/configuration/#rocketchat_config
@@ -2945,10 +2540,7 @@ Appears in: [Receiver](#receiver)
 | token<a href="#rocketchatconfig-token" id="rocketchatconfig-token">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/> |
 | token_id<a href="#rocketchatconfig-token_id" id="rocketchatconfig-token_id">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>The sender token and token_id<br />See https://docs.rocket.chat/use-rocket.chat/user-guides/user-panel/my-account#personal-access-tokens |
 
-
 #### Route
-
-
 
 Route defines a node in the routing tree.
 
@@ -2967,10 +2559,7 @@ Appears in: [SubRoute](#subroute), [VMAlertmanagerConfigSpec](#vmalertmanagercon
 | repeat_interval<a href="#route-repeat_interval" id="route-repeat_interval">#</a><br/>_string_ | _(Optional)_<br/>How long to wait before repeating the last notification. |
 | routes<a href="#route-routes" id="route-routes">#</a><br/>_[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#json-v1-apiextensions-k8s-io) array_ | _(Optional)_<br/>Child routes.<br />https://prometheus.io/docs/alerting/latest/configuration/#route |
 
-
 #### Rule
-
-
 
 Rule describes an alerting or recording rule.
 
@@ -2988,10 +2577,7 @@ Appears in: [RuleGroup](#rulegroup)
 | record<a href="#rule-record" id="rule-record">#</a><br/>_string_ | _(Optional)_<br/>Record represents a query, that will be recorded to dataSource |
 | update_entries_limit<a href="#rule-update_entries_limit" id="rule-update_entries_limit">#</a><br/>_integer_ | _(Optional)_<br/>UpdateEntriesLimit defines max number of rule's state updates stored in memory.<br />Overrides `-rule.updateEntriesLimit` in vmalert. |
 
-
 #### RuleGroup
-
-
 
 RuleGroup is a list of sequentially evaluated recording and alerting rules.
 
@@ -3014,12 +2600,7 @@ Appears in: [VMRuleSpec](#vmrulespec)
 | tenant<a href="#rulegroup-tenant" id="rulegroup-tenant">#</a><br/>_string_ | _(Optional)_<br/>Tenant id for group, can be used only with enterprise version of vmalert.<br />See more details [here](https://docs.victoriametrics.com/victoriametrics/vmalert/#multitenancy). |
 | type<a href="#rulegroup-type" id="rulegroup-type">#</a><br/>_string_ | _(Optional)_<br/>Type defines datasource type for enterprise version of vmalert<br />possible values - prometheus,graphite,vlogs |
 
-
 #### ScrapeClass
-
-
-
-
 
 Appears in: [CommonScrapeParams](#commonscrapeparams), [VMAgentSpec](#vmagentspec), [VMSingleSpec](#vmsinglespec)
 
@@ -3037,10 +2618,7 @@ Appears in: [CommonScrapeParams](#commonscrapeparams), [VMAgentSpec](#vmagentspe
 | relabelConfigs<a href="#scrapeclass-relabelconfigs" id="scrapeclass-relabelconfigs">#</a><br/>_[RelabelConfig](#relabelconfig) array_ | _(Optional)_<br/>RelabelConfigs to apply to samples during service discovery. |
 | tlsConfig<a href="#scrapeclass-tlsconfig" id="scrapeclass-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 
-
 #### SecretOrConfigMap
-
-
 
 SecretOrConfigMap allows to specify data as a Secret or ConfigMap. Fields are mutually exclusive.
 
@@ -3052,24 +2630,13 @@ Appears in: [OAuth2](#oauth2), [TLSConfig](#tlsconfig)
 | secret<a href="#secretorconfigmap-secret" id="secretorconfigmap-secret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Secret containing data to use for the targets. |
 
 
-
-
 #### SecurityContext
-
-
 
 SecurityContext extends PodSecurityContext with ContainerSecurityContext
 It allows to globally configure security params for pod and all containers
 
 Appears in: [CommonApplicationDeploymentParams](#commonapplicationdeploymentparams), [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlselect), [VLSingleSpec](#vlsinglespec), [VLStorage](#vlstorage), [VLogsSpec](#vlogsspec), [VMAgentSpec](#vmagentspec), [VMAlertSpec](#vmalertspec), [VMAlertmanagerSpec](#vmalertmanagerspec), [VMAnomalySpec](#vmanomalyspec), [VMAuthLoadBalancerSpec](#vmauthloadbalancerspec), [VMAuthSpec](#vmauthspec), [VMDistributedZoneAgentSpec](#vmdistributedzoneagentspec), [VMInsert](#vminsert), [VMSelect](#vmselect), [VMSingleSpec](#vmsinglespec), [VMStorage](#vmstorage), [VTInsert](#vtinsert), [VTSelect](#vtselect), [VTSingleSpec](#vtsinglespec), [VTStorage](#vtstorage)
-
-
-
 #### Sigv4Config
-
-
-
-
 
 Appears in: [SnsConfig](#snsconfig)
 
@@ -3082,10 +2649,7 @@ Appears in: [SnsConfig](#snsconfig)
 | role_arn<a href="#sigv4config-role_arn" id="sigv4config-role_arn">#</a><br/>_string_ | _(Optional)_<br/>AWS Role ARN, an alternative to using AWS API keys |
 | secret_key_selector<a href="#sigv4config-secret_key_selector" id="sigv4config-secret_key_selector">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>secret key selector to get the keys from a Kubernetes Secret |
 
-
 #### SlackAction
-
-
 
 SlackAction configures a single Slack action that is sent with each
 notification.
@@ -3104,10 +2668,7 @@ Appears in: [SlackConfig](#slackconfig)
 | url<a href="#slackaction-url" id="slackaction-url">#</a><br/>_string_ | _(Optional)_<br/> |
 | value<a href="#slackaction-value" id="slackaction-value">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### SlackConfig
-
-
 
 SlackConfig configures notifications via Slack.
 See https://prometheus.io/docs/alerting/latest/configuration/#slack_config
@@ -3139,10 +2700,7 @@ Appears in: [Receiver](#receiver)
 | title_link<a href="#slackconfig-title_link" id="slackconfig-title_link">#</a><br/>_string_ | _(Optional)_<br/> |
 | username<a href="#slackconfig-username" id="slackconfig-username">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### SlackConfirmationField
-
-
 
 SlackConfirmationField protect users from destructive actions or
 particularly distinguished decisions by asking them to confirm their button
@@ -3159,10 +2717,7 @@ Appears in: [SlackAction](#slackaction)
 | text<a href="#slackconfirmationfield-text" id="slackconfirmationfield-text">#</a><br/>_string_ | _(Required)_<br/> |
 | title<a href="#slackconfirmationfield-title" id="slackconfirmationfield-title">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### SlackField
-
-
 
 SlackField configures a single Slack field that is sent with each notification.
 See https://api.slack.com/docs/message-attachments#fields for more information.
@@ -3175,12 +2730,7 @@ Appears in: [SlackConfig](#slackconfig)
 | title<a href="#slackfield-title" id="slackfield-title">#</a><br/>_string_ | _(Required)_<br/> |
 | value<a href="#slackfield-value" id="slackfield-value">#</a><br/>_string_ | _(Required)_<br/> |
 
-
 #### SnsConfig
-
-
-
-
 
 Appears in: [Receiver](#receiver)
 
@@ -3197,10 +2747,7 @@ Appears in: [Receiver](#receiver)
 | target_arn<a href="#snsconfig-target_arn" id="snsconfig-target_arn">#</a><br/>_string_ | _(Optional)_<br/>Mobile platform endpoint ARN if message is delivered via mobile notifications<br />Specify this, topic_arn or phone_number |
 | topic_arn<a href="#snsconfig-topic_arn" id="snsconfig-topic_arn">#</a><br/>_string_ | _(Optional)_<br/>SNS topic ARN, either specify this, phone_number or target_arn |
 
-
 #### StatefulSetUpdateStrategyBehavior
-
-
 
 StatefulSetUpdateStrategyBehavior customizes behavior for StatefulSet updates.
 
@@ -3210,10 +2757,7 @@ Appears in: [VLStorage](#vlstorage), [VMSelect](#vmselect), [VMStorage](#vmstora
 | --- | --- |
 | maxUnavailable<a href="#statefulsetupdatestrategybehavior-maxunavailable" id="statefulsetupdatestrategybehavior-maxunavailable">#</a><br/>_[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#intorstring-intstr-util)_ | _(Optional)_<br/>MaxUnavailable defines the maximum number of pods that can be unavailable during the update.<br />It can be specified as an absolute number (e.g. 2) or a percentage of the total pods (e.g. "50%").<br />For example, if set to 100%, all pods will be upgraded at once, minimizing downtime when needed. |
 
-
 #### StaticConfig
-
-
 
 StaticConfig defines a static configuration.
 See [here](https://docs.victoriametrics.com/victoriametrics/sd_configs/#static_configs)
@@ -3225,10 +2769,7 @@ Appears in: [VMScrapeConfigSpec](#vmscrapeconfigspec)
 | labels<a href="#staticconfig-labels" id="staticconfig-labels">#</a><br/>_object (keys:string, values:string)_ | _(Optional)_<br/>Labels assigned to all metrics scraped from the targets. |
 | targets<a href="#staticconfig-targets" id="staticconfig-targets">#</a><br/>_string array_ | _(Optional)_<br/>List of targets for this static configuration. |
 
-
 #### StaticRef
-
-
 
 StaticRef - user-defined routing host address.
 
@@ -3239,10 +2780,7 @@ Appears in: [TargetRef](#targetref)
 | url<a href="#staticref-url" id="staticref-url">#</a><br/>_string_ | _(Required)_<br/>URL http url for given staticRef. |
 | urls<a href="#staticref-urls" id="staticref-urls">#</a><br/>_string array_ | _(Optional)_<br/>URLs allows setting multiple urls for load-balancing at vmauth-side. |
 
-
 #### StorageSpec
-
-
 
 StorageSpec defines the configured storage for a group VM servers.
 If neither `emptyDir` nor `volumeClaimTemplate` is specified, then by default an [EmptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will be used.
@@ -3254,10 +2792,7 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLStorage](#vlstorage), [VMAgentSpec](
 | emptyDir<a href="#storagespec-emptydir" id="storagespec-emptydir">#</a><br/>_[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#emptydirvolumesource-v1-core)_ | _(Optional)_<br/>EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More<br />info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir |
 | volumeClaimTemplate<a href="#storagespec-volumeclaimtemplate" id="storagespec-volumeclaimtemplate">#</a><br/>_[EmbeddedPersistentVolumeClaim](#embeddedpersistentvolumeclaim)_ | _(Optional)_<br/>A PVC spec to be used by the StatefulSets/Deployments. |
 
-
 #### StreamAggrConfig
-
-
 
 StreamAggrConfig defines the stream aggregation config
 
@@ -3276,10 +2811,7 @@ Appears in: [VMAgentRemoteWriteSpec](#vmagentremotewritespec), [VMAgentSpec](#vm
 | keepInput<a href="#streamaggrconfig-keepinput" id="streamaggrconfig-keepinput">#</a><br/>_boolean_ | _(Optional)_<br/>Allows writing both raw and aggregate data |
 | rules<a href="#streamaggrconfig-rules" id="streamaggrconfig-rules">#</a><br/>_[StreamAggrRule](#streamaggrrule) array_ | _(Optional)_<br/>Stream aggregation rules |
 
-
 #### StreamAggrRule
-
-
 
 StreamAggrRule defines the rule in stream aggregation config
 
@@ -3305,7 +2837,6 @@ Appears in: [StreamAggrConfig](#streamaggrconfig)
 | staleness_interval<a href="#streamaggrrule-staleness_interval" id="streamaggrrule-staleness_interval">#</a><br/>_string_ | _(Optional)_<br/>Staleness interval is interval after which the series state will be reset if no samples have been sent during it.<br />The parameter is only relevant for outputs: total, total_prometheus, increase, increase_prometheus and histogram_bucket. |
 | without<a href="#streamaggrrule-without" id="streamaggrrule-without">#</a><br/>_string array_ | _(Optional)_<br/>Without is an optional list of labels, which must be excluded when grouping input series.<br />See also By.<br />If neither By nor Without are set, then the Outputs are calculated<br />individually per each input time series. |
 
-
 #### StringOrArray
 
 _Underlying type:_ _string array_
@@ -3314,13 +2845,7 @@ StringOrArray is a helper type for storing string or array of string.
 
 Appears in: [GCESDConfig](#gcesdconfig), [RelabelConfig](#relabelconfig), [StreamAggrRule](#streamaggrrule), [UnauthorizedAccessConfigURLMap](#unauthorizedaccessconfigurlmap), [VMAuthUnauthorizedUserAccessSpec](#vmauthunauthorizeduseraccessspec)
 
-
-
-
-
 #### TLSClientConfig
-
-
 
 TLSClientConfig defines TLS configuration for the application's client
 
@@ -3337,10 +2862,7 @@ Appears in: [VMAlertmanagerGossipConfig](#vmalertmanagergossipconfig), [VMAlertm
 | key_secret_ref<a href="#tlsclientconfig-key_secret_ref" id="tlsclientconfig-key_secret_ref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>Key defines reference for secret with certificate key content under given key<br />mutually exclusive with KeyFile |
 | server_name<a href="#tlsclientconfig-server_name" id="tlsclientconfig-server_name">#</a><br/>_string_ | _(Optional)_<br/>ServerName indicates a name of a server |
 
-
 #### TLSConfig
-
-
 
 TLSConfig specifies TLSConfig configuration parameters.
 
@@ -3358,11 +2880,7 @@ Appears in: [APIServerConfig](#apiserverconfig), [ConsulSDConfig](#consulsdconfi
 | serverName<a href="#tlsconfig-servername" id="tlsconfig-servername">#</a><br/>_string_ | _(Optional)_<br/>Used to verify the hostname for the targets. |
 
 
-
-
 #### TLSServerConfig
-
-
 
 TLSServerConfig defines TLS configuration for the application's server
 
@@ -3383,10 +2901,7 @@ Appears in: [VMAlertmanagerGossipConfig](#vmalertmanagergossipconfig), [VMAlertm
 | min_version<a href="#tlsserverconfig-min_version" id="tlsserverconfig-min_version">#</a><br/>_string_ | _(Optional)_<br/>MinVersion minimum TLS version that is acceptable. |
 | prefer_server_cipher_suites<a href="#tlsserverconfig-prefer_server_cipher_suites" id="tlsserverconfig-prefer_server_cipher_suites">#</a><br/>_boolean_ | _(Optional)_<br/>PreferServerCipherSuites controls whether the server selects the<br />client's most preferred ciphersuite |
 
-
 #### TargetEndpoint
-
-
 
 TargetEndpoint defines single static target endpoint.
 
@@ -3419,10 +2934,7 @@ Appears in: [VMStaticScrapeSpec](#vmstaticscrapespec)
 | tlsConfig<a href="#targetendpoint-tlsconfig" id="targetendpoint-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 | vm_scrape_params<a href="#targetendpoint-vm_scrape_params" id="targetendpoint-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### TargetRef
-
-
 
 TargetRef describes target for user traffic forwarding.
 one of target types can be chosen:
@@ -3442,10 +2954,7 @@ Appears in: [VMAuthUnauthorizedUserAccessSpec](#vmauthunauthorizeduseraccessspec
 | targetRefBasicAuth<a href="#targetref-targetrefbasicauth" id="targetref-targetrefbasicauth">#</a><br/>_[TargetRefBasicAuth](#targetrefbasicauth)_ | _(Optional)_<br/>TargetRefBasicAuth allow an target endpoint to authenticate over basic authentication |
 | target_path_suffix<a href="#targetref-target_path_suffix" id="targetref-target_path_suffix">#</a><br/>_string_ | _(Optional)_<br/>TargetPathSuffix allows to add some suffix to the target path<br />It allows to hide tenant configuration from user with crd as ref.<br />it also may contain any url encoded params. |
 
-
 #### TargetRefBasicAuth
-
-
 
 TargetRefBasicAuth target basic authentication
 
@@ -3456,10 +2965,7 @@ Appears in: [TargetRef](#targetref)
 | password<a href="#targetrefbasicauth-password" id="targetrefbasicauth-password">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Required)_<br/>The secret in the service scrape namespace that contains the password<br />for authentication.<br />It must be at them same namespace as CRD |
 | username<a href="#targetrefbasicauth-username" id="targetrefbasicauth-username">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Required)_<br/>The secret in the service scrape namespace that contains the username<br />for authentication.<br />It must be at them same namespace as CRD |
 
-
 #### TelegramConfig
-
-
 
 TelegramConfig configures notification via telegram
 https://prometheus.io/docs/alerting/latest/configuration/#telegram_config
@@ -3478,10 +2984,7 @@ Appears in: [Receiver](#receiver)
 | parse_mode<a href="#telegramconfig-parse_mode" id="telegramconfig-parse_mode">#</a><br/>_string_ | _(Optional)_<br/>ParseMode for telegram message,<br />supported values are MarkdownV2, Markdown, Markdown and empty string for plain text. |
 | send_resolved<a href="#telegramconfig-send_resolved" id="telegramconfig-send_resolved">#</a><br/>_boolean_ | _(Optional)_<br/>SendResolved controls notify about resolved alerts. |
 
-
 #### TimeInterval
-
-
 
 TimeInterval defines intervals of time
 
@@ -3496,10 +2999,7 @@ Appears in: [TimeIntervals](#timeintervals)
 | weekdays<a href="#timeinterval-weekdays" id="timeinterval-weekdays">#</a><br/>_string array_ | _(Optional)_<br/>Weekdays defines list of days of the week, where the week begins on Sunday and ends on Saturday. |
 | years<a href="#timeinterval-years" id="timeinterval-years">#</a><br/>_string array_ | _(Optional)_<br/>Years defines numerical list of years, ranges are accepted.<br />For example, ['2020:2022', '2030'] |
 
-
 #### TimeIntervals
-
-
 
 TimeIntervals for alerts
 
@@ -3510,10 +3010,7 @@ Appears in: [VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)
 | name<a href="#timeintervals-name" id="timeintervals-name">#</a><br/>_string_ | _(Required)_<br/>Name of interval |
 | time_intervals<a href="#timeintervals-time_intervals" id="timeintervals-time_intervals">#</a><br/>_[TimeInterval](#timeinterval) array_ | _(Required)_<br/>TimeIntervals interval configuration |
 
-
 #### TimeRange
-
-
 
 TimeRange  ranges inclusive of the starting time and exclusive of the end time
 
@@ -3524,10 +3021,7 @@ Appears in: [TimeInterval](#timeinterval)
 | end_time<a href="#timerange-end_time" id="timerange-end_time">#</a><br/>_string_ | _(Required)_<br/>EndTime for example HH:MM |
 | start_time<a href="#timerange-start_time" id="timerange-start_time">#</a><br/>_string_ | _(Required)_<br/>StartTime for example  HH:MM |
 
-
 #### URLMapCommon
-
-
 
 URLMapCommon contains common fields for unauthorized user and user in vmuser
 
@@ -3544,10 +3038,7 @@ Appears in: [TargetRef](#targetref), [UnauthorizedAccessConfigURLMap](#unauthori
 | src_headers<a href="#urlmapcommon-src_headers" id="urlmapcommon-src_headers">#</a><br/>_string array_ | _(Required)_<br/>SrcHeaders is an optional list of headers, which must match request headers. |
 | src_query_args<a href="#urlmapcommon-src_query_args" id="urlmapcommon-src_query_args">#</a><br/>_string array_ | _(Required)_<br/>SrcQueryArgs is an optional list of query args, which must match request URL query args. |
 
-
 #### UnauthorizedAccessConfigURLMap
-
-
 
 UnauthorizedAccessConfigURLMap defines element of url_map routing configuration
 For UnauthorizedAccessConfig and VMAuthUnauthorizedUserAccessSpec.URLMap
@@ -3561,15 +3052,10 @@ Appears in: [VMAuthSpec](#vmauthspec), [VMAuthUnauthorizedUserAccessSpec](#vmaut
 | src_paths<a href="#unauthorizedaccessconfigurlmap-src_paths" id="unauthorizedaccessconfigurlmap-src_paths">#</a><br/>_string array_ | _(Required)_<br/>SrcPaths is an optional list of regular expressions, which must match the request path. |
 | url_prefix<a href="#unauthorizedaccessconfigurlmap-url_prefix" id="unauthorizedaccessconfigurlmap-url_prefix">#</a><br/>_[StringOrArray](#stringorarray)_ | _(Required)_<br/>UrlPrefix contains backend url prefixes for the proxied request url.<br />URLPrefix defines prefix prefix for destination |
 
-
 #### VLogs
-
-
 
 VLogs is fast, cost-effective and scalable logs database.
 VLogs is the Schema for the vlogs API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -3578,10 +3064,7 @@ VLogs is the Schema for the vlogs API
 | metadata<a href="#vlogs-metadata" id="vlogs-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vlogs-spec" id="vlogs-spec">#</a><br/>_[VLogsSpec](#vlogsspec)_ | _(Required)_<br/> |
 
-
 #### VLogsSpec
-
-
 
 VLogsSpec defines the desired state of VLogs
 VLogs is deprecated, migrate to the VLSingle
@@ -3642,15 +3125,10 @@ Appears in: [VLogs](#vlogs)
 | volumeMounts<a href="#vlogsspec-volumemounts" id="vlogsspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vlogsspec-volumes" id="vlogsspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMAgent
-
-
 
 VMAgent - is a tiny but brave agent, which helps you collect metrics from various sources and stores them in VictoriaMetrics
 or any other Prometheus-compatible storage system that supports the remote_write protocol.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -3659,10 +3137,7 @@ or any other Prometheus-compatible storage system that supports the remote_write
 | metadata<a href="#vmagent-metadata" id="vmagent-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmagent-spec" id="vmagent-spec">#</a><br/>_[VMAgentSpec](#vmagentspec)_ | _(Required)_<br/> |
 
-
 #### VMAgentRemoteWriteSettings
-
-
 
 VMAgentRemoteWriteSettings - defines global settings for all remoteWrite urls.
 
@@ -3679,10 +3154,7 @@ Appears in: [VMAgentSpec](#vmagentspec), [VMDistributedZoneAgentSpec](#vmdistrib
 | tmpDataPath<a href="#vmagentremotewritesettings-tmpdatapath" id="vmagentremotewritesettings-tmpdatapath">#</a><br/>_string_ | _(Optional)_<br/>Path to directory where temporary data for remote write component is stored (default vmagent-remotewrite-data) |
 | useMultiTenantMode<a href="#vmagentremotewritesettings-usemultitenantmode" id="vmagentremotewritesettings-usemultitenantmode">#</a><br/>_boolean_ | _(Optional)_<br/>Configures vmagent accepting data via the same multitenant endpoints as vminsert at VictoriaMetrics cluster does,<br />see [here](https://docs.victoriametrics.com/victoriametrics/vmagent/#multitenancy).<br />it's global setting and affects all remote storage configurations |
 
-
 #### VMAgentRemoteWriteSpec
-
-
 
 VMAgentRemoteWriteSpec defines the remote storage configuration for VmAgent
 
@@ -3705,10 +3177,7 @@ Appears in: [VMAgentSpec](#vmagentspec)
 | url<a href="#vmagentremotewritespec-url" id="vmagentremotewritespec-url">#</a><br/>_string_ | _(Required)_<br/>URL of the endpoint to send samples to. |
 | urlRelabelConfig<a href="#vmagentremotewritespec-urlrelabelconfig" id="vmagentremotewritespec-urlrelabelconfig">#</a><br/>_[ConfigMapKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#configmapkeyselector-v1-core)_ | _(Optional)_<br/>ConfigMap with relabeling config which is applied to metrics before sending them to the corresponding -remoteWrite.url. |
 
-
 #### VMAgentSpec
-
-
 
 VMAgentSpec defines the desired state of VMAgent
 
@@ -3823,14 +3292,9 @@ Appears in: [VMAgent](#vmagent)
 | volumeMounts<a href="#vmagentspec-volumemounts" id="vmagentspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vmagentspec-volumes" id="vmagentspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMAlert
 
-
-
 VMAlert  executes a list of given alerting or recording rules against configured address.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -3839,10 +3303,7 @@ VMAlert  executes a list of given alerting or recording rules against configured
 | metadata<a href="#vmalert-metadata" id="vmalert-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmalert-spec" id="vmalert-spec">#</a><br/>_[VMAlertSpec](#vmalertspec)_ | _(Required)_<br/> |
 
-
 #### VMAlertDatasourceSpec
-
-
 
 VMAlertDatasourceSpec defines the remote storage configuration for VmAlert to read alerts from
 
@@ -3856,10 +3317,7 @@ Appears in: [VMAlertSpec](#vmalertspec)
 | tlsConfig<a href="#vmalertdatasourcespec-tlsconfig" id="vmalertdatasourcespec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/> |
 | url<a href="#vmalertdatasourcespec-url" id="vmalertdatasourcespec-url">#</a><br/>_string_ | _(Required)_<br/>Victoria Metrics or VMSelect url. Required parameter. E.g. http://127.0.0.1:8428 |
 
-
 #### VMAlertNotifierSpec
-
-
 
 VMAlertNotifierSpec defines the notifier url for sending information about alerts
 
@@ -3874,10 +3332,7 @@ Appears in: [VMAlertSpec](#vmalertspec)
 | tlsConfig<a href="#vmalertnotifierspec-tlsconfig" id="vmalertnotifierspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/> |
 | url<a href="#vmalertnotifierspec-url" id="vmalertnotifierspec-url">#</a><br/>_string_ | _(Optional)_<br/>AlertManager url.  E.g. http://127.0.0.1:9093 |
 
-
 #### VMAlertRemoteReadSpec
-
-
 
 VMAlertRemoteReadSpec defines the remote storage configuration for VmAlert to read alerts from
 
@@ -3892,10 +3347,7 @@ Appears in: [VMAlertSpec](#vmalertspec)
 | tlsConfig<a href="#vmalertremotereadspec-tlsconfig" id="vmalertremotereadspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/> |
 | url<a href="#vmalertremotereadspec-url" id="vmalertremotereadspec-url">#</a><br/>_string_ | _(Required)_<br/>URL of the endpoint to send samples to. |
 
-
 #### VMAlertRemoteWriteSpec
-
-
 
 VMAlertRemoteWriteSpec defines the remote storage configuration for VmAlert
 
@@ -3913,10 +3365,7 @@ Appears in: [VMAlertSpec](#vmalertspec)
 | tlsConfig<a href="#vmalertremotewritespec-tlsconfig" id="vmalertremotewritespec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/> |
 | url<a href="#vmalertremotewritespec-url" id="vmalertremotewritespec-url">#</a><br/>_string_ | _(Required)_<br/>URL of the endpoint to send samples to. |
 
-
 #### VMAlertSpec
-
-
 
 VMAlertSpec defines the desired state of VMAlert
 
@@ -3991,14 +3440,9 @@ Appears in: [VMAlert](#vmalert)
 | volumeMounts<a href="#vmalertspec-volumemounts" id="vmalertspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vmalertspec-volumes" id="vmalertspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMAlertmanager
 
-
-
 VMAlertmanager represents Victoria-Metrics deployment for Alertmanager.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4007,14 +3451,9 @@ VMAlertmanager represents Victoria-Metrics deployment for Alertmanager.
 | metadata<a href="#vmalertmanager-metadata" id="vmalertmanager-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmalertmanager-spec" id="vmalertmanager-spec">#</a><br/>_[VMAlertmanagerSpec](#vmalertmanagerspec)_ | _(Required)_<br/>Specification of the desired behavior of the VMAlertmanager cluster. More info:<br />https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status |
 
-
 #### VMAlertmanagerConfig
 
-
-
 VMAlertmanagerConfig is the Schema for the vmalertmanagerconfigs API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4023,10 +3462,7 @@ VMAlertmanagerConfig is the Schema for the vmalertmanagerconfigs API
 | metadata<a href="#vmalertmanagerconfig-metadata" id="vmalertmanagerconfig-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmalertmanagerconfig-spec" id="vmalertmanagerconfig-spec">#</a><br/>_[VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)_ | _(Required)_<br/> |
 
-
 #### VMAlertmanagerConfigSpec
-
-
 
 VMAlertmanagerConfigSpec defines configuration for VMAlertmanagerConfig
 it must reference only locally defined objects
@@ -4040,10 +3476,7 @@ Appears in: [VMAlertmanagerConfig](#vmalertmanagerconfig)
 | route<a href="#vmalertmanagerconfigspec-route" id="vmalertmanagerconfigspec-route">#</a><br/>_[Route](#route)_ | _(Optional)_<br/>Route definition for alertmanager, may include nested routes. |
 | time_intervals<a href="#vmalertmanagerconfigspec-time_intervals" id="vmalertmanagerconfigspec-time_intervals">#</a><br/>_[TimeIntervals](#timeintervals) array_ | _(Optional)_<br/>TimeIntervals defines named interval for active/mute notifications interval<br />See https://prometheus.io/docs/alerting/latest/configuration/#time_interval |
 
-
 #### VMAlertmanagerGossipConfig
-
-
 
 VMAlertmanagerGossipConfig defines Gossip TLS configuration for alertmanager
 
@@ -4054,10 +3487,7 @@ Appears in: [VMAlertmanagerSpec](#vmalertmanagerspec)
 | tls_client_config<a href="#vmalertmanagergossipconfig-tls_client_config" id="vmalertmanagergossipconfig-tls_client_config">#</a><br/>_[TLSClientConfig](#tlsclientconfig)_ | _(Required)_<br/>TLSClientConfig defines client TLS configuration for alertmanager |
 | tls_server_config<a href="#vmalertmanagergossipconfig-tls_server_config" id="vmalertmanagergossipconfig-tls_server_config">#</a><br/>_[TLSServerConfig](#tlsserverconfig)_ | _(Required)_<br/>TLSServerConfig defines server TLS configuration for alertmanager |
 
-
 #### VMAlertmanagerHTTPConfig
-
-
 
 VMAlertmanagerHTTPConfig defines http server configuration for alertmanager
 
@@ -4068,10 +3498,7 @@ Appears in: [VMAlertmanagerWebConfig](#vmalertmanagerwebconfig)
 | headers<a href="#vmalertmanagerhttpconfig-headers" id="vmalertmanagerhttpconfig-headers">#</a><br/>_object (keys:string, values:string)_ | _(Optional)_<br/>Headers defines list of headers that can be added to HTTP responses. |
 | http2<a href="#vmalertmanagerhttpconfig-http2" id="vmalertmanagerhttpconfig-http2">#</a><br/>_boolean_ | _(Optional)_<br/>HTTP2 enables HTTP/2 support. Note that HTTP/2 is only supported with TLS.<br />This can not be changed on the fly. |
 
-
 #### VMAlertmanagerSpec
-
-
 
 VMAlertmanagerSpec is a specification of the desired behavior of the VMAlertmanager cluster. More info:
 https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
@@ -4156,10 +3583,7 @@ Appears in: [VMAlertmanager](#vmalertmanager)
 | volumes<a href="#vmalertmanagerspec-volumes" id="vmalertmanagerspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | webConfig<a href="#vmalertmanagerspec-webconfig" id="vmalertmanagerspec-webconfig">#</a><br/>_[VMAlertmanagerWebConfig](#vmalertmanagerwebconfig)_ | _(Optional)_<br/>WebConfig defines configuration for webserver<br />https://github.com/prometheus/alertmanager/blob/main/docs/https.md |
 
-
 #### VMAlertmanagerTracingConfig
-
-
 
 VMAlertmanagerTracingConfig defines Tracing configuration for alertmanager
 
@@ -4176,10 +3600,7 @@ Appears in: [VMAlertmanagerSpec](#vmalertmanagerspec)
 | timeout<a href="#vmalertmanagertracingconfig-timeout" id="vmalertmanagertracingconfig-timeout">#</a><br/>_string_ | _(Optional)_<br/>Timeout defines tracing connection timeout |
 | tls_config<a href="#vmalertmanagertracingconfig-tls_config" id="vmalertmanagertracingconfig-tls_config">#</a><br/>_[TLSClientConfig](#tlsclientconfig)_ | _(Optional)_<br/>TLSConfig defines tracing TLS config |
 
-
 #### VMAlertmanagerWebConfig
-
-
 
 VMAlertmanagerWebConfig defines web server configuration for alertmanager
 
@@ -4191,14 +3612,9 @@ Appears in: [VMAlertmanagerSpec](#vmalertmanagerspec)
 | http_server_config<a href="#vmalertmanagerwebconfig-http_server_config" id="vmalertmanagerwebconfig-http_server_config">#</a><br/>_[VMAlertmanagerHTTPConfig](#vmalertmanagerhttpconfig)_ | _(Optional)_<br/>HTTPServerConfig defines http server configuration for alertmanager web server |
 | tls_server_config<a href="#vmalertmanagerwebconfig-tls_server_config" id="vmalertmanagerwebconfig-tls_server_config">#</a><br/>_[TLSServerConfig](#tlsserverconfig)_ | _(Optional)_<br/>TLSServerConfig defines server TLS configuration for alertmanager |
 
-
 #### VMAuth
 
-
-
 VMAuth is the Schema for the vmauths API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4207,10 +3623,7 @@ VMAuth is the Schema for the vmauths API
 | metadata<a href="#vmauth-metadata" id="vmauth-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmauth-spec" id="vmauth-spec">#</a><br/>_[VMAuthSpec](#vmauthspec)_ | _(Required)_<br/> |
 
-
 #### VMAuthLoadBalancer
-
-
 
 VMAuthLoadBalancer configures vmauth as a load balancer
 for the requests
@@ -4224,10 +3637,7 @@ Appears in: [VLClusterSpec](#vlclusterspec), [VMClusterSpec](#vmclusterspec), [V
 | enabled<a href="#vmauthloadbalancer-enabled" id="vmauthloadbalancer-enabled">#</a><br/>_boolean_ | _(Required)_<br/> |
 | spec<a href="#vmauthloadbalancer-spec" id="vmauthloadbalancer-spec">#</a><br/>_[VMAuthLoadBalancerSpec](#vmauthloadbalancerspec)_ | _(Required)_<br/> |
 
-
 #### VMAuthLoadBalancerSpec
-
-
 
 VMAuthLoadBalancerSpec defines configuration spec for VMAuth used as load-balancer
 for VMCluster component
@@ -4288,10 +3698,7 @@ Appears in: [VMAuthLoadBalancer](#vmauthloadbalancer)
 | volumeMounts<a href="#vmauthloadbalancerspec-volumemounts" id="vmauthloadbalancerspec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vmauthloadbalancerspec-volumes" id="vmauthloadbalancerspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMAuthSpec
-
-
 
 VMAuthSpec defines the desired state of VMAuth
 
@@ -4377,10 +3784,7 @@ Appears in: [VMAuth](#vmauth), [VMDistributedAuth](#vmdistributedauth)
 | volumes<a href="#vmauthspec-volumes" id="vmauthspec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vmauthspec-vpa" id="vmauthspec-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VMAuthUnauthorizedUserAccessSpec
-
-
 
 VMAuthUnauthorizedUserAccessSpec defines unauthorized_user section configuration for vmauth
 
@@ -4404,12 +3808,7 @@ Appears in: [VMAuthSpec](#vmauthspec)
 | url_map<a href="#vmauthunauthorizeduseraccessspec-url_map" id="vmauthunauthorizeduseraccessspec-url_map">#</a><br/>_[UnauthorizedAccessConfigURLMap](#unauthorizedaccessconfigurlmap) array_ | _(Required)_<br/>URLMap defines url map for destination<br/><b>Deprecated: </b>since version <a href="https://docs.victoriametrics.com/operator/changelog/#v0670">v0.67.0</a> will be removed in <a href="https://docs.victoriametrics.com/operator/changelog/#v0690">v0.69.0</a> use <a href="#vmauthunauthorizeduseraccessspec-targetrefs">targetRefs</a> instead<br/> |
 | url_prefix<a href="#vmauthunauthorizeduseraccessspec-url_prefix" id="vmauthunauthorizeduseraccessspec-url_prefix">#</a><br/>_[StringOrArray](#stringorarray)_ | _(Required)_<br/>URLPrefix defines url prefix for destination<br/><b>Deprecated: </b>since version <a href="https://docs.victoriametrics.com/operator/changelog/#v0670">v0.67.0</a> will be removed in <a href="https://docs.victoriametrics.com/operator/changelog/#v0690">v0.69.0</a> use <a href="#vmauthunauthorizeduseraccessspec-targetrefs">targetRefs</a> instead<br/> |
 
-
 #### VMBackup
-
-
-
-
 
 Appears in: [VMSingleSpec](#vmsinglespec), [VMStorage](#vmstorage)
 
@@ -4438,15 +3837,10 @@ Appears in: [VMSingleSpec](#vmsinglespec), [VMStorage](#vmstorage)
 | snapshotDeleteURL<a href="#vmbackup-snapshotdeleteurl" id="vmbackup-snapshotdeleteurl">#</a><br/>_string_ | _(Optional)_<br/>SnapShotDeleteURL overwrites url for snapshot delete |
 | volumeMounts<a href="#vmbackup-volumemounts" id="vmbackup-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the vmbackupmanager container,<br />that are generated as a result of StorageSpec objects. |
 
-
 #### VMCluster
-
-
 
 VMCluster is fast, cost-effective and scalable time-series database.
 Cluster version with
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4455,10 +3849,7 @@ Cluster version with
 | metadata<a href="#vmcluster-metadata" id="vmcluster-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Optional)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmcluster-spec" id="vmcluster-spec">#</a><br/>_[VMClusterSpec](#vmclusterspec)_ | _(Required)_<br/> |
 
-
 #### VMClusterSpec
-
-
 
 VMClusterSpec defines the desired state of VMCluster
 
@@ -4481,12 +3872,7 @@ Appears in: [VMCluster](#vmcluster), [VMDistributedZoneCluster](#vmdistributedzo
 | vmselect<a href="#vmclusterspec-vmselect" id="vmclusterspec-vmselect">#</a><br/>_[VMSelect](#vmselect)_ | _(Optional)_<br/> |
 | vmstorage<a href="#vmclusterspec-vmstorage" id="vmclusterspec-vmstorage">#</a><br/>_[VMStorage](#vmstorage)_ | _(Optional)_<br/> |
 
-
 #### VMInsert
-
-
-
-
 
 Appears in: [VMClusterSpec](#vmclusterspec)
 
@@ -4541,16 +3927,11 @@ Appears in: [VMClusterSpec](#vmclusterspec)
 | volumes<a href="#vminsert-volumes" id="vminsert-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vminsert-vpa" id="vminsert-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VMNodeScrape
-
-
 
 VMNodeScrape defines discovery for targets placed on kubernetes nodes,
 usually its node-exporters and other host services.
 InternalIP is used as __address__ for scraping.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4559,10 +3940,7 @@ InternalIP is used as __address__ for scraping.
 | metadata<a href="#vmnodescrape-metadata" id="vmnodescrape-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmnodescrape-spec" id="vmnodescrape-spec">#</a><br/>_[VMNodeScrapeSpec](#vmnodescrapespec)_ | _(Required)_<br/> |
 
-
 #### VMNodeScrapeSpec
-
-
 
 VMNodeScrapeSpec defines specification for VMNodeScrape.
 
@@ -4598,16 +3976,11 @@ Appears in: [VMNodeScrape](#vmnodescrape)
 | tlsConfig<a href="#vmnodescrapespec-tlsconfig" id="vmnodescrapespec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 | vm_scrape_params<a href="#vmnodescrapespec-vm_scrape_params" id="vmnodescrapespec-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### VMPodScrape
-
-
 
 VMPodScrape is scrape configuration for pods,
 it generates vmagent's config for scraping pod targets
 based on selectors.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4616,10 +3989,7 @@ based on selectors.
 | metadata<a href="#vmpodscrape-metadata" id="vmpodscrape-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Optional)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmpodscrape-spec" id="vmpodscrape-spec">#</a><br/>_[VMPodScrapeSpec](#vmpodscrapespec)_ | _(Required)_<br/> |
 
-
 #### VMPodScrapeSpec
-
-
 
 VMPodScrapeSpec defines the desired state of VMPodScrape
 
@@ -4637,16 +4007,11 @@ Appears in: [VMPodScrape](#vmpodscrape)
 | selector<a href="#vmpodscrapespec-selector" id="vmpodscrapespec-selector">#</a><br/>_[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | _(Optional)_<br/>Selector to select Pod objects. |
 | seriesLimit<a href="#vmpodscrapespec-serieslimit" id="vmpodscrapespec-serieslimit">#</a><br/>_integer_ | _(Optional)_<br/>SeriesLimit defines per-scrape limit on number of unique time series<br />a single target can expose during all the scrapes on the time window of 24h. |
 
-
 #### VMProbe
-
-
 
 VMProbe defines a probe for targets, that will be executed with prober,
 like blackbox exporter.
 It helps to monitor reachability of target with various checks.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4655,10 +4020,7 @@ It helps to monitor reachability of target with various checks.
 | metadata<a href="#vmprobe-metadata" id="vmprobe-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Optional)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmprobe-spec" id="vmprobe-spec">#</a><br/>_[VMProbeSpec](#vmprobespec)_ | _(Required)_<br/> |
 
-
 #### VMProbeSpec
-
-
 
 VMProbeSpec contains specification parameters for a Probe.
 
@@ -4693,10 +4055,7 @@ Appears in: [VMProbe](#vmprobe)
 | vmProberSpec<a href="#vmprobespec-vmproberspec" id="vmprobespec-vmproberspec">#</a><br/>_[VMProberSpec](#vmproberspec)_ | _(Required)_<br/>Specification for the prober to use for probing targets.<br />The prober.URL parameter is required. Targets cannot be probed if left empty. |
 | vm_scrape_params<a href="#vmprobespec-vm_scrape_params" id="vmprobespec-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### VMProbeTargetKubernetes
-
-
 
 VMProbeTargetKubernetes defines the set of k8s objects considered for probing.
 
@@ -4709,10 +4068,7 @@ Appears in: [VMProbeTargets](#vmprobetargets)
 | role<a href="#vmprobetargetkubernetes-role" id="vmprobetargetkubernetes-role">#</a><br/>_string_ | _(Required)_<br/>Role defines k8s role name |
 | selector<a href="#vmprobetargetkubernetes-selector" id="vmprobetargetkubernetes-selector">#</a><br/>_[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | _(Required)_<br/>Select k8s objects by labels. |
 
-
 #### VMProbeTargetStatic
-
-
 
 VMProbeTargetStatic defines the set of static targets considered for probing.
 
@@ -4724,10 +4080,7 @@ Appears in: [VMProbeTargets](#vmprobetargets)
 | relabelingConfigs<a href="#vmprobetargetstatic-relabelingconfigs" id="vmprobetargetstatic-relabelingconfigs">#</a><br/>_[RelabelConfig](#relabelconfig) array_ | _(Required)_<br/>RelabelConfigs to apply to samples during service discovery. |
 | targets<a href="#vmprobetargetstatic-targets" id="vmprobetargetstatic-targets">#</a><br/>_string array_ | _(Required)_<br/>Targets is a list of URLs to probe using the configured prober. |
 
-
 #### VMProbeTargets
-
-
 
 VMProbeTargets defines a set of static and dynamically discovered targets for the prober.
 
@@ -4740,10 +4093,7 @@ Appears in: [VMProbeSpec](#vmprobespec)
 | static<a href="#vmprobetargets-static" id="vmprobetargets-static">#</a><br/>_[VMProbeTargetStatic](#vmprobetargetstatic)_ | _(Optional)_<br/>Static defines static targets which are considers for probing. |
 | staticConfig<a href="#vmprobetargets-staticconfig" id="vmprobetargets-staticconfig">#</a><br/>_[VMProbeTargetStatic](#vmprobetargetstatic)_ | _(Optional)_<br/>StaticConfig defines static targets which are considers for probing.<br/><b>Deprecated: </b>since version <a href="https://docs.victoriametrics.com/operator/changelog/#v0680">v0.68.0</a> will be removed in <a href="https://docs.victoriametrics.com/operator/changelog/#v0710">v0.71.0</a> use <a href="#vmprobetargets-static">static</a> instead<br/> |
 
-
 #### VMProberSpec
-
-
 
 VMProberSpec contains specification parameters for the Prober used for probing.
 
@@ -4755,10 +4105,7 @@ Appears in: [VMProbeSpec](#vmprobespec)
 | scheme<a href="#vmproberspec-scheme" id="vmproberspec-scheme">#</a><br/>_string_ | _(Optional)_<br/>HTTP scheme to use for scraping.<br />Defaults to `http`. |
 | url<a href="#vmproberspec-url" id="vmproberspec-url">#</a><br/>_string_ | _(Required)_<br/>Mandatory URL of the prober. |
 
-
 #### VMRestore
-
-
 
 VMRestore defines config options for vmrestore start-up
 
@@ -4768,10 +4115,7 @@ Appears in: [VMBackup](#vmbackup)
 | --- | --- |
 | onStart<a href="#vmrestore-onstart" id="vmrestore-onstart">#</a><br/>_[VMRestoreOnStartConfig](#vmrestoreonstartconfig)_ | _(Optional)_<br/>OnStart defines configuration for restore on pod start |
 
-
 #### VMRestoreOnStartConfig
-
-
 
 VMRestoreOnStartConfig controls vmrestore setting
 
@@ -4781,14 +4125,9 @@ Appears in: [VMRestore](#vmrestore)
 | --- | --- |
 | enabled<a href="#vmrestoreonstartconfig-enabled" id="vmrestoreonstartconfig-enabled">#</a><br/>_boolean_ | _(Optional)_<br/>Enabled defines if restore on start enabled |
 
-
 #### VMRule
 
-
-
 VMRule defines rule records for vmalert application
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4797,10 +4136,7 @@ VMRule defines rule records for vmalert application
 | metadata<a href="#vmrule-metadata" id="vmrule-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmrule-spec" id="vmrule-spec">#</a><br/>_[VMRuleSpec](#vmrulespec)_ | _(Required)_<br/> |
 
-
 #### VMRuleSpec
-
-
 
 VMRuleSpec defines the desired state of VMRule
 
@@ -4810,14 +4146,9 @@ Appears in: [VMRule](#vmrule)
 | --- | --- |
 | groups<a href="#vmrulespec-groups" id="vmrulespec-groups">#</a><br/>_[RuleGroup](#rulegroup) array_ | _(Required)_<br/>Groups list of group rules |
 
-
 #### VMScrapeConfig
 
-
-
 VMScrapeConfig specifies a set of targets and parameters describing how to scrape them.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4826,10 +4157,7 @@ VMScrapeConfig specifies a set of targets and parameters describing how to scrap
 | metadata<a href="#vmscrapeconfig-metadata" id="vmscrapeconfig-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmscrapeconfig-spec" id="vmscrapeconfig-spec">#</a><br/>_[VMScrapeConfigSpec](#vmscrapeconfigspec)_ | _(Required)_<br/> |
 
-
 #### VMScrapeConfigSpec
-
-
 
 VMScrapeConfigSpec defines the desired state of VMScrapeConfig
 
@@ -4873,10 +4201,7 @@ Appears in: [VMScrapeConfig](#vmscrapeconfig)
 | tlsConfig<a href="#vmscrapeconfigspec-tlsconfig" id="vmscrapeconfigspec-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig configuration to use when scraping the endpoint |
 | vm_scrape_params<a href="#vmscrapeconfigspec-vm_scrape_params" id="vmscrapeconfigspec-vm_scrape_params">#</a><br/>_[VMScrapeParams](#vmscrapeparams)_ | _(Optional)_<br/>VMScrapeParams defines VictoriaMetrics specific scrape parameters |
 
-
 #### VMScrapeParams
-
-
 
 VMScrapeParams defines scrape target configuration that compatible only with VictoriaMetrics scrapers
 VMAgent and VMSingle
@@ -4894,10 +4219,7 @@ Appears in: [Endpoint](#endpoint), [EndpointScrapeParams](#endpointscrapeparams)
 | scrape_offset<a href="#vmscrapeparams-scrape_offset" id="vmscrapeparams-scrape_offset">#</a><br/>_string_ | _(Optional)_<br/> |
 | stream_parse<a href="#vmscrapeparams-stream_parse" id="vmscrapeparams-stream_parse">#</a><br/>_boolean_ | _(Optional)_<br/> |
 
-
 #### VMSelect
-
-
 
 VMSelect defines configuration section for vmselect components of the victoria-metrics cluster
 
@@ -4957,17 +4279,12 @@ Appears in: [VMClusterSpec](#vmclusterspec)
 | volumes<a href="#vmselect-volumes" id="vmselect-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vmselect-vpa" id="vmselect-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VMServiceScrape
-
-
 
 VMServiceScrape is scrape configuration for endpoints associated with
 kubernetes service,
 it generates scrape configuration for vmagent based on selectors.
 result config will scrape service endpoints
-
-
 
 | Field | Description |
 | --- | --- |
@@ -4976,10 +4293,7 @@ result config will scrape service endpoints
 | metadata<a href="#vmservicescrape-metadata" id="vmservicescrape-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmservicescrape-spec" id="vmservicescrape-spec">#</a><br/>_[VMServiceScrapeSpec](#vmservicescrapespec)_ | _(Required)_<br/> |
 
-
 #### VMServiceScrapeSpec
-
-
 
 VMServiceScrapeSpec defines the desired state of VMServiceScrape
 
@@ -4999,14 +4313,9 @@ Appears in: [VLAgentSpec](#vlagentspec), [VLInsert](#vlinsert), [VLSelect](#vlse
 | seriesLimit<a href="#vmservicescrapespec-serieslimit" id="vmservicescrapespec-serieslimit">#</a><br/>_integer_ | _(Optional)_<br/>SeriesLimit defines per-scrape limit on number of unique time series<br />a single target can expose during all the scrapes on the time window of 24h. |
 | targetLabels<a href="#vmservicescrapespec-targetlabels" id="vmservicescrapespec-targetlabels">#</a><br/>_string array_ | _(Optional)_<br/>TargetLabels transfers labels on the Kubernetes Service onto the target. |
 
-
 #### VMSingle
 
-
-
 VMSingle  is fast, cost-effective and scalable time-series database.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -5015,10 +4324,7 @@ VMSingle  is fast, cost-effective and scalable time-series database.
 | metadata<a href="#vmsingle-metadata" id="vmsingle-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmsingle-spec" id="vmsingle-spec">#</a><br/>_[VMSingleSpec](#vmsinglespec)_ | _(Required)_<br/> |
 
-
 #### VMSingleSpec
-
-
 
 VMSingleSpec defines the desired state of VMSingle
 
@@ -5127,14 +4433,9 @@ Appears in: [VMSingle](#vmsingle)
 | volumeMounts<a href="#vmsinglespec-volumemounts" id="vmsinglespec-volumemounts">#</a><br/>_[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volumemount-v1-core) array_ | _(Optional)_<br/>VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.<br />VolumeMounts specified will be appended to other VolumeMounts in the Application container |
 | volumes<a href="#vmsinglespec-volumes" id="vmsinglespec-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 
-
 #### VMStaticScrape
 
-
-
 VMStaticScrape  defines static targets configuration for scraping.
-
-
 
 | Field | Description |
 | --- | --- |
@@ -5143,10 +4444,7 @@ VMStaticScrape  defines static targets configuration for scraping.
 | metadata<a href="#vmstaticscrape-metadata" id="vmstaticscrape-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmstaticscrape-spec" id="vmstaticscrape-spec">#</a><br/>_[VMStaticScrapeSpec](#vmstaticscrapespec)_ | _(Required)_<br/> |
 
-
 #### VMStaticScrapeSpec
-
-
 
 VMStaticScrapeSpec defines the desired state of VMStaticScrape.
 
@@ -5160,12 +4458,7 @@ Appears in: [VMStaticScrape](#vmstaticscrape)
 | seriesLimit<a href="#vmstaticscrapespec-serieslimit" id="vmstaticscrapespec-serieslimit">#</a><br/>_integer_ | _(Optional)_<br/>SeriesLimit defines per-scrape limit on number of unique time series<br />a single target can expose during all the scrapes on the time window of 24h. |
 | targetEndpoints<a href="#vmstaticscrapespec-targetendpoints" id="vmstaticscrapespec-targetendpoints">#</a><br/>_[TargetEndpoint](#targetendpoint) array_ | _(Required)_<br/>A list of target endpoints to scrape metrics from. |
 
-
 #### VMStorage
-
-
-
-
 
 Appears in: [VMClusterSpec](#vmclusterspec)
 
@@ -5227,14 +4520,9 @@ Appears in: [VMClusterSpec](#vmclusterspec)
 | volumes<a href="#vmstorage-volumes" id="vmstorage-volumes">#</a><br/>_[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | _(Required)_<br/>Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.<br />Volumes specified will be appended to other volumes that are generated.<br />/ +optional |
 | vpa<a href="#vmstorage-vpa" id="vmstorage-vpa">#</a><br/>_[EmbeddedVPA](#embeddedvpa)_ | _(Optional)_<br/>Configures vertical pod autoscaling. |
 
-
 #### VMUser
 
-
-
 VMUser is the Schema for the vmusers API
-
-
 
 | Field | Description |
 | --- | --- |
@@ -5243,10 +4531,7 @@ VMUser is the Schema for the vmusers API
 | metadata<a href="#vmuser-metadata" id="vmuser-metadata">#</a><br/>_[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | _(Required)_<br/>Refer to Kubernetes API documentation for fields of `metadata`. |
 | spec<a href="#vmuser-spec" id="vmuser-spec">#</a><br/>_[VMUserSpec](#vmuserspec)_ | _(Required)_<br/> |
 
-
 #### VMUserConfigOptions
-
-
 
 VMUserConfigOptions defines configuration options for VMUser object
 
@@ -5266,10 +4551,7 @@ Appears in: [VMAuthSpec](#vmauthspec), [VMAuthUnauthorizedUserAccessSpec](#vmaut
 | retry_status_codes<a href="#vmuserconfigoptions-retry_status_codes" id="vmuserconfigoptions-retry_status_codes">#</a><br/>_integer array_ | _(Optional)_<br/>RetryStatusCodes defines http status codes in numeric format for request retries<br />e.g. [429,503] |
 | tlsConfig<a href="#vmuserconfigoptions-tlsconfig" id="vmuserconfigoptions-tlsconfig">#</a><br/>_[TLSConfig](#tlsconfig)_ | _(Optional)_<br/>TLSConfig defines tls configuration for the backend connection |
 
-
 #### VMUserIPFilters
-
-
 
 VMUserIPFilters defines filters for IP addresses
 supported only with enterprise version of [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/#ip-filters)
@@ -5281,10 +4563,7 @@ Appears in: [VMAuthSpec](#vmauthspec), [VMAuthUnauthorizedUserAccessSpec](#vmaut
 | allow_list<a href="#vmuseripfilters-allow_list" id="vmuseripfilters-allow_list">#</a><br/>_string array_ | _(Required)_<br/> |
 | deny_list<a href="#vmuseripfilters-deny_list" id="vmuseripfilters-deny_list">#</a><br/>_string array_ | _(Required)_<br/> |
 
-
 #### VMUserSpec
-
-
 
 VMUserSpec defines the desired state of VMUser
 
@@ -5315,10 +4594,7 @@ Appears in: [VMUser](#vmuser)
 | tokenRef<a href="#vmuserspec-tokenref" id="vmuserspec-tokenref">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>TokenRef allows fetching token from user-created secrets by its name and key. |
 | username<a href="#vmuserspec-username" id="vmuserspec-username">#</a><br/>_string_ | _(Optional)_<br/>Username basic auth user name for accessing protected endpoint,<br />will be replaced with metadata.name of VMUser if omitted. |
 
-
 #### VictorOpsConfig
-
-
 
 VictorOpsConfig configures notifications via VictorOps.
 See https://prometheus.io/docs/alerting/latest/configuration/#victorops_config
@@ -5338,10 +4614,7 @@ Appears in: [Receiver](#receiver)
 | send_resolved<a href="#victoropsconfig-send_resolved" id="victoropsconfig-send_resolved">#</a><br/>_boolean_ | _(Optional)_<br/>SendResolved controls notify about resolved alerts. |
 | state_message<a href="#victoropsconfig-state_message" id="victoropsconfig-state_message">#</a><br/>_string_ | _(Optional)_<br/>Contains long explanation of the alerted problem. |
 
-
 #### WeChatConfig
-
-
 
 WeChatConfig configures notifications via WeChat.
 See https://prometheus.io/docs/alerting/latest/configuration/#wechat_config
@@ -5362,12 +4635,7 @@ Appears in: [Receiver](#receiver)
 | to_tag<a href="#wechatconfig-to_tag" id="wechatconfig-to_tag">#</a><br/>_string_ | _(Optional)_<br/> |
 | to_user<a href="#wechatconfig-to_user" id="wechatconfig-to_user">#</a><br/>_string_ | _(Optional)_<br/> |
 
-
 #### WebexConfig
-
-
-
-
 
 Appears in: [Receiver](#receiver)
 
@@ -5379,10 +4647,7 @@ Appears in: [Receiver](#receiver)
 | room_id<a href="#webexconfig-room_id" id="webexconfig-room_id">#</a><br/>_string_ | _(Required)_<br/>The ID of the Webex Teams room where to send the messages |
 | send_resolved<a href="#webexconfig-send_resolved" id="webexconfig-send_resolved">#</a><br/>_boolean_ | _(Optional)_<br/>SendResolved controls notify about resolved alerts. |
 
-
 #### WebhookConfig
-
-
 
 WebhookConfig configures notifications via a generic receiver supporting the webhook payload.
 See https://prometheus.io/docs/alerting/latest/configuration/#webhook_config
@@ -5397,5 +4662,4 @@ Appears in: [Receiver](#receiver)
 | timeout<a href="#webhookconfig-timeout" id="webhookconfig-timeout">#</a><br/>_string_ | _(Optional)_<br/>Timeout is the maximum time allowed to invoke the webhook<br />available since v0.28.0 alertmanager version |
 | url<a href="#webhookconfig-url" id="webhookconfig-url">#</a><br/>_string_ | _(Optional)_<br/>URL to send requests to,<br />one of `urlSecret` and `url` must be defined. |
 | url_secret<a href="#webhookconfig-url_secret" id="webhookconfig-url_secret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>URLSecret defines secret name and key at the CRD namespace.<br />It must contain the webhook URL.<br />one of `urlSecret` and `url` must be defined. |
-
 

--- a/docs/templates/api/details.tpl
+++ b/docs/templates/api/details.tpl
@@ -2,18 +2,24 @@
 {{- $gv := . -}}
 
 ## {{ $gv.GroupVersionString }}
+{{- if $gv.Doc }}
 
-{{ $gv.Doc }}
+{{ trim $gv.Doc }}
+{{- end }}
+{{- if $gv.Kinds }}
 
-{{- if $gv.Kinds  }}
 ### Resource Types
+{{- if $gv.SortedKinds}}
 {{- range $gv.SortedKinds }}
 - {{ $gv.TypeForKind . | markdownRenderTypeLink }}
 {{- end }}
-{{ end }}
+{{- end }}
 
+{{- end }}
+{{- if $gv.SortedTypes }}
 {{ range $gv.SortedTypes }}
 {{ template "type" . }}
-{{ end }}
+{{- end }}
 
+{{- end }}
 {{- end -}}

--- a/docs/templates/api/list.tpl
+++ b/docs/templates/api/list.tpl
@@ -22,7 +22,6 @@ tags:
 {{- range $groupVersions }}
 - {{ markdownRenderGVLink . }}
 {{- end }}
-
 {{ range $groupVersions }}
 {{ template "gvDetails" . }}
 {{ end }}

--- a/docs/templates/api/type.tpl
+++ b/docs/templates/api/type.tpl
@@ -31,23 +31,27 @@
 {{- if markdownShouldRenderType $type -}}
 
 #### {{ $type.Name }}
+{{- if $type.IsAlias }}
 
-{{ if $type.IsAlias }}_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType }}_{{ end }}
+_Underlying type:_ _{{ markdownRenderTypeLink $type.UnderlyingType }}_
+{{- end }}
+{{- if $type.Doc }}
 
 {{ $type.Doc }}
+{{- end }}
+{{- if $type.Validation }}
 
-{{ if $type.Validation -}}
 _Validation:_
 {{- range $type.Validation }}
 - {{ . }}
 {{- end }}
 {{- end }}
+{{- if $type.References }}
 
-{{- if $type.References -}}
 Appears in: {{ range $i, $ref := $type.SortedReferences }}{{ if $i }}, {{ end }}{{ markdownRenderTypeLink $ref }}{{- end }}
 {{- end }}
+{{- if $type.Members }}
 
-{{ if $type.Members -}}
 | Field | Description |
 | --- | --- |
 {{ if $type.GVK -}}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up API docs templates to avoid empty sections and produce cleaner formatting with consistent ordering of kinds and types.

- **Refactors**
  - Render group doc, resource types, and type details only when present (alias, doc, validation, references, members).
  - Use SortedKinds and SortedTypes for consistent ordering.
  - Trim group/version doc text and remove an extra blank line in list.tpl.
  - Remove generated docs/api.md from the repo.

<sup>Written for commit a15d3562e3ae548df26e57451815fe84c3a1a2c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

