### PR TITLE
vmdistributed: ignore vmauth management if its controller is disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ aliases:
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/) and [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): previously, ingest-only mode could still mount scrape configuration secrets when relabeling or stream aggregation was configured, which caused unexpected secret mounts and RBAC-related failures; now these secrets are not mounted in ingest-only mode, so deployments start with the expected minimal permissions and avoid related runtime errors. See [#1828](https://github.com/VictoriaMetrics/operator/issues/1828).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): do not recreate STS if VCT size was increased and recreate in other cases.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): wait for STS deletion in case of recreation without throwing an error.
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): ignore VMAuth update/delete operations if controller is disabled.
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/finalize/vmdistributed.go
+++ b/internal/controller/operator/factory/finalize/vmdistributed.go
@@ -13,6 +13,7 @@ import (
 
 	vmv1alpha1 "github.com/VictoriaMetrics/operator/api/operator/v1alpha1"
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 )
 
 // OnVMDistributedDelete disowns referenced and removes created by VMDistributed components
@@ -34,12 +35,14 @@ func OnVMDistributedDelete(ctx context.Context, rclient client.Client, cr *vmv1a
 				},
 			})
 		}
-		objsToDisown = append(objsToDisown, &vmv1beta1.VMAuth{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.VMAuthName(),
-				Namespace: cr.Namespace,
-			},
-		})
+		if !build.IsControllerDisabled("VMAuth") {
+			objsToDisown = append(objsToDisown, &vmv1beta1.VMAuth{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cr.VMAuthName(),
+					Namespace: cr.Namespace,
+				},
+			})
+		}
 	}
 
 	owner := cr.AsOwner()

--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -9,6 +9,7 @@ import (
 
 	vmv1alpha1 "github.com/VictoriaMetrics/operator/api/operator/v1alpha1"
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 )
 
 func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) vmv1beta1.TargetRef {
@@ -64,7 +65,7 @@ func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, excludeIds ...int) vmv1beta
 }
 
 func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) *vmv1beta1.VMAuth {
-	if !ptr.Deref(cr.Spec.VMAuth.Enabled, true) {
+	if !ptr.Deref(cr.Spec.VMAuth.Enabled, true) || build.IsControllerDisabled("VMAuth") {
 		return nil
 	}
 	vmAuth := vmv1beta1.VMAuth{

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -110,5 +110,5 @@ func (r *VMDistributedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // IsDisabled returns true if controller should be disabled
 func (*VMDistributedReconciler) IsDisabled(_ *config.BaseOperatorConf, disabledControllers sets.Set[string]) bool {
-	return disabledControllers.HasAny("VMAgent", "VMAuth", "VMCluster")
+	return disabledControllers.HasAny("VMAgent", "VMCluster")
 }


### PR DESCRIPTION
allow using vmdistributed resource with disable vmauth controller

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow VMDistributed to keep reconciling when the VMAuth controller is disabled. Prevents accidental VMAuth changes while the controller is off.

- **Bug Fixes**
  - Skip VMAuth creation and cleanup when the VMAuth controller is disabled.
  - VMDistributed reconciler no longer disables itself when only VMAuth is disabled (still disables for VMAgent or VMCluster).
  - Updated changelog with the fix.

<sup>Written for commit 3df5a571b991941bc4010398c83a6842280ef72d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

