### PR TITLE
removed owner reference for PVC owned by statefulset

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ aliases:
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): VMPodScrape for VLAgent and VMAgent now uses the correct port; previously it used the wrong port and could cause scrape failures. See [#1887](https://github.com/VictoriaMetrics/operator/issues/1887).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): updated VMAuth config consolidating all VMSelects into a single read and all VMClusters into a single write backend
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): fix PVC being owned by StatefulSet and top-level object simultaenously. See [#1845](https://github.com/VictoriaMetrics/operator/issues/1845).
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): remove unneeded finalizer from core K8s resources. See [#835](https://github.com/VictoriaMetrics/operator/issues/835).
 

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -139,7 +139,7 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 		}
 		// check if pvcs need to resize
 		if cr.HasClaim {
-			return updateSTSPVC(ctx, rclient, &existingObj, owner)
+			return updateSTSPVC(ctx, rclient, &existingObj)
 		}
 		return nil
 	})

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -82,7 +82,7 @@ func getPVCFromSTS(pvcName string, sts *appsv1.StatefulSet) *corev1.PersistentVo
 	return nil
 }
 
-func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.StatefulSet, owner *metav1.OwnerReference) error {
+func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.StatefulSet) error {
 	// fast path
 	if sts.Spec.Replicas != nil && *sts.Spec.Replicas == 0 {
 		return nil
@@ -120,7 +120,7 @@ func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.Statef
 			continue
 		}
 		// update PVC size and metadata if it's needed
-		if err := updatePVC(ctx, rclient, &pvc, &stsClaim, nil, owner); err != nil {
+		if err := updatePVC(ctx, rclient, &pvc, &stsClaim, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
@@ -210,7 +210,7 @@ func Test_updateSTSPVC(t *testing.T) {
 		t.Helper()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
 		ctx := context.TODO()
-		err := updateSTSPVC(ctx, cl, o.sts, nil)
+		err := updateSTSPVC(ctx, cl, o.sts)
 		if o.wantErr {
 			assert.Error(t, err)
 		} else {


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1845

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop attaching OwnerReference to StatefulSet PVCs during resize to prevent unintended garbage collection and match Kubernetes behavior. Fixes #1845.

- **Bug Fixes**
  - Removed owner parameter from updateSTSPVC; updated caller and unit test.
  - updatePVC now receives nil owner for StatefulSet-claimed PVCs.

<sup>Written for commit 0c8306c38eb594f7aad2788ee4d7d1ec774f2ba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

