### PR TITLE
vmdistributed: merge all vmclusters into a single read and all vmagents into a single write backend in vmauth config

### DIFF
--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -55,13 +55,17 @@ type VMUserSpec struct {
 
 // TargetRef describes target for user traffic forwarding.
 // one of target types can be chosen:
-// crd or static per targetRef.
+// crds or static per targetRef.
 // user can define multiple targetRefs with different ref Types.
 type TargetRef struct {
 	// CRD describes exist operator's CRD object,
 	// operator generates access url based on CRD params.
 	// +optional
 	CRD *CRDRef `json:"crd,omitempty"`
+	// CRD describes existing operator's CRD objects,
+	// operator generates access url based on CRD params.
+	// +optional
+	CRDs []CRDRef `json:"crds,omitempty"`
 	// Static - user defined url for traffic forward,
 	// for instance http://vmsingle:8428
 	// +optional
@@ -87,11 +91,18 @@ type TargetRef struct {
 }
 
 func (r *TargetRef) validate(isRetryCodesSet bool) error {
-	if r.CRD != nil && r.Static != nil {
-		return fmt.Errorf("targetRef validation failed, one of `crd` or `static` must be configured, got both")
+	var refs []string
+	if r.CRD != nil {
+		refs = append(refs, "crd")
 	}
-	if r.CRD == nil && r.Static == nil {
-		return fmt.Errorf("targetRef validation failed, one of `crd` or `static` must be configured, got none")
+	if len(r.CRDs) > 0 {
+		refs = append(refs, "crds")
+	}
+	if r.Static != nil {
+		refs = append(refs, "static")
+	}
+	if len(refs) != 1 {
+		return fmt.Errorf("targetRef validation failed, exactly one of `crd`, `crds` or `static` must be configured, found: [%s]", strings.Join(refs, ","))
 	}
 	if r.Static != nil {
 		if r.Static.URL == "" && len(r.Static.URLs) == 0 {
@@ -111,6 +122,11 @@ func (r *TargetRef) validate(isRetryCodesSet bool) error {
 	if r.CRD != nil {
 		if r.CRD.Namespace == "" || r.CRD.Name == "" {
 			return fmt.Errorf("crd.name and crd.namespace cannot be empty")
+		}
+	}
+	for i, crd := range r.CRDs {
+		if crd.Namespace == "" || crd.Name == "" {
+			return fmt.Errorf("crds[%d].name and crds[%d].namespace cannot be empty", i, i)
 		}
 	}
 	if err := validateHTTPHeaders(r.ResponseHeaders); err != nil {

--- a/api/operator/v1beta1/zz_generated.deepcopy.go
+++ b/api/operator/v1beta1/zz_generated.deepcopy.go
@@ -3766,6 +3766,11 @@ func (in *TargetRef) DeepCopyInto(out *TargetRef) {
 		*out = new(CRDRef)
 		**out = **in
 	}
+	if in.CRDs != nil {
+		in, out := &in.CRDs, &out.CRDs
+		*out = make([]CRDRef, len(*in))
+		copy(*out, *in)
+	}
 	if in.Static != nil {
 		in, out := &in.Static, &out.Static
 		*out = new(StaticRef)

--- a/config/crd/overlay/crd.yaml
+++ b/config/crd/overlay/crd.yaml
@@ -13936,6 +13936,40 @@ spec:
                           - name
                           - namespace
                           type: object
+                        crds:
+                          items:
+                            properties:
+                              kind:
+                                enum:
+                                - VMAgent
+                                - VMAlert
+                                - VMSingle
+                                - VLogs
+                                - VMAlertManager
+                                - VMAlertmanager
+                                - VMCluster/vmselect
+                                - VMCluster/vmstorage
+                                - VMCluster/vminsert
+                                - VLSingle
+                                - VLCluster/vlinsert
+                                - VLCluster/vlselect
+                                - VLCluster/vlstorage
+                                - VLAgent
+                                - VTCluster/vtinsert
+                                - VTCluster/vtselect
+                                - VTCluster/vtstorage
+                                - VTSingle
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            - namespace
+                            type: object
+                          type: array
                         discover_backend_ips:
                           type: boolean
                         drop_src_path_prefix_parts:
@@ -20835,6 +20869,40 @@ spec:
                                   - name
                                   - namespace
                                   type: object
+                                crds:
+                                  items:
+                                    properties:
+                                      kind:
+                                        enum:
+                                        - VMAgent
+                                        - VMAlert
+                                        - VMSingle
+                                        - VLogs
+                                        - VMAlertManager
+                                        - VMAlertmanager
+                                        - VMCluster/vmselect
+                                        - VMCluster/vmstorage
+                                        - VMCluster/vminsert
+                                        - VLSingle
+                                        - VLCluster/vlinsert
+                                        - VLCluster/vlselect
+                                        - VLCluster/vlstorage
+                                        - VLAgent
+                                        - VTCluster/vtinsert
+                                        - VTCluster/vtselect
+                                        - VTCluster/vtstorage
+                                        - VTSingle
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    - namespace
+                                    type: object
+                                  type: array
                                 discover_backend_ips:
                                   type: boolean
                                 drop_src_path_prefix_parts:
@@ -37483,6 +37551,40 @@ spec:
                       - name
                       - namespace
                       type: object
+                    crds:
+                      items:
+                        properties:
+                          kind:
+                            enum:
+                            - VMAgent
+                            - VMAlert
+                            - VMSingle
+                            - VLogs
+                            - VMAlertManager
+                            - VMAlertmanager
+                            - VMCluster/vmselect
+                            - VMCluster/vmstorage
+                            - VMCluster/vminsert
+                            - VLSingle
+                            - VLCluster/vlinsert
+                            - VLCluster/vlselect
+                            - VLCluster/vlstorage
+                            - VLAgent
+                            - VTCluster/vtinsert
+                            - VTCluster/vtselect
+                            - VTCluster/vtstorage
+                            - VTSingle
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        - namespace
+                        type: object
+                      type: array
                     discover_backend_ips:
                       type: boolean
                     drop_src_path_prefix_parts:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,8 +17,10 @@ aliases:
 
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): VMSingle reuses vmagent implementation to allow scraping and relabelling. See [#1694](https://github.com/VictoriaMetrics/operator/issues/1694)
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): perform statefulset pods deletion instead of eviction when maxUnavailable set to 100%, which is important for [minimum downtime strategy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#minimum-downtime-strategy). See [#1706](https://github.com/VictoriaMetrics/operator/issues/1706).
+* FEATURE: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): support `targetRefs[*].crds` to place multiple CRD objects behind a single backend
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): VMPodScrape for VLAgent and VMAgent now uses the correct port; previously it used the wrong port and could cause scrape failures. See [#1887](https://github.com/VictoriaMetrics/operator/issues/1887).
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): updated VMAuth config consolidating all VMSelects into a single read and all VMClusters into a single write backend
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): remove unneeded finalizer from core K8s resources. See [#835](https://github.com/VictoriaMetrics/operator/issues/835).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3427,7 +3427,7 @@ Appears in: [VMStaticScrapeSpec](#vmstaticscrapespec)
 
 TargetRef describes target for user traffic forwarding.
 one of target types can be chosen:
-crd or static per targetRef.
+crds or static per targetRef.
 user can define multiple targetRefs with different ref Types.
 
 Appears in: [VMAuthUnauthorizedUserAccessSpec](#vmauthunauthorizeduseraccessspec), [VMUserSpec](#vmuserspec)
@@ -3436,6 +3436,7 @@ Appears in: [VMAuthUnauthorizedUserAccessSpec](#vmauthunauthorizeduseraccessspec
 | --- | --- |
 | URLMapCommon<a href="#targetref-urlmapcommon" id="targetref-urlmapcommon">#</a><br/>_[URLMapCommon](#urlmapcommon)_ | _(Required)_<br/> |
 | crd<a href="#targetref-crd" id="targetref-crd">#</a><br/>_[CRDRef](#crdref)_ | _(Optional)_<br/>CRD describes exist operator's CRD object,<br />operator generates access url based on CRD params. |
+| crds<a href="#targetref-crds" id="targetref-crds">#</a><br/>_[CRDRef](#crdref) array_ | _(Optional)_<br/>CRD describes existing operator's CRD objects,<br />operator generates access url based on CRD params. |
 | hosts<a href="#targetref-hosts" id="targetref-hosts">#</a><br/>_string array_ | _(Required)_<br/> |
 | paths<a href="#targetref-paths" id="targetref-paths">#</a><br/>_string array_ | _(Optional)_<br/>Paths - matched path to route. |
 | query_args<a href="#targetref-query_args" id="targetref-query_args">#</a><br/>_[QueryArg](#queryarg) array_ | _(Optional)_<br/>QueryArgs appends list of query arguments to generated URL |

--- a/internal/controller/operator/factory/vmauth/vmusers_config.go
+++ b/internal/controller/operator/factory/vmauth/vmusers_config.go
@@ -305,28 +305,39 @@ func (c *clusterWithURL) AsURL() string {
 }
 
 func fetchCRDRefURLs(ctx context.Context, rclient client.Client, refs []vmv1beta1.TargetRef, crdURLCache map[string]string) error {
-	for j := range refs {
-		ref := &refs[j]
-		if ref.CRD == nil {
-			continue
+	updateCache := func(crd *vmv1beta1.CRDRef) error {
+		if crd == nil {
+			return nil
 		}
-		key := ref.CRD.AsKey()
+		key := crd.AsKey()
 		if _, ok := crdURLCache[key]; ok {
-			continue
+			return nil
 		}
-		crdObj, ok := crdNameToObject[ref.CRD.Kind]
+		crdObj, ok := crdNameToObject[crd.Kind]
 		if !ok {
-			return fmt.Errorf("unsupported kind for ref: %q at idx=%d", ref.CRD.Kind, j)
+			return fmt.Errorf("unsupported kind=%q", crd.Kind)
 		}
-		ref.CRD.AddRefToObj(crdObj.(client.Object))
+		crd.AddRefToObj(crdObj.(client.Object))
 		url, err := getAsURLObject(ctx, rclient, crdObj)
 		if err != nil {
 			if !build.IsNotFound(err) {
 				return fmt.Errorf("cannot get object as url: %w", err)
 			}
-			return fmt.Errorf("cannot find CRD link for kind=%q at ref idx=%d: %w", ref.CRD.Kind, j, err)
+			return fmt.Errorf("cannot find CRD link for kind=%q: %w", crd.Kind, err)
 		}
 		crdURLCache[key] = url
+		return nil
+	}
+	for j := range refs {
+		ref := &refs[j]
+		if err := updateCache(ref.CRD); err != nil {
+			return fmt.Errorf("targetRefs[%d].crd: %w", j, err)
+		}
+		for i, crd := range ref.CRDs {
+			if err := updateCache(&crd); err != nil {
+				return fmt.Errorf("targetRefs[%d].crds[%d]: %w", j, i, err)
+			}
+		}
 	}
 	return nil
 }
@@ -588,6 +599,14 @@ func genURLMaps(userName string, refs []vmv1beta1.TargetRef, result yaml.MapSlic
 				return nil, fmt.Errorf("cannot find crdRef target: %q, for user: %s", ref.CRD.AsKey(), userName)
 			}
 			urlPrefixes = append(urlPrefixes, urlPrefix)
+		case len(ref.CRDs) > 0:
+			for i, crd := range ref.CRDs {
+				urlPrefix := crdURLCache[crd.AsKey()]
+				if urlPrefix == "" {
+					return nil, fmt.Errorf("cannot find crdRef[%d] target: %q, for user: %s", i, crd.AsKey(), userName)
+				}
+				urlPrefixes = append(urlPrefixes, urlPrefix)
+			}
 		case len(ref.Static.URL) > 0:
 			urlPrefixes = append(urlPrefixes, ref.Static.URL)
 		case len(ref.Static.URLs) > 0:
@@ -685,7 +704,7 @@ func genURLMaps(userName string, refs []vmv1beta1.TargetRef, result yaml.MapSlic
 	for i := range refs {
 		var urlMap yaml.MapSlice
 		ref := refs[i]
-		if ref.Static == nil && ref.CRD == nil {
+		if ref.Static == nil && ref.CRD == nil && len(ref.CRDs) == 0 {
 			continue
 		}
 		urlPrefix, err := handleRef(ref)

--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -11,7 +11,8 @@ import (
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 )
 
-func appendVMClusterTargetRefs(targetRefs []vmv1beta1.TargetRef, vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) []vmv1beta1.TargetRef {
+func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) vmv1beta1.TargetRef {
+	var crds []vmv1beta1.CRDRef
 	for i := range vmClusters {
 		if slices.Contains(excludeIds, i) {
 			continue
@@ -20,23 +21,24 @@ func appendVMClusterTargetRefs(targetRefs []vmv1beta1.TargetRef, vmClusters []*v
 		if vmCluster.CreationTimestamp.IsZero() {
 			continue
 		}
-		targetRefs = append(targetRefs, vmv1beta1.TargetRef{
-			URLMapCommon: vmv1beta1.URLMapCommon{
-				LoadBalancingPolicy: ptr.To("first_available"),
-				RetryStatusCodes:    []int{500, 502, 503},
-			},
-			Paths: []string{"/select/.+", "/admin/tenants"},
-			CRD: &vmv1beta1.CRDRef{
-				Kind:      "VMCluster/vmselect",
-				Name:      vmCluster.Name,
-				Namespace: vmCluster.Namespace,
-			},
+		crds = append(crds, vmv1beta1.CRDRef{
+			Kind:      "VMCluster/vmselect",
+			Name:      vmCluster.Name,
+			Namespace: vmCluster.Namespace,
 		})
 	}
-	return targetRefs
+	return vmv1beta1.TargetRef{
+		URLMapCommon: vmv1beta1.URLMapCommon{
+			LoadBalancingPolicy: ptr.To("first_available"),
+			RetryStatusCodes:    []int{500, 502, 503},
+		},
+		Paths: []string{"/select/.+", "/admin/tenants"},
+		CRDs:  crds,
+	}
 }
 
-func appendVMAgentTargetRefs(targetRefs []vmv1beta1.TargetRef, vmAgents []*vmv1beta1.VMAgent, excludeIds ...int) []vmv1beta1.TargetRef {
+func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, excludeIds ...int) vmv1beta1.TargetRef {
+	var crds []vmv1beta1.CRDRef
 	for i := range vmAgents {
 		if slices.Contains(excludeIds, i) {
 			continue
@@ -45,20 +47,20 @@ func appendVMAgentTargetRefs(targetRefs []vmv1beta1.TargetRef, vmAgents []*vmv1b
 		if vmAgent.CreationTimestamp.IsZero() {
 			continue
 		}
-		targetRefs = append(targetRefs, vmv1beta1.TargetRef{
-			URLMapCommon: vmv1beta1.URLMapCommon{
-				LoadBalancingPolicy: ptr.To("first_available"),
-				RetryStatusCodes:    []int{500, 502, 503},
-			},
-			Paths: []string{"/insert/.+", "/api/v1/write"},
-			CRD: &vmv1beta1.CRDRef{
-				Kind:      "VMAgent",
-				Name:      vmAgent.Name,
-				Namespace: vmAgent.Namespace,
-			},
+		crds = append(crds, vmv1beta1.CRDRef{
+			Kind:      "VMAgent",
+			Name:      vmAgent.Name,
+			Namespace: vmAgent.Namespace,
 		})
 	}
-	return targetRefs
+	return vmv1beta1.TargetRef{
+		URLMapCommon: vmv1beta1.URLMapCommon{
+			LoadBalancingPolicy: ptr.To("first_available"),
+			RetryStatusCodes:    []int{500, 502, 503},
+		},
+		Paths: []string{"/insert/.+", "/api/v1/write"},
+		CRDs:  crds,
+	}
 }
 
 func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) *vmv1beta1.VMAuth {
@@ -77,14 +79,14 @@ func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, 
 		vmAuth.Spec.UnauthorizedUserAccessSpec = &vmv1beta1.VMAuthUnauthorizedUserAccessSpec{}
 	}
 	var targetRefs []vmv1beta1.TargetRef
-	targetRefs = appendVMClusterTargetRefs(targetRefs, vmClusters, excludeIds...)
-	targetRefs = appendVMAgentTargetRefs(targetRefs, vmAgents, excludeIds...)
-	slices.SortFunc(targetRefs, func(a, b vmv1beta1.TargetRef) int {
-		return cmp.Or(
-			cmp.Compare(a.CRD.Kind, b.CRD.Kind),
-			cmp.Compare(a.CRD.Name, b.CRD.Name),
-		)
-	})
+	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, excludeIds...))
+	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, excludeIds...))
+	for i := range targetRefs {
+		targetRef := &targetRefs[i]
+		slices.SortFunc(targetRef.CRDs, func(a, b vmv1beta1.CRDRef) int {
+			return cmp.Compare(a.Name, b.Name)
+		})
+	}
 	vmAuth.Spec.UnauthorizedUserAccessSpec.URLMap = nil
 	vmAuth.Spec.UnauthorizedUserAccessSpec.URLPrefix = nil
 	vmAuth.Spec.UnauthorizedUserAccessSpec.TargetRefs = targetRefs

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
@@ -343,8 +343,8 @@ func TestCreateOrUpdate(t *testing.T) {
 				},
 			}
 			var targetRefs []vmv1beta1.TargetRef
-			targetRefs = appendVMAgentTargetRefs(targetRefs, d.zones.vmagents)
-			targetRefs = appendVMClusterTargetRefs(targetRefs, []*vmv1beta1.VMCluster{d.zones.vmclusters[0]})
+			targetRefs = append(targetRefs, vmAgentTargetRef(d.zones.vmagents))
+			targetRefs = append(targetRefs, vmClusterTargetRef([]*vmv1beta1.VMCluster{d.zones.vmclusters[0]}))
 			lb.Spec.UnauthorizedUserAccessSpec = &vmv1beta1.VMAuthUnauthorizedUserAccessSpec{
 				TargetRefs: targetRefs,
 			}
@@ -405,27 +405,29 @@ func TestCreateOrUpdate(t *testing.T) {
 			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
-			targetRefs := make([]vmv1beta1.TargetRef, 6)
+			var vmClusterCRDs, vmAgentCRDs []vmv1beta1.CRDRef
+			for i := range d.zones.vmagents {
+				vmAgentCRDs = append(vmAgentCRDs, vmv1beta1.CRDRef{
+					Name:      d.zones.vmagents[i].Name,
+					Namespace: d.zones.vmagents[i].Namespace,
+					Kind:      "VMAgent",
+				})
+			}
+			for i := range d.zones.vmclusters {
+				vmClusterCRDs = append(vmClusterCRDs, vmv1beta1.CRDRef{
+					Name:      d.zones.vmclusters[i].Name,
+					Namespace: d.zones.vmclusters[i].Namespace,
+					Kind:      "VMCluster/vmselect",
+				})
+			}
+			targetRefs := []vmv1beta1.TargetRef{
+				{Paths: []string{"/insert/.+", "/api/v1/write"}, CRDs: vmAgentCRDs},
+				{Paths: []string{"/select/.+", "/admin/tenants"}, CRDs: vmClusterCRDs},
+			}
 			for i := range targetRefs {
 				targetRef := &targetRefs[i]
 				targetRef.LoadBalancingPolicy = ptr.To("first_available")
 				targetRef.RetryStatusCodes = []int{500, 502, 503}
-				if i < len(d.zones.vmagents) {
-					targetRef.CRD = &vmv1beta1.CRDRef{
-						Name:      d.zones.vmagents[i].Name,
-						Namespace: d.zones.vmagents[i].Namespace,
-						Kind:      "VMAgent",
-					}
-					targetRef.Paths = []string{"/insert/.+", "/api/v1/write"}
-				} else {
-					idx := i - len(d.zones.vmagents)
-					targetRef.CRD = &vmv1beta1.CRDRef{
-						Name:      d.zones.vmclusters[idx].Name,
-						Namespace: d.zones.vmclusters[idx].Namespace,
-						Kind:      "VMCluster/vmselect",
-					}
-					targetRef.Paths = []string{"/select/.+", "/admin/tenants"}
-				}
 			}
 			var got vmv1beta1.VMAuth
 			nsn := types.NamespacedName{
@@ -534,27 +536,29 @@ func TestCreateOrUpdate(t *testing.T) {
 			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
-			targetRefs := make([]vmv1beta1.TargetRef, 6)
+			var vmClusterCRDs, vmAgentCRDs []vmv1beta1.CRDRef
+			for i := range d.zones.vmagents {
+				vmAgentCRDs = append(vmAgentCRDs, vmv1beta1.CRDRef{
+					Name:      d.zones.vmagents[i].Name,
+					Namespace: d.zones.vmagents[i].Namespace,
+					Kind:      "VMAgent",
+				})
+			}
+			for i := range d.zones.vmclusters {
+				vmClusterCRDs = append(vmClusterCRDs, vmv1beta1.CRDRef{
+					Name:      d.zones.vmclusters[i].Name,
+					Namespace: d.zones.vmclusters[i].Namespace,
+					Kind:      "VMCluster/vmselect",
+				})
+			}
+			targetRefs := []vmv1beta1.TargetRef{
+				{Paths: []string{"/insert/.+", "/api/v1/write"}, CRDs: vmAgentCRDs},
+				{Paths: []string{"/select/.+", "/admin/tenants"}, CRDs: vmClusterCRDs},
+			}
 			for i := range targetRefs {
 				targetRef := &targetRefs[i]
 				targetRef.LoadBalancingPolicy = ptr.To("first_available")
 				targetRef.RetryStatusCodes = []int{500, 502, 503}
-				if i < len(d.zones.vmagents) {
-					targetRef.CRD = &vmv1beta1.CRDRef{
-						Name:      d.zones.vmagents[i].Name,
-						Namespace: d.zones.vmagents[i].Namespace,
-						Kind:      "VMAgent",
-					}
-					targetRef.Paths = []string{"/insert/.+", "/api/v1/write"}
-				} else {
-					idx := i - len(d.zones.vmagents)
-					targetRef.CRD = &vmv1beta1.CRDRef{
-						Name:      d.zones.vmclusters[idx].Name,
-						Namespace: d.zones.vmclusters[idx].Namespace,
-						Kind:      "VMCluster/vmselect",
-					}
-					targetRef.Paths = []string{"/select/.+", "/admin/tenants"}
-				}
 			}
 			var got vmv1beta1.VMAuth
 			nsn := types.NamespacedName{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consolidates VMDistributed VMAuth by merging all VMCluster/vmselect targets into one read backend and all VMAgents into one write backend. Adds VMUser targetRefs[*].crds to route to multiple CRDs; deprecates targetRefs[*].crd.

- **New Features**
  - VMUser: add targetRefs[*].crds for multiple CRD targets; crd is deprecated. API schema/docs/deepcopy, URL resolution, and validation updated (exactly one of crd/crds/static is required).

- **Bug Fixes**
  - VMDistributed: VMAuth now emits two targetRefs (write=VMAgents, read=VMCluster/vmselect) with aggregated CRDs per backend, reducing config size and stabilizing routing; tests updated.

<sup>Written for commit 73d85c65cf8c9f6c24621f1b704663c820357a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

