### PR TITLE
trigger CI for release branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - master
+      - release-*
     types:
       - opened
       - reopened


### PR DESCRIPTION
since we already have release branches, let's start running CI for PRs to that branches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI for PRs into release branches by adding "release-*" to the GitHub Actions pull_request trigger. This ensures the same checks run on release candidates as on master.

<sup>Written for commit 7c55ea73187be98a81031fcec874912925686c01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

