### PR TITLE
reconcile: updated conditions for STS recreate

### DIFF
--- a/config/crd/overlay/kustomization.yaml
+++ b/config/crd/overlay/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- crd.yaml
+- crd.descriptionless.yaml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ aliases:
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): fix PVC being owned by StatefulSet and top-level object simultaenously. See [#1845](https://github.com/VictoriaMetrics/operator/issues/1845).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): remove unneeded finalizer from core K8s resources. See [#835](https://github.com/VictoriaMetrics/operator/issues/835).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): remove finalizers from VMServiceScrape and VMPodScrape objects, and keep finalizers on VMAgent, VMCluster, and VMAuth when DeletionTimestamp is not empty.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): do not recreate STS if VCT size was increased and recreate in other cases.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): wait for STS deletion in case of recreation without throwing an error.
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -74,9 +74,11 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 	var mustRecreatePod bool
 	var prevMeta *metav1.ObjectMeta
 	var prevTemplateAnnotations map[string]string
+	var prevVCTs []corev1.PersistentVolumeClaim
 	if prevObj != nil {
 		prevMeta = &prevObj.ObjectMeta
 		prevTemplateAnnotations = prevObj.Spec.Template.Annotations
+		prevVCTs = prevObj.Spec.VolumeClaimTemplates
 	}
 
 	rclient.Scheme().Default(newObj)
@@ -114,10 +116,10 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 		}
 
 		var mustRecreateSTS bool
