### PR TITLE
add -enterprise suffix for explicitly defined tag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): recreate STS if immutable fields changed.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): wait for STS deletion in case of recreation without throwing an error.
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): ignore VMAuth update/delete operations if controller is disabled.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): add `-enterprise` suffix if license is provided, before it was added only while using default image tag. See [#1949](https://github.com/VictoriaMetrics/operator/issues/1949).
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -449,11 +449,11 @@ func addDefaultsToCommonParams(common *vmv1beta1.CommonAppsParams, cp *commonPar
 		} else {
 			common.Image.Tag = appDefaults.Version
 		}
-		if cp != nil && cp.license.IsProvided() {
-			common.Image.Tag = addEntSuffixToTag(common.Image.Tag)
-		}
 	}
 	if cp != nil {
+		if cp.license.IsProvided() {
+			common.Image.Tag = addEntSuffixToTag(common.Image.Tag)
+		}
 		common.ImagePullSecrets = append(common.ImagePullSecrets, cp.imagePullSecrets...)
 		if cp.useStrictSecurity != nil {
 			useStrictSecurity = *cp.useStrictSecurity

--- a/internal/controller/operator/factory/build/defaults_test.go
+++ b/internal/controller/operator/factory/build/defaults_test.go
@@ -47,7 +47,7 @@ func TestAddEnterpriseTagToAppCommonDefaults(t *testing.T) {
 				Key: ptr.To("license-key-value"),
 			},
 		},
-		wantVersion: "v1.120.0",
+		wantVersion: "v1.120.0-enterprise",
 	})
 	f(opts{
 		specVersion: "v1.120.0",
@@ -56,7 +56,7 @@ func TestAddEnterpriseTagToAppCommonDefaults(t *testing.T) {
 				Key: ptr.To("license-key-value"),
 			},
 		},
-		wantVersion: "v1.120.0",
+		wantVersion: "v1.120.0-enterprise",
 	})
 	f(opts{
 		specVersion: "v1.120.0-enterprise",


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1949

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the `-enterprise` suffix is added to the image tag whenever a license is provided, even when the tag is explicitly set. This fixes cases where custom tags unintentionally pulled non-enterprise images.

<sup>Written for commit 2d6e870745a8bda8bc03d42ba78291726088844b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

