### PR TITLE
undo IsZero check for PVC storage size

### DIFF
--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand.go
@@ -131,7 +131,7 @@ func updateSTSPVC(ctx context.Context, rclient client.Client, sts *appsv1.Statef
 func modifyPVC(ctx context.Context, rclient client.Client, existingObj, newObj, prevObj *corev1.PersistentVolumeClaim, owner *metav1.OwnerReference) (bool, error) {
 	existingSize := existingObj.Spec.Resources.Requests.Storage()
 	newSize := newObj.Spec.Resources.Requests.Storage()
-	if existingSize.IsZero() || newSize.IsZero() {
+	if existingSize == nil || newSize == nil {
 		return false, nil
 	}
 	var prevMeta *metav1.ObjectMeta


### PR DESCRIPTION
expected isZero covers nil, but it doesn't, reverting this change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PVC storage size check from IsZero() to a nil check. Prevents a nil dereference and safely skips PVC updates when storage requests are missing.

<sup>Written for commit e3b21a57537275f9f057ca9c304a4c231239020d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