-		mustRecreateSTS, mustRecreatePod = isSTSRecreateRequired(ctx, newObj, &existingObj)
+		mustRecreateSTS, mustRecreatePod = isSTSRecreateRequired(ctx, &existingObj, newObj, prevVCTs)
 		if mustRecreateSTS {
 			recreateSTS = func() error {
-				return removeStatefulSetKeepPods(ctx, rclient, newObj, &existingObj)
+				return removeStatefulSetKeepPods(ctx, rclient, &existingObj, newObj)
 			}
 			return nil
 		}

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -10,8 +10,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,26 +37,27 @@ import (
 // One of possible solutions - save current sts to the object annotation and remove it later if needed.
 // Other solution, to check orphaned objects by selector.
 // Lets leave it as this for now and handle later.
-func isSTSRecreateRequired(ctx context.Context, newSTS, oldStatefulSet *appsv1.StatefulSet) (bool, bool) {
+func isSTSRecreateRequired(ctx context.Context, existingObj, newObj *appsv1.StatefulSet, prevVCTs []corev1.PersistentVolumeClaim) (bool, bool) {
 	l := logger.WithContext(ctx)
-	if newSTS.Spec.ServiceName != oldStatefulSet.Spec.ServiceName {
+	if newObj.Spec.ServiceName != existingObj.Spec.ServiceName {
 		return true, true
 	}
 
 	// if vct got added, removed or changed, recreate the sts
-	if len(newSTS.Spec.VolumeClaimTemplates) != len(oldStatefulSet.Spec.VolumeClaimTemplates) {
+	if len(newObj.Spec.VolumeClaimTemplates) != len(existingObj.Spec.VolumeClaimTemplates) {
 		l.Info("VolumeClaimTemplates count changes, recreating statefulset")
 		return true, true
 	}
 
 	var vctChanged bool
-	for _, newVCT := range newSTS.Spec.VolumeClaimTemplates {
-		existingObj := getPVCFromSTS(newVCT.Name, oldStatefulSet)
-		if existingObj == nil {
+	for _, newVCT := range newObj.Spec.VolumeClaimTemplates {
+		existingVCT := getPVCByName(existingObj.Spec.VolumeClaimTemplates, newVCT.Name)
+		if existingVCT == nil {
 			l.Info(fmt.Sprintf("VolumeClaimTemplate=%s was not found at VolumeClaimTemplates, recreating statefulset", newVCT.Name))
 			return true, true
 		}
-		if shouldRecreateSTSOnStorageChange(ctx, existingObj, &newVCT) {
+		prevVCT := getPVCByName(prevVCTs, newVCT.Name)
+		if immutableVCTFieldsChanged(ctx, existingVCT, &newVCT, prevVCT) {
 			l.Info(fmt.Sprintf("VolumeClaimTemplate=%s have some changes, recreating StatefulSet", newVCT.Name))
 			vctChanged = true
 		}
@@ -65,16 +66,16 @@ func isSTSRecreateRequired(ctx context.Context, newSTS, oldStatefulSet *appsv1.S
 	if vctChanged {
 		return true, false
 	}
-	if shouldRecreateSTSOnImmutableFieldChange(ctx, newSTS, oldStatefulSet) {
+	if immutableSTSFieldsChanged(ctx, existingObj, newObj) {
 		return true, false
 	}
 
 	return false, false
 }
 
-func getPVCFromSTS(pvcName string, sts *appsv1.StatefulSet) *corev1.PersistentVolumeClaim {
-	for _, claim := range sts.Spec.VolumeClaimTemplates {
-		if claim.Name == pvcName {
+func getPVCByName(vcts []corev1.PersistentVolumeClaim, name string) *corev1.PersistentVolumeClaim {
+	for _, claim := range vcts {
+		if claim.Name == name {
 			return &claim
 		}
 	}
@@ -106,10 +107,11 @@ func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.Statef
 	if len(pvcs.Items) == 0 {
 		return fmt.Errorf("got 0 pvcs under %s for selector %v, statefulset could not be working", sts.Namespace, sts.Spec.Selector.MatchLabels)
 	}
+	nsn := types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}
 	for _, pvc := range pvcs.Items {
 		idx := strings.LastIndexByte(pvc.Name, '-')
 		if idx <= 0 {
-			return fmt.Errorf("not expected name for PVC=%q, it must have - as separator for sts=%q", pvc.Name, sts.Name)
+			return fmt.Errorf("not expected name for PVC=%q, it must have - as separator for StatefulSet=%q", pvc.Name, nsn.String())
 		}
 		// pvc created by sts always has name of CLAIM_NAME-STS_NAME-REPLICA_IDX
 		stsClaimName := pvc.Name[:idx]
@@ -129,7 +131,7 @@ func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.Statef
 func modifyPVC(ctx context.Context, rclient client.Client, existingObj, newObj, prevObj *corev1.PersistentVolumeClaim, owner *metav1.OwnerReference) (bool, error) {
 	existingSize := existingObj.Spec.Resources.Requests.Storage()
 	newSize := newObj.Spec.Resources.Requests.Storage()
-	if existingSize == nil || newSize == nil {
+	if existingSize.IsZero() || newSize.IsZero() {
 		return false, nil
 	}
 	var prevMeta *metav1.ObjectMeta
@@ -235,93 +237,101 @@ func isStorageClassExpandable(ctx context.Context, rclient client.Client, pvc *c
 	return false, nil
 }
 
-func shouldRecreateSTSOnStorageChange(ctx context.Context, existingObj, newObj *corev1.PersistentVolumeClaim) bool {
-	// fast path
+func immutableVCTFieldsChanged(ctx context.Context, existingObj, newObj, prevObj *corev1.PersistentVolumeClaim) bool {
 	if existingObj == nil && newObj == nil {
 		return false
 	}
-	// one of pvcs are not nil
-	hasNotNilPVC := (existingObj == nil && newObj != nil) || (existingObj != nil && newObj == nil)
-	if hasNotNilPVC {
+	if existingObj == nil || newObj == nil {
 		return true
+	}
+	newSize := newObj.Spec.Resources.Requests.Storage()
+	existingSize := existingObj.Spec.Resources.Requests.Storage()
+	nsn := types.NamespacedName{Name: existingObj.Name, Namespace: existingObj.Namespace}
+	if newSize.Cmp(*existingSize) < 0 {
+		logger.WithContext(ctx).Info(fmt.Sprintf("must recreate STS, its PVC=%s claim size=%s was decreased to %s", nsn.String(), existingSize.String(), newSize.String()))
+		return true
+	}
+	newSpec := newObj.Spec.DeepCopy()
+	if existingSize != nil {
+		newSpec.Resources.Requests[corev1.ResourceStorage] = *existingSize
 	}
 
-	if i := newObj.Spec.Resources.Requests.Storage().Cmp(*existingObj.Spec.Resources.Requests.Storage()); i != 0 {
-		sizeDiff := resource.NewQuantity(0, resource.BinarySI)
-		sizeDiff.Add(*newObj.Spec.Resources.Requests.Storage())
-		sizeDiff.Sub(*existingObj.Spec.Resources.Requests.Storage())
-		logger.WithContext(ctx).Info(fmt.Sprintf("must re-recreate sts, its pvc claim size=%s was changed", sizeDiff.String()))
-		return true
+	var prevLabels, prevAnnotations map[string]string
+	if prevObj != nil {
+		prevLabels = prevObj.Labels
+		prevAnnotations = prevObj.Annotations
 	}
-
-	// compare meta and spec for pvc
-	specDiff := diffDeepDerivative(newObj.Spec, existingObj.Spec)
-	if len(specDiff) > 0 {
-		logger.WithContext(ctx).Info(fmt.Sprintf("changes detected for PVC=%s, spec_diff=%v", newObj.Name, specDiff))
-		return true
+	newAnnotations := mergeMaps(existingObj.Annotations, newObj.Annotations, prevAnnotations)
+	newLabels := mergeMaps(existingObj.Labels, newObj.Labels, prevLabels)
+	isEqual := equality.Semantic.DeepEqual(existingObj.Labels, newLabels) &&
+		equality.Semantic.DeepEqual(existingObj.Annotations, newAnnotations)
+	specDiff := diffDeepDerivative(newSpec, &existingObj.Spec)
+	isEqual = isEqual && len(specDiff) == 0
+	if isEqual {
+		return false
 	}
-	return false
+	logger.WithContext(ctx).Info(fmt.Sprintf("changes detected for PVC=%s, spec_diff=%v", nsn.String(), specDiff))
+	return true
 }
 
-// shouldRecreateSTSOnImmutableFieldChange checks if immutable statefulSet fields were changed
+// immutableSTSFieldsChanged checks if immutable newObj fields were changed
 //
 // logic was borrowed from
 // https://github.com/kubernetes/kubernetes/blob/a866cbe2e5bbaa01cfd5e969aa3e033f3282a8a2/pkg/apis/apps/validation/validation.go#L166
-func shouldRecreateSTSOnImmutableFieldChange(ctx context.Context, statefulSet, oldStatefulSet *appsv1.StatefulSet) bool {
+func immutableSTSFieldsChanged(ctx context.Context, existingObj, newObj *appsv1.StatefulSet) bool {
 	// statefulset updates aren't super common and general updates are likely to be touching spec, so we'll do this
 	// deep copy right away.  This avoids mutating our inputs
-	newStatefulSetClone := statefulSet.DeepCopy()
+	newObjClone := newObj.DeepCopy()
 
 	// VolumeClaimTemplates must be checked before performing this check
-	newStatefulSetClone.Spec.VolumeClaimTemplates = oldStatefulSet.Spec.VolumeClaimTemplates
+	newObjClone.Spec.VolumeClaimTemplates = existingObj.Spec.VolumeClaimTemplates
 
-	newStatefulSetClone.Spec.Replicas = oldStatefulSet.Spec.Replicas
-	newStatefulSetClone.Spec.Template = oldStatefulSet.Spec.Template
-	newStatefulSetClone.Spec.UpdateStrategy = oldStatefulSet.Spec.UpdateStrategy
-	newStatefulSetClone.Spec.MinReadySeconds = oldStatefulSet.Spec.MinReadySeconds
-	newStatefulSetClone.Spec.PersistentVolumeClaimRetentionPolicy = oldStatefulSet.Spec.PersistentVolumeClaimRetentionPolicy
-	newStatefulSetClone.Spec.RevisionHistoryLimit = oldStatefulSet.Spec.RevisionHistoryLimit
+	newObjClone.Spec.Replicas = existingObj.Spec.Replicas
+	newObjClone.Spec.Template = existingObj.Spec.Template
+	newObjClone.Spec.UpdateStrategy = existingObj.Spec.UpdateStrategy
+	newObjClone.Spec.MinReadySeconds = existingObj.Spec.MinReadySeconds
+	newObjClone.Spec.PersistentVolumeClaimRetentionPolicy = existingObj.Spec.PersistentVolumeClaimRetentionPolicy
+	newObjClone.Spec.RevisionHistoryLimit = existingObj.Spec.RevisionHistoryLimit
 
-	specDiff := diffDeep(newStatefulSetClone.Spec, oldStatefulSet.Spec)
+	specDiff := diffDeep(newObjClone.Spec, existingObj.Spec)
 	if len(specDiff) > 0 {
-		logger.WithContext(ctx).Info(fmt.Sprintf("immutable StatefulSet field changed, spec_diff=%v", specDiff))
+		nsn := types.NamespacedName{Name: existingObj.Name, Namespace: existingObj.Namespace}
+		logger.WithContext(ctx).Info(fmt.Sprintf("immutable StatefulSet=%s field changed, spec_diff=%v", nsn.String(), specDiff))
 		return true
 	}
 	return false
 }
 
-func removeStatefulSetKeepPods(ctx context.Context, rclient client.Client, statefulSet, oldStatefulSet *appsv1.StatefulSet) error {
+func removeStatefulSetKeepPods(ctx context.Context, rclient client.Client, existingObj, newObj *appsv1.StatefulSet) error {
 	// removes finalizer from exist sts, it allows to delete it
-	nsn := types.NamespacedName{Name: oldStatefulSet.Name, Namespace: oldStatefulSet.Namespace}
-	if err := finalize.RemoveFinalizer(ctx, rclient, oldStatefulSet); err != nil {
+	nsn := types.NamespacedName{Name: existingObj.Name, Namespace: existingObj.Namespace}
+	if err := finalize.RemoveFinalizer(ctx, rclient, existingObj); err != nil {
 		return fmt.Errorf("failed to remove finalizer from StatefulSet=%s: %w", nsn.String(), err)
 	}
-	opts := client.DeleteOptions{PropagationPolicy: func() *metav1.DeletionPropagation {
-		p := metav1.DeletePropagationOrphan
-		return &p
-	}()}
-	if err := rclient.Delete(ctx, oldStatefulSet, &opts); err != nil {
+	opts := client.DeleteOptions{
+		PropagationPolicy: ptr.To(metav1.DeletePropagationOrphan),
+	}
+	if err := rclient.Delete(ctx, existingObj, &opts); err != nil {
 		return err
 	}
 
 	// wait until sts disappears
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(_ context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Second*30, true, func(ctx context.Context) (done bool, err error) {
 		if err := rclient.Get(ctx, nsn, &appsv1.StatefulSet{}); err != nil {
 			if k8serrors.IsNotFound(err) {
 				return true, nil
 			}
 			return false, fmt.Errorf("unexpected error for polling, want notFound, got: %w", err)
 		}
-		err = fmt.Errorf("sts wasn't yet removed")
-		return
+		return false, nil
 	}); err != nil {
-		return fmt.Errorf("cannot wait for sts to be deleted: %w", err)
+		return fmt.Errorf("cannot wait for StatefulSet=%s to be deleted: %w", nsn.String(), err)
 	}
 
-	if err := rclient.Create(ctx, statefulSet); err != nil {
+	if err := rclient.Create(ctx, newObj); err != nil {
 		// try to restore previous one and throw error
-		oldStatefulSet.ResourceVersion = ""
-		if err2 := rclient.Create(ctx, oldStatefulSet); err2 != nil {
+		existingObj.ResourceVersion = ""
+		if err2 := rclient.Create(ctx, existingObj); err2 != nil {
 			return fmt.Errorf("cannot restore previous StatefulSet=%s configuration after remove original error: %s: restore error %w", nsn.String(), err, err2)
 		}
 		return fmt.Errorf("cannot create new StatefulSet=%s instead of replaced, perform manual action to handle this error or report BUG: %w", nsn.String(), err)

--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
@@ -19,25 +19,29 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
 
-func Test_reCreateSTS(t *testing.T) {
+func Test_recreateOrUpdateSTS(t *testing.T) {
 	type opts struct {
-		newSTS          *appsv1.StatefulSet
-		oldSTS          *appsv1.StatefulSet
+		newObj          *appsv1.StatefulSet
+		existingObj     *appsv1.StatefulSet
 		validate        func(sts *appsv1.StatefulSet)
 		mustRecreateSTS bool
 		mustRecreatePod bool
 	}
 	f := func(o opts) {
 		t.Helper()
-		cl := k8stools.GetTestClientWithObjects([]runtime.Object{o.oldSTS})
+		cl := k8stools.GetTestClientWithObjects([]runtime.Object{o.existingObj})
 		t.Helper()
 		ctx := context.TODO()
-		mustRecreateSTS, mustRecreatePod := isSTSRecreateRequired(ctx, o.newSTS, o.oldSTS)
+		mustRecreateSTS, mustRecreatePod := isSTSRecreateRequired(ctx, o.existingObj, o.newObj, nil)
 		if mustRecreateSTS {
-			assert.NoError(t, removeStatefulSetKeepPods(ctx, cl, o.newSTS, o.oldSTS))
+			assert.NoError(t, removeStatefulSetKeepPods(ctx, cl, o.existingObj, o.newObj))
+		} else {
+			newObj := o.existingObj.DeepCopy()
+			newObj.Spec = o.newObj.Spec
+			assert.NoError(t, cl.Update(ctx, newObj))
 		}
 		var updatedSTS appsv1.StatefulSet
-		nsn := types.NamespacedName{Namespace: o.newSTS.Namespace, Name: o.newSTS.Name}
+		nsn := types.NamespacedName{Namespace: o.newObj.Namespace, Name: o.newObj.Name}
 		assert.NoError(t, cl.Get(ctx, nsn, &updatedSTS))
 		o.validate(&updatedSTS)
 		assert.Equal(t, mustRecreateSTS, o.mustRecreateSTS)
@@ -46,13 +50,13 @@ func Test_reCreateSTS(t *testing.T) {
 
 	// add claim to sts
 	f(opts{
-		oldSTS: &appsv1.StatefulSet{
+		existingObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
 				Namespace: "default",
 			},
 		},
-		newSTS: &appsv1.StatefulSet{
+		newObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
 				Namespace: "default",
@@ -75,7 +79,7 @@ func Test_reCreateSTS(t *testing.T) {
 
 	// resize claim at sts
 	f(opts{
-		oldSTS: &appsv1.StatefulSet{
+		existingObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
 				Namespace: "default",
@@ -93,7 +97,7 @@ func Test_reCreateSTS(t *testing.T) {
 				},
 			}},
 		},
-		newSTS: &appsv1.StatefulSet{
+		newObj: &appsv1.StatefulSet{
 
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
@@ -117,13 +121,61 @@ func Test_reCreateSTS(t *testing.T) {
 			sz := sts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().String()
 			assert.Equal(t, sz, "15Gi")
 		},
+		mustRecreateSTS: false,
+		mustRecreatePod: false,
+	})
+
+	// downsize claim
+	f(opts{
+		existingObj: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vmselect",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-claim"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("15Gi"),
+							},
+						},
+					},
+				},
+			}},
+		},
+		newObj: &appsv1.StatefulSet{
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vmselect",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-claim"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			}},
+		},
+		validate: func(sts *appsv1.StatefulSet) {
+			assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)
+			sz := sts.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().String()
+			assert.Equal(t, sz, "10Gi")
+		},
 		mustRecreateSTS: true,
 		mustRecreatePod: false,
 	})
 
-	// change claim storageClass name
+	// change claim labels
 	f(opts{
-		oldSTS: &appsv1.StatefulSet{
+		existingObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
 				Namespace: "default",
@@ -142,7 +194,61 @@ func Test_reCreateSTS(t *testing.T) {
 				},
 			}},
 		},
-		newSTS: &appsv1.StatefulSet{
+		newObj: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vmselect",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "new-claim",
+						Labels: map[string]string{
+							"test": "test",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+						StorageClassName: ptr.To("old-sc"),
+					},
+				},
+			}},
+		},
+		validate: func(sts *appsv1.StatefulSet) {
+			assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)
+			labels := sts.Spec.VolumeClaimTemplates[0].Labels
+			assert.Equal(t, labels["test"], "test")
+		},
+		mustRecreateSTS: true,
+		mustRecreatePod: false,
+	})
+
+	// change claim storageClass name
+	f(opts{
+		existingObj: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vmselect",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-claim"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+						StorageClassName: ptr.To("old-sc"),
+					},
+				},
+			}},
+		},
+		newObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmselect",
 				Namespace: "default",
@@ -172,7 +278,7 @@ func Test_reCreateSTS(t *testing.T) {
 
 	// change serviceName
 	f(opts{
-		oldSTS: &appsv1.StatefulSet{
+		existingObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmagent",
 				Namespace: "default",
@@ -181,7 +287,7 @@ func Test_reCreateSTS(t *testing.T) {
 				ServiceName: "old-service",
 			},
 		},
-		newSTS: &appsv1.StatefulSet{
+		newObj: &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vmagent",
 				Namespace: "default",

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
@@ -3,6 +3,7 @@ package vmdistributed
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,27 +57,29 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 			Build()
 
 		ctx := context.TODO()
-		err := CreateOrUpdate(ctx, args.cr, fclient)
-		if want.err != nil {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-
-		if !assert.Equal(t, len(want.actions), len(actions)) {
-			for i, action := range actions {
-				t.Logf("Action %d: %s %s %s", i, action.Verb, action.Kind, action.Resource)
+		synctest.Test(t, func(t *testing.T) {
+			err := CreateOrUpdate(ctx, args.cr, fclient)
+			if want.err != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-		}
 
-		for i, action := range want.actions {
-			if i >= len(actions) {
-				break
+			if !assert.Equal(t, len(want.actions), len(actions)) {
+				for i, action := range actions {
+					t.Logf("Action %d: %s %s %s", i, action.Verb, action.Kind, action.Resource)
+				}
 			}
-			assert.Equal(t, action.Verb, actions[i].Verb, "idx %d verb", i)
-			assert.Equal(t, action.Kind, actions[i].Kind, "idx %d kind", i)
-			assert.Equal(t, action.Resource, actions[i].Resource, "idx %d resource", i)
-		}
+
+			for i, action := range want.actions {
+				if i >= len(actions) {
+					break
+				}
+				assert.Equal(t, action.Verb, actions[i].Verb, "idx %d verb", i)
+				assert.Equal(t, action.Kind, actions[i].Kind, "idx %d kind", i)
+				assert.Equal(t, action.Resource, actions[i].Resource, "idx %d resource", i)
+			}
+		})
 	}
 
 	name := "test-dist"


### PR DESCRIPTION
* do not recreate STS if VCT size was increased decreased and recreate in other cases
* use 3-way merge for labels and annotations for VCT metadata
* do not throw error on STS recreation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined StatefulSet recreation: we recreate when VCT spec/metadata or other immutable fields change; we expand PVCs in place on size increase, while downsizing still recreates. Recreation waits for deletion with orphaned pods and returns clearer, namespaced errors.

- **Bug Fixes**
  - Recreate STS on VCT changes and immutable spec changes; ServiceName changes also recreate pods. Expand in place on PVC size increase; downsizing recreates. Uses 3-way merge for VCT labels/annotations to avoid unnecessary recreations.
  - Wait for StatefulSet deletion during recreation without throwing an error; error messages include the namespaced StatefulSet and PVC context.
  - Stabilized reconcile tests with testing/synctest; updated changelog.

<sup>Written for commit 10d47376b2305fa7c930919e17708261ef62f766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



