### PR TITLE
finalize: fixed resources lists for some CRs

### DIFF
--- a/internal/controller/operator/factory/finalize/vlagent.go
+++ b/internal/controller/operator/factory/finalize/vlagent.go
@@ -41,7 +41,6 @@ func OnVLAgentDelete(ctx context.Context, rclient client.Client, cr *vmv1.VLAgen
 		}},
 		&appsv1.DaemonSet{ObjectMeta: objMeta},
 		&appsv1.StatefulSet{ObjectMeta: objMeta},
-		&corev1.PersistentVolumeClaim{ObjectMeta: objMeta},
 		&policyv1.PodDisruptionBudget{ObjectMeta: objMeta},
 	}
 	if cr.Spec.ServiceSpec != nil {

--- a/internal/controller/operator/factory/finalize/vlogs.go
+++ b/internal/controller/operator/factory/finalize/vlogs.go
@@ -25,7 +25,6 @@ func OnVLogsDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.VLo
 			Name:      cr.GetServiceAccountName(),
 			Namespace: ns,
 		}},
-		&corev1.PersistentVolumeClaim{ObjectMeta: objMeta},
 	}
 	if cr.Spec.ServiceSpec != nil {
 		objsToRemove = append(objsToRemove, &corev1.Service{ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/operator/factory/finalize/vmagent.go
+++ b/internal/controller/operator/factory/finalize/vmagent.go
@@ -56,11 +56,11 @@ func OnVMAgentDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.V
 			Name:      build.ResourceName(build.TLSAssetsResourceKind, cr),
 			Namespace: ns,
 		}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Name:      build.ResourceName(build.RelabelConfigResourceKind, cr),
 			Namespace: ns,
 		}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Name:      build.ResourceName(build.StreamAggrConfigResourceKind, cr),
 			Namespace: ns,
 		}},

--- a/internal/controller/operator/factory/finalize/vmsingle.go
+++ b/internal/controller/operator/factory/finalize/vmsingle.go
@@ -45,11 +45,11 @@ func OnVMSingleDelete(ctx context.Context, rclient client.Client, cr *vmv1beta1.
 			Name:      build.ResourceName(build.TLSAssetsResourceKind, cr),
 			Namespace: ns,
 		}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Name:      build.ResourceName(build.RelabelConfigResourceKind, cr),
 			Namespace: ns,
 		}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Name:      build.ResourceName(build.StreamAggrConfigResourceKind, cr),
 			Namespace: ns,
 		}},


### PR DESCRIPTION
VLAgent has no PVC, VMAgent/VMSingle use configMaps for relabel and stream aggregation configs, VLogs two identical PVC items in a list

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix finalizer cleanup for VLAgent, VLogs, VMAgent, and VMSingle to target the correct resources and avoid deleting PVCs. This prevents data loss and ensures the right configs are removed.

- **Bug Fixes**
  - Stop deleting PersistentVolumeClaims for VLAgent and VLogs during finalization.
  - For VMAgent and VMSingle, remove relabel and stream-aggregator ConfigMaps (not Secrets).

<sup>Written for commit 9ddf22605dd363df8bed29ca05601e8e623600eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

