### PR TITLE
reconcile: use synctest instead of default timeouts change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,7 +29,7 @@ aliases:
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026
 
-* SECURITY: upgrade Go builder from Go1.25.5 to Go1.25.7. See [the list of issues addressed in Go1.25.7](https://github.com/golang/go/issues?q=milestone%3AGo1.25.7+label%3ACherryPickApproved).)
+* SECURITY: upgrade Go builder from Go1.25.5 to Go1.25.7. See [the list of issues addressed in Go1.25.7](https://github.com/golang/go/issues?q=milestone%3AGo1.25.7+label%3ACherryPickApproved).
 
 * BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fix configuration marshalling for [Prophet model](https://docs.victoriametrics.com/anomaly-detection/components/models/#prophet). Previously, using Prophet model would lead to panic during configuration marshalling.
 

--- a/docs/resources/vmagent.md
+++ b/docs/resources/vmagent.md
@@ -56,7 +56,7 @@ Also, you can check out the [examples](https://docs.victoriametrics.com/operator
 - [VMProbe](https://docs.victoriametrics.com/operator/resources/vmprobe/)
 - [VMScrapeConfig](https://docs.victoriametrics.com/operator/resources/vmscrapeconfig/)
 
-These objects specify which targets VMSingle should scrape and how to collect metrics, and generate part of [VMAgent](https://docs.victoriametrics.com/victoriametrics/vmagent/) scrape configuration.
+These objects specify which targets VMAgent should scrape and how to collect metrics, and generate part of [VMAgent](https://docs.victoriametrics.com/victoriametrics/vmagent/) scrape configuration.
 
 `VMAgent` uses selectors to filter scrape objects. Selectors are defined using the `NamespaceSelector` and `Selector` suffixes for each scrape object type in the VMAgent spec:
 
@@ -70,13 +70,13 @@ These objects specify which targets VMSingle should scrape and how to collect me
 This enables access control configuration for objects across namespaces.
 See [this doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta/) for selector specifications.
 
-In addition to these selectors, object filtering in a cluster can be done by the `selectAllByDefault` VMSingle spec field and the operator's `WATCH_NAMESPACE` environment variable.
+In addition to these selectors, object filtering in a cluster can be done by the `selectAllByDefault` VMAgent spec field and the operator's `WATCH_NAMESPACE` environment variable.
 
 Following rules are applied:
 
 - If both `...NamespaceSelector` and `...Selector` are undefined, no objects are selected by default. Setting `spec.selectAllByDefault: true` selects all objects of the given type.
 - If `...NamespaceSelector` is defined and `...Selector` is undefined, all objects in the namespaces matched by ...NamespaceSelector are selected.
-- If `...NamespaceSelector` is undefined and `...Selector` is defined, all objects in VMSingle’s namespaces matching ...Selector are selected.
+- If `...NamespaceSelector` is undefined and `...Selector` is defined, all objects in VMAgent’s namespaces matching ...Selector are selected.
 - If `...NamespaceSelector` and `...Selector` both are defined, then only objects in the namespaces matched by...NamespaceSelector for the given ...Selector are matching.
 
 Below is a more visual and detailed view:

--- a/internal/controller/operator/factory/reconcile/configmap_test.go
+++ b/internal/controller/operator/factory/reconcile/configmap_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -26,18 +27,20 @@ func TestConfigMapReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		_, err := ConfigMap(ctx, cl, o.new, o.prevMeta, o.owner)
-		assert.NoError(t, err)
-		assert.Equal(t, o.actions, cl.Actions)
-		if o.validate != nil {
-			var got corev1.ConfigMap
-			nsn := types.NamespacedName{
-				Name:      o.new.Name,
-				Namespace: o.new.Namespace,
+		synctest.Test(t, func(t *testing.T) {
+			_, err := ConfigMap(ctx, cl, o.new, o.prevMeta, o.owner)
+			assert.NoError(t, err)
+			assert.Equal(t, o.actions, cl.Actions)
+			if o.validate != nil {
+				var got corev1.ConfigMap
+				nsn := types.NamespacedName{
+					Name:      o.new.Name,
+					Namespace: o.new.Namespace,
+				}
+				assert.NoError(t, cl.Get(ctx, nsn, &got))
+				o.validate(&got)
 			}
-			assert.NoError(t, cl.Get(ctx, nsn, &got))
-			o.validate(&got)
-		}
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/daemonset_test.go
+++ b/internal/controller/operator/factory/reconcile/daemonset_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,12 +61,14 @@ func TestDaemonSetReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		if o.wantErr {
-			assert.Error(t, DaemonSet(ctx, cl, o.new, o.prev, nil))
-		} else {
-			assert.NoError(t, DaemonSet(ctx, cl, o.new, o.prev, nil))
-		}
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			if o.wantErr {
+				assert.Error(t, DaemonSet(ctx, cl, o.new, o.prev, nil))
+			} else {
+				assert.NoError(t, DaemonSet(ctx, cl, o.new, o.prev, nil))
+			}
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-ds", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/deploy_test.go
+++ b/internal/controller/operator/factory/reconcile/deploy_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,19 +75,21 @@ func TestDeployReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		err := Deployment(ctx, cl, o.new, o.prev, o.hasHPA, nil)
-		if o.wantErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-		assert.Equal(t, o.actions, cl.Actions)
-		if o.validate != nil {
-			var got appsv1.Deployment
-			nsn := types.NamespacedName{Name: o.new.Name, Namespace: o.new.Namespace}
-			assert.NoError(t, cl.Get(ctx, nsn, &got))
-			o.validate(&got)
-		}
+		synctest.Test(t, func(t *testing.T) {
+			err := Deployment(ctx, cl, o.new, o.prev, o.hasHPA, nil)
+			if o.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, o.actions, cl.Actions)
+			if o.validate != nil {
+				var got appsv1.Deployment
+				nsn := types.NamespacedName{Name: o.new.Name, Namespace: o.new.Namespace}
+				assert.NoError(t, cl.Get(ctx, nsn, &got))
+				o.validate(&got)
+			}
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-1", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/hpa_test.go
+++ b/internal/controller/operator/factory/reconcile/hpa_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	v2 "k8s.io/api/autoscaling/v2"
@@ -46,8 +47,10 @@ func TestHPAReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, HPA(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, HPA(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-hpa", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/httproute_test.go
+++ b/internal/controller/operator/factory/reconcile/httproute_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,8 +46,10 @@ func TestHTTPRouteReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, HTTPRoute(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, HTTPRoute(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-route", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/ingress_test.go
+++ b/internal/controller/operator/factory/reconcile/ingress_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -43,8 +44,10 @@ func TestIngressReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, Ingress(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, Ingress(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-ingress", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/pdb_test.go
+++ b/internal/controller/operator/factory/reconcile/pdb_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
@@ -47,8 +48,10 @@ func TestPDBReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, PDB(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, PDB(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-pdb", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/pvc_test.go
+++ b/internal/controller/operator/factory/reconcile/pvc_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -47,8 +48,10 @@ func TestPersistentVolumeClaimReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, PersistentVolumeClaim(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, PersistentVolumeClaim(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-pvc", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/rbac_test.go
+++ b/internal/controller/operator/factory/reconcile/rbac_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -48,8 +49,10 @@ func TestRoleBindingReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, RoleBinding(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, RoleBinding(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-rb", Namespace: "default"}
@@ -121,8 +124,10 @@ func TestRoleReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, Role(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, Role(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-role", Namespace: "default"}
@@ -198,8 +203,10 @@ func TestClusterRoleBindingReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, ClusterRoleBinding(ctx, cl, o.new, o.prev))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, ClusterRoleBinding(ctx, cl, o.new, o.prev))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-crb"}
@@ -270,8 +277,10 @@ func TestClusterRoleReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, ClusterRole(ctx, cl, o.new, o.prev))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, ClusterRole(ctx, cl, o.new, o.prev))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-cr"}

--- a/internal/controller/operator/factory/reconcile/reconcile.go
+++ b/internal/controller/operator/factory/reconcile/reconcile.go
@@ -29,12 +29,13 @@ var (
 	vmStatusInterval          = 5 * time.Second
 )
 
-// InitFromConfig sets package configuration from config
-func InitDeadlines(intervalCheck, appWaitDeadline, podReadyDeadline, statusInterval time.Duration) {
+// Init sets package defaults
+func Init(intervalCheck, appWaitDeadline, podReadyDeadline, statusInterval, statusUpdate time.Duration) {
 	podWaitReadyIntervalCheck = intervalCheck
 	appWaitReadyDeadline = appWaitDeadline
 	podWaitReadyTimeout = podReadyDeadline
 	vmStatusInterval = statusInterval
+	statusUpdateTTL = statusUpdate
 }
 
 // mergeMaps performs 3-way merge for labels and annotations

--- a/internal/controller/operator/factory/reconcile/reconcile_test.go
+++ b/internal/controller/operator/factory/reconcile/reconcile_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
 
-func init() {
-	InitDeadlines(10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond, 10*time.Millisecond)
-}
-
 func TestWaitForStatus(t *testing.T) {
 	f := func(status vmv1beta1.UpdateStatus, isErr bool) {
 		vmc := &vmv1beta1.VMCluster{

--- a/internal/controller/operator/factory/reconcile/secret_test.go
+++ b/internal/controller/operator/factory/reconcile/secret_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -40,8 +41,10 @@ func TestSecretReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, Secret(ctx, cl, o.new, o.prevMeta, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, Secret(ctx, cl, o.new, o.prevMeta, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-secret", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/service_test.go
+++ b/internal/controller/operator/factory/reconcile/service_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -28,10 +29,12 @@ func Test_reconcileService(t *testing.T) {
 		t.Helper()
 		cl := k8stools.GetTestClientWithObjects(opts.predefinedObjects)
 		ctx := context.Background()
-		assert.NoError(t, Service(ctx, cl, opts.newService, opts.prevService, nil))
-		var gotSvc corev1.Service
-		assert.NoError(t, cl.Get(ctx, types.NamespacedName{Namespace: opts.newService.Namespace, Name: opts.newService.Name}, &gotSvc))
-		opts.validate(&gotSvc)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, Service(ctx, cl, opts.newService, opts.prevService, nil))
+			var gotSvc corev1.Service
+			assert.NoError(t, cl.Get(ctx, types.NamespacedName{Namespace: opts.newService.Namespace, Name: opts.newService.Name}, &gotSvc))
+			opts.validate(&gotSvc)
+		})
 	}
 
 	f(opts{

--- a/internal/controller/operator/factory/reconcile/statefulset_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_test.go
@@ -740,23 +740,25 @@ func TestStatefulsetReconcile(t *testing.T) {
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
 		var emptyOpts STSOptions
-		err := StatefulSet(ctx, cl, emptyOpts, o.new, o.prev, nil)
-		if o.wantErr {
-			assert.Error(t, err)
-			return
-		} else {
-			assert.NoError(t, err)
-		}
-		nsn := types.NamespacedName{
-			Name:      o.new.Name,
-			Namespace: o.new.Namespace,
-		}
-		assert.Equal(t, o.actions, cl.Actions)
-		if o.validate != nil {
-			var got appsv1.StatefulSet
-			assert.NoError(t, cl.Get(ctx, nsn, &got))
-			o.validate(&got)
-		}
+		synctest.Test(t, func(t *testing.T) {
+			err := StatefulSet(ctx, cl, emptyOpts, o.new, o.prev, nil)
+			if o.wantErr {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			nsn := types.NamespacedName{
+				Name:      o.new.Name,
+				Namespace: o.new.Namespace,
+			}
+			assert.Equal(t, o.actions, cl.Actions)
+			if o.validate != nil {
+				var got appsv1.StatefulSet
+				assert.NoError(t, cl.Get(ctx, nsn, &got))
+				o.validate(&got)
+			}
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-1", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -24,13 +24,6 @@ var (
 	statusExpireTTL = 3 * statusUpdateTTL
 )
 
-// SetStatusUpdateTTL configures TTL for LastUpdateTime field
-//
-// Higher value decreases load on Kubernetes API server
-func SetStatusUpdateTTL(v time.Duration) {
-	statusExpireTTL = v
-}
-
 type objectWithStatus interface {
 	client.Object
 	GetStatusMetadata() *vmv1beta1.StatusMetadata

--- a/internal/controller/operator/factory/reconcile/vmagent_test.go
+++ b/internal/controller/operator/factory/reconcile/vmagent_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,18 +45,20 @@ func TestVMAgentReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		err := VMAgent(ctx, cl, o.new, o.prev, nil)
-		if o.wantErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-		assert.Equal(t, o.actions, cl.Actions)
-		if o.validate != nil {
-			var got vmv1beta1.VMAgent
-			assert.NoError(t, cl.Get(ctx, types.NamespacedName{Name: o.new.Name, Namespace: o.new.Namespace}, &got))
-			o.validate(&got)
-		}
+		synctest.Test(t, func(t *testing.T) {
+			err := VMAgent(ctx, cl, o.new, o.prev, nil)
+			if o.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, o.actions, cl.Actions)
+			if o.validate != nil {
+				var got vmv1beta1.VMAgent
+				assert.NoError(t, cl.Get(ctx, types.NamespacedName{Name: o.new.Name, Namespace: o.new.Namespace}, &got))
+				o.validate(&got)
+			}
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vmagent", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/vmauth_test.go
+++ b/internal/controller/operator/factory/reconcile/vmauth_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,8 +43,10 @@ func TestVMAuthReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		assert.NoError(t, VMAuth(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, VMAuth(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vmauth", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/vmcluster_test.go
+++ b/internal/controller/operator/factory/reconcile/vmcluster_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,8 +40,10 @@ func TestVMClusterReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		assert.NoError(t, VMCluster(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, VMCluster(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vmcluster", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/vmpodscrape_test.go
+++ b/internal/controller/operator/factory/reconcile/vmpodscrape_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,8 +48,10 @@ func TestVMPodScrape(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		assert.NoError(t, VMPodScrape(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, VMPodScrape(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vmpodscrape", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/vmservicescrape_test.go
+++ b/internal/controller/operator/factory/reconcile/vmservicescrape_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +47,10 @@ func TestVMServiceScrape(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActionsAndObjects(o.predefinedObjects)
-		assert.NoError(t, VMServiceScrape(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, VMServiceScrape(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vmservicescrape", Namespace: "default"}

--- a/internal/controller/operator/factory/reconcile/vpa_test.go
+++ b/internal/controller/operator/factory/reconcile/vpa_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -48,8 +49,10 @@ func TestVPAReconcile(t *testing.T) {
 		t.Helper()
 		ctx := context.Background()
 		cl := k8stools.GetTestClientWithActions(o.predefinedObjects)
-		assert.NoError(t, VPA(ctx, cl, o.new, o.prev, nil))
-		assert.Equal(t, o.actions, cl.Actions)
+		synctest.Test(t, func(t *testing.T) {
+			assert.NoError(t, VPA(ctx, cl, o.new, o.prev, nil))
+			assert.Equal(t, o.actions, cl.Actions)
+		})
 	}
 
 	nn := types.NamespacedName{Name: "test-vpa", Namespace: "default"}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -232,8 +232,7 @@ func RunManager(ctx context.Context) error {
 		}
 	}
 
-	reconcile.InitDeadlines(baseConfig.PodWaitReadyIntervalCheck, baseConfig.AppReadyTimeout, baseConfig.PodWaitReadyTimeout, 5*time.Second)
-	reconcile.SetStatusUpdateTTL(*statusUpdateTTL)
+	reconcile.Init(baseConfig.PodWaitReadyIntervalCheck, baseConfig.AppReadyTimeout, baseConfig.PodWaitReadyTimeout, 5*time.Second, *statusUpdateTTL)
 	config := ctrl.GetConfigOrDie()
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(*clientQPS), *clientBurst)
 


### PR DESCRIPTION
moved commit from 0.68.2
https://github.com/VictoriaMetrics/operator/pull/1918/changes/0fe5bf975c888d72195528889777a433fd219c1f

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch reconcile tests to testing/synctest to remove real-time waits and reduce flakes. Consolidate timeout and status update TTL into a single reconcile.Init(...) and update manager; minor docs fixes.

- **Refactors**
  - Wrapped reconciliation tests with synctest.Test and added testing/synctest imports across resource tests.
  - Replaced InitDeadlines and SetStatusUpdateTTL with Init(intervalCheck, appWaitDeadline, podReadyDeadline, statusInterval, statusUpdateTTL).
  - Updated manager to use the new Init and removed SetStatusUpdateTTL; dropped the init() in reconcile_test.go.
  - Docs: fixed VMAgent page wording (VMSingle -> VMAgent) and a changelog punctuation tweak.

- **Migration**
  - Replace:
    - reconcile.InitDeadlines(a, b, c, d)
    - reconcile.SetStatusUpdateTTL(e)
  - With:
    - reconcile.Init(a, b, c, d, e)
  - No behavior changes; tests run faster and are more deterministic.

<sup>Written for commit eed1793bcdca409c6cd8a07a7d704b7f830e04cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

