### PR TITLE
ci: removed hardcoded master branch from CRD release job

### DIFF
--- a/.github/workflows/crds.yaml
+++ b/.github/workflows/crds.yaml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: VictoriaMetrics/operator
-          ref: master
           token: ${{ secrets.VM_BOT_GH_TOKEN }}
           path: __vm-operator-repo
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!*.md'
+      - '!.github/**'
       - '.github/workflows/docs.yaml'
-      - 'codespell/**'
+      - '!codespell/**'
+      - 'LICENSE'
+      - 'PROJECT'
   pull_request:
     branches:
       - master
@@ -19,11 +23,15 @@ on:
       - synchronize
       - ready_for_review
       - converted_to_draft
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!*.md'
+      - '!.github/**'
       - '.github/workflows/docs.yaml'
-      - 'codespell/**'
+      - '!codespell/**'
+      - 'LICENSE'
+      - 'PROJECT'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the hardcoded "master" from the CRD release job; the operator repo is checked out at its default branch.
CI triggers now use explicit paths: they run on code changes and updates to LICENSE or PROJECT, and ignore docs, Markdown, .github (except .github/workflows/docs.yaml), and codespell.

<sup>Written for commit 4e809718b9f696e40028b46e04341588b2958f16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

