### PR TITLE
ci: do not trigger release on update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,7 @@ name: Release
 on:
   release:
     types:
-      - created
-      - prereleased
+      - released
 jobs:
   release:
     name: Release on GitHub


### PR DESCRIPTION
currently CI is triggered each time release is updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GitHub Actions release workflow to trigger only on the 'released' event. This prevents duplicate or noisy runs on release creation or prerelease updates.

<sup>Written for commit 5f6db23185f6d34bf279f7aafc87e4abe81fef12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

