### PR TITLE
reconcile: do not ignore StatefulSet pod recreation

### DIFF
--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -73,7 +73,7 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 	if err := validateStatefulSet(newObj); err != nil {
 		return err
 	}
-	var mustRecreatePod bool
+	var recreatePod bool
 	var prevMeta *metav1.ObjectMeta
 	var prevTemplateAnnotations map[string]string
 	var prevVCTs []corev1.PersistentVolumeClaim
@@ -116,9 +116,9 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 			spec.Replicas = existingObj.Spec.Replicas
 		}
 
-		var mustRecreateSTS bool
-		mustRecreateSTS, mustRecreatePod = isSTSRecreateRequired(ctx, &existingObj, newObj, prevVCTs)
+		mustRecreateSTS, mustRecreatePod := isSTSRecreateRequired(ctx, &existingObj, newObj, prevVCTs)
 		if mustRecreateSTS {
+			recreatePod = mustRecreatePod
 			if err := finalize.RemoveFinalizer(ctx, rclient, &existingObj); err != nil {
 				return fmt.Errorf("failed to remove finalizer from StatefulSet=%s: %w", nsn.String(), err)
 			}
@@ -164,7 +164,7 @@ func StatefulSet(ctx context.Context, rclient client.Client, cr STSOptions, newO
 	switch updateStrategy {
 	case appsv1.OnDeleteStatefulSetStrategyType:
 		opts := rollingUpdateOpts{
-			recreate:       mustRecreatePod,
+			recreate:       recreatePod,
 			selector:       cr.SelectorLabels(),
 			maxUnavailable: 1,
 		}

--- a/internal/controller/operator/factory/vlagent/vlagent.go
+++ b/internal/controller/operator/factory/vlagent/vlagent.go
@@ -543,7 +543,8 @@ func buildRemoteWriteArgs(cr *vmv1.VLAgent) ([]string, error) {
 	var storageLimit int64
 
 	if cr.Spec.Storage != nil {
-		if storage, ok := cr.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+		storage := cr.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests.Storage()
+		if !storage.IsZero() {
 			storageInt, ok := storage.AsInt64()
 			if ok {
 				storageLimit = storageInt


### PR DESCRIPTION
during statefulset reconcile if isSTSRecreateRequired returns true for a first value it triggers statefulset deletion and restarts reconcile, but it then executes isSTSRecreateRequired once again and overwrites global mustRecreatePod variable ignoring pod recreation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes StatefulSet reconcile so required pod recreation isn’t lost after triggering a StatefulSet delete, ensuring pods are recreated when needed. Also hardens storage limit parsing for `VLAgent` remote write.

- **Bug Fixes**
  - Preserve pod recreation flag from `isSTSRecreateRequired` across StatefulSet deletion and reuse it in OnDelete rolling updates.
  - Use `Requests.Storage()` with `IsZero()` in `vlagent` to correctly detect storage limits when the request is unset or zero.

<sup>Written for commit 6e6b6946cd4413bfd27d5245bb4a2406fcbeddf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

