### PR TITLE
controllers: use single error handling for all CRs

### DIFF
--- a/api/operator/v1/vlagent_types.go
+++ b/api/operator/v1/vlagent_types.go
@@ -279,8 +279,8 @@ type VLAgentStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VLAgentStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VLAgent) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // +genclient

--- a/api/operator/v1/vlcluster_types.go
+++ b/api/operator/v1/vlcluster_types.go
@@ -213,8 +213,8 @@ type VLClusterStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VLClusterStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VLCluster) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VLInsert defines vlinsert component configuration at victoria-logs cluster

--- a/api/operator/v1/vlsingle_types.go
+++ b/api/operator/v1/vlsingle_types.go
@@ -119,8 +119,8 @@ type VLSingleStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VLSingleStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VLSingle) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VLSingle is fast, cost-effective and scalable logs database.

--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -189,8 +189,8 @@ type VMAnomalyStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMAnomalyStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMAnomaly) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VMAnomaly is the Schema for the vmanomalies API.

--- a/api/operator/v1/vtcluster_types.go
+++ b/api/operator/v1/vtcluster_types.go
@@ -208,8 +208,8 @@ type VTClusterStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VTClusterStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VTCluster) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VTInsert defines vtinsert component configuration at victoria-traces cluster

--- a/api/operator/v1/vtsingle_types.go
+++ b/api/operator/v1/vtsingle_types.go
@@ -113,8 +113,8 @@ type VTSingleStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VTSingleStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VTSingle) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VTSingle is fast, cost-effective and scalable traces database.

--- a/api/operator/v1alpha1/vmdistributed_types.go
+++ b/api/operator/v1alpha1/vmdistributed_types.go
@@ -397,8 +397,8 @@ func (cr *VMDistributed) DefaultStatusFields(vs *VMDistributedStatus) {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMDistributedStatus) GetStatusMetadata() *vmv1beta1.StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMDistributed) GetStatusMetadata() *vmv1beta1.StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated

--- a/api/operator/v1beta1/vlogs_types.go
+++ b/api/operator/v1beta1/vlogs_types.go
@@ -105,8 +105,8 @@ type VLogsStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VLogsStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VLogs) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VLogs is fast, cost-effective and scalable logs database.

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -396,8 +396,8 @@ type VMAgentStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMAgentStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMAgent) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // +genclient

--- a/api/operator/v1beta1/vmalert_types.go
+++ b/api/operator/v1beta1/vmalert_types.go
@@ -269,8 +269,8 @@ type VMAlertStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMAlertStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMAlert) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VMAlert  executes a list of given alerting or recording rules against configured address.

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -273,8 +273,8 @@ type VMAlertmanagerStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMAlertmanagerStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMAlertmanager) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface

--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -109,6 +109,14 @@ func (r *VMAlertmanagerConfig) GetStatusMetadata() *StatusMetadata {
 	return &r.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMAlertmanagerConfig) GetStatus() *VMAlertmanagerConfigStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMAlertmanagerConfig) DefaultStatusFields(vs *VMAlertmanagerConfigStatus) {}
+
 func (r *VMAlertmanagerConfig) Validate() error {
 	if MustSkipCRValidation(r) {
 		return nil

--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -548,8 +548,8 @@ type VMAuthStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMAuthStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMAuth) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VMAuth is the Schema for the vmauths API

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -240,8 +240,8 @@ type VMClusterStatus struct {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMClusterStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMCluster) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // VMClusterList contains a list of VMCluster

--- a/api/operator/v1beta1/vmnodescrape_types.go
+++ b/api/operator/v1beta1/vmnodescrape_types.go
@@ -87,6 +87,14 @@ func (cr *VMNodeScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMNodeScrape) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMNodeScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 // AsKey returns unique key for object
 func (cr *VMNodeScrape) AsKey(_ bool) string {
 	return cr.Namespace + "/" + cr.Name

--- a/api/operator/v1beta1/vmpodscrape_types.go
+++ b/api/operator/v1beta1/vmpodscrape_types.go
@@ -152,6 +152,14 @@ func (cr *VMPodScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMPodScrape) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMPodScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 func init() {
 	SchemeBuilder.Register(&VMPodScrape{}, &VMPodScrapeList{})
 }

--- a/api/operator/v1beta1/vmprobe_types.go
+++ b/api/operator/v1beta1/vmprobe_types.go
@@ -167,6 +167,14 @@ func (cr *VMProbe) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMProbe) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMProbe) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 // AsKey returns unique key for object
 func (cr *VMProbe) AsKey(_ bool) string {
 	return cr.Namespace + "/" + cr.Name

--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -25,6 +26,8 @@ var initVMAlertTemplatesOnce sync.Once
 type VMRuleSpec struct {
 	// Groups list of group rules
 	Groups []RuleGroup `json:"groups"`
+	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingError string `json:"-" yaml:"-"`
 }
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.
@@ -138,6 +141,14 @@ func (cr *VMRule) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMRule) GetStatus() *VMRuleStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMRule) DefaultStatusFields(vs *VMRuleStatus) {}
+
 // AsKey returns unique key for object
 func (cr *VMRule) AsKey(_ bool) string {
 	return fmt.Sprintf("%s-%s.yaml", cr.Namespace, cr.Name)
@@ -228,6 +239,16 @@ type VMRule struct {
 	Spec VMRuleSpec `json:"spec"`
 	// +optional
 	Status VMRuleStatus `json:"status,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (r *VMRule) UnmarshalJSON(src []byte) error {
+	type rcfg VMRule
+	if err := json.Unmarshal(src, (*rcfg)(r)); err != nil {
+		r.Spec.ParsingError = fmt.Sprintf("cannot parse vmrule config: %s, err: %s", string(src), err)
+		return nil
+	}
+	return nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/operator/v1beta1/vmscrapeconfig_types.go
+++ b/api/operator/v1beta1/vmscrapeconfig_types.go
@@ -591,6 +591,14 @@ func (cr *VMScrapeConfig) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMScrapeConfig) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMScrapeConfig) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 func init() {
 	SchemeBuilder.Register(&VMScrapeConfig{}, &VMScrapeConfigList{})
 }

--- a/api/operator/v1beta1/vmservicescrape_types.go
+++ b/api/operator/v1beta1/vmservicescrape_types.go
@@ -174,6 +174,14 @@ func (cr *VMServiceScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMServiceScrape) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMServiceScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 func init() {
 	SchemeBuilder.Register(&VMServiceScrape{}, &VMServiceScrapeList{})
 }

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -401,8 +401,8 @@ func (cr *VMSingle) Validate() error {
 }
 
 // GetStatusMetadata returns metadata for object status
-func (cr *VMSingleStatus) GetStatusMetadata() *StatusMetadata {
-	return &cr.StatusMetadata
+func (cr *VMSingle) GetStatusMetadata() *StatusMetadata {
+	return &cr.Status.StatusMetadata
 }
 
 // GetAdditionalService returns AdditionalServiceSpec settings

--- a/api/operator/v1beta1/vmstaticscrape_types.go
+++ b/api/operator/v1beta1/vmstaticscrape_types.go
@@ -93,6 +93,14 @@ func (cr *VMStaticScrape) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
 
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMStaticScrape) GetStatus() *ScrapeObjectStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMStaticScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
 // AsKey returns unique key for object
 func (cr *VMStaticScrape) AsKey(_ bool) string {
 	return cr.Namespace + "/" + cr.Name

--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,8 @@ import (
 
 // VMUserSpec defines the desired state of VMUser
 type VMUserSpec struct {
+	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingError string `json:"-" yaml:"-"`
 	// Name of the VMUser object.
 	// +optional
 	Name *string `json:"name,omitempty"`
@@ -278,6 +281,16 @@ func (cr *VMUser) SelectorLabels() map[string]string {
 	}
 }
 
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMUserSpec) UnmarshalJSON(src []byte) error {
+	type pcr VMUserSpec
+	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
+		cr.ParsingError = fmt.Sprintf("cannot parse vmuserspec: %s, err: %s", string(src), err)
+		return nil
+	}
+	return nil
+}
+
 // FinalLabels returns combination of selector and managed labels
 func (cr *VMUser) FinalLabels() map[string]string {
 	v := cr.SelectorLabels()
@@ -291,6 +304,14 @@ func (cr *VMUser) FinalLabels() map[string]string {
 func (cr *VMUser) GetStatusMetadata() *StatusMetadata {
 	return &cr.Status.StatusMetadata
 }
+
+// GetStatus implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMUser) GetStatus() *VMUserStatus {
+	return &cr.Status
+}
+
+// DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
+func (cr *VMUser) DefaultStatusFields(vs *VMUserStatus) {}
 
 func (cr *VMUser) AsKey(hide bool) string {
 	var id string

--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -146,7 +146,6 @@ func handleReconcileErr[T client.Object, ST reconcile.StatusWithMetadata[STC], S
 		deregisterObjectByCollector(ge.requestObject.Name, ge.requestObject.Namespace, ge.controller)
 		getObjectsErrorsTotal.WithLabelValues(ge.controller, ge.requestObject.String()).Inc()
 		if k8serrors.IsNotFound(err) {
-			err = nil
 			return originResult, nil
 		}
 	case k8serrors.IsConflict(err):
@@ -184,72 +183,6 @@ func handleReconcileErr[T client.Object, ST reconcile.StatusWithMetadata[STC], S
 			logger.WithContext(ctx).Error(err, "failed to create error event at kubernetes API during reconciliation error")
 		}
 	}
-
-	return originResult, err
-}
-
-func handleReconcileErrWithoutStatus(
-	ctx context.Context,
-	rclient client.Client,
-	object client.Object,
-	originResult ctrl.Result,
-	err error,
-) (ctrl.Result, error) {
-	if err == nil {
-		return originResult, nil
-	}
-	var ge *getError
-	var pe *parsingError
-	switch {
-	case errors.Is(err, context.Canceled):
-		contextCancelErrorsTotal.Inc()
-		if !errors.Is(context.Cause(ctx), ErrShutdown) {
-			originResult.RequeueAfter = time.Second * 5
-		}
-		return originResult, nil
-	case errors.As(err, &pe):
-		parseObjectErrorsTotal.WithLabelValues(pe.controller, "unknown").Inc()
-	case errors.As(err, &ge):
-		deregisterObjectByCollector(ge.requestObject.Name, ge.requestObject.Namespace, ge.controller)
-		getObjectsErrorsTotal.WithLabelValues(ge.controller, ge.requestObject.String()).Inc()
-		if k8serrors.IsNotFound(err) {
-			err = nil
-			return originResult, nil
-		}
-	case k8serrors.IsConflict(err):
-		controller := "unknown"
-		if object != nil && !reflect.ValueOf(object).IsNil() && object.GetNamespace() != "" {
-			controller = object.GetObjectKind().GroupVersionKind().GroupKind().Kind
-		}
-		conflictErrorsTotal.WithLabelValues(controller, "unknown").Inc()
-		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
-	}
-	if object != nil && !reflect.ValueOf(object).IsNil() && object.GetNamespace() != "" {
-		errEvent := &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "victoria-metrics-operator-" + uuid.New().String(),
-				Namespace: object.GetNamespace(),
-			},
-			Type:    corev1.EventTypeWarning,
-			Reason:  "ReconciliationError",
-			Message: err.Error(),
-			Source: corev1.EventSource{
-				Component: "victoria-metrics-operator",
-			},
-			LastTimestamp: metav1.NewTime(time.Now()),
-			InvolvedObject: corev1.ObjectReference{
-				Kind:            object.GetObjectKind().GroupVersionKind().Kind,
-				Namespace:       object.GetNamespace(),
-				Name:            object.GetName(),
-				UID:             object.GetUID(),
-				ResourceVersion: object.GetResourceVersion(),
-			},
-		}
-		if err := rclient.Create(ctx, errEvent); err != nil {
-			logger.WithContext(ctx).Error(err, "failed to create error event at kubernetes API during reconciliation error")
-		}
-	}
-
 	return originResult, err
 }
 

--- a/internal/controller/operator/controllers_test.go
+++ b/internal/controller/operator/controllers_test.go
@@ -319,23 +319,27 @@ func TestIsSelectorsMatchesTargetCRD(t *testing.T) {
 	})
 }
 
-func TestHandleReconcileErrWithoutStatus(t *testing.T) {
+func TestHandleReconcileErr(t *testing.T) {
 	type opts struct {
+		ctx        context.Context
 		err        error
 		origin     ctrl.Result
 		wantResult ctrl.Result
 		wantErr    error
 	}
 
-	f := func(ctx context.Context, o opts) {
+	f := func(o opts) {
 		t.Helper()
-		got, err := handleReconcileErrWithoutStatus(ctx, nil, nil, o.origin, o.err)
+		if o.ctx == nil {
+			o.ctx = context.Background()
+		}
+		got, err := handleReconcileErr(o.ctx, nil, (*vmv1beta1.VMCluster)(nil), o.origin, o.err)
 		assert.Equal(t, o.wantErr, err)
 		assert.Equal(t, o.wantResult, got)
 	}
 
 	// no error
-	f(context.Background(), opts{
+	f(opts{
 		err:        nil,
 		origin:     ctrl.Result{RequeueAfter: 10},
 		wantResult: ctrl.Result{RequeueAfter: 10},
@@ -343,7 +347,7 @@ func TestHandleReconcileErrWithoutStatus(t *testing.T) {
 	})
 
 	// context canceled
-	f(context.Background(), opts{
+	f(opts{
 		err:        context.Canceled,
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{RequeueAfter: time.Second * 5},
@@ -353,43 +357,11 @@ func TestHandleReconcileErrWithoutStatus(t *testing.T) {
 	// context canceled with ErrShutdown
 	shutdownCtx, shutdownCancel := context.WithCancelCause(context.Background())
 	shutdownCancel(ErrShutdown)
-	f(shutdownCtx, opts{
+	f(opts{
+		ctx:        shutdownCtx,
 		err:        fmt.Errorf("wrapped: %w", errors.Join(context.Canceled, ErrShutdown)),
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{},
 		wantErr:    nil,
 	})
-}
-
-func TestHandleReconcileErr(t *testing.T) {
-	type opts struct {
-		err        error
-		origin     ctrl.Result
-		wantResult ctrl.Result
-		wantErr    error
-	}
-
-	f := func(o opts) {
-		t.Helper()
-		got, err := handleReconcileErr(context.Background(), nil, (*vmv1beta1.VMCluster)(nil), o.origin, o.err)
-		assert.Equal(t, o.wantErr, err)
-		assert.Equal(t, o.wantResult, got)
-	}
-
-	// no error
-	f(opts{
-		err:        nil,
-		origin:     ctrl.Result{RequeueAfter: 10},
-		wantResult: ctrl.Result{RequeueAfter: 10},
-		wantErr:    nil,
-	})
-
-	// context canceled
-	f(opts{
-		err:        context.Canceled,
-		origin:     ctrl.Result{},
-		wantResult: ctrl.Result{RequeueAfter: time.Second * 5},
-		wantErr:    nil,
-	})
-
 }

--- a/internal/controller/operator/factory/reconcile/reconcile.go
+++ b/internal/controller/operator/factory/reconcile/reconcile.go
@@ -147,7 +147,7 @@ func waitForStatus[T client.Object, ST StatusWithMetadata[STC], STC any](
 	interval time.Duration,
 	status vmv1beta1.UpdateStatus,
 ) error {
-	lastStatus := obj.GetStatus().GetStatusMetadata()
+	lastStatus := obj.GetStatusMetadata()
 	nsn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	err := wait.PollUntilContextCancel(ctx, interval, false, func(ctx context.Context) (done bool, err error) {
 		if err = rclient.Get(ctx, nsn, obj); err != nil {
@@ -157,7 +157,7 @@ func waitForStatus[T client.Object, ST StatusWithMetadata[STC], STC any](
 			err = fmt.Errorf("unexpected error during attempt to get %T=%s: %w", obj, nsn.String(), err)
 			return
 		}
-		lastStatus = obj.GetStatus().GetStatusMetadata()
+		lastStatus = obj.GetStatusMetadata()
 		return lastStatus != nil && obj.GetGeneration() == lastStatus.ObservedGeneration && lastStatus.UpdateStatus == status, nil
 	})
 	if err != nil {

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -175,20 +175,20 @@ type ObjectWithDeepCopyAndStatus[T client.Object, ST StatusWithMetadata[STC], ST
 	client.Object
 	DeepCopy() T
 	GetStatus() ST
+	GetStatusMetadata() *vmv1beta1.StatusMetadata
 	DefaultStatusFields(ST)
 }
 
 // StatusWithMetadata defines
 type StatusWithMetadata[T any] interface {
 	DeepCopy() T
-	GetStatusMetadata() *vmv1beta1.StatusMetadata
 }
 
 // UpdateStatus reconcile provided object status with given actualStatus status
 func UpdateObjectStatus[T client.Object, ST StatusWithMetadata[STC], STC any](ctx context.Context, rclient client.Client, object ObjectWithDeepCopyAndStatus[T, ST, STC], actualStatus vmv1beta1.UpdateStatus, maybeErr error) error {
 	currentStatus := object.GetStatus()
 	prevStatus := currentStatus.DeepCopy()
-	currMeta := currentStatus.GetStatusMetadata()
+	currMeta := object.GetStatusMetadata()
 	newUpdateStatus := actualStatus
 
 	switch actualStatus {

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -63,35 +63,35 @@ func (r *VLAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runti
 func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vlagent", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VLAgent{}
+	var instance vmv1.VLAgent
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VLAgent instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{origin: err, controller: "vlagent", requestObject: req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{origin: err, controller: "vlagent", requestObject: req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vlagent")
+	RegisterObjectStat(&instance, "vlagent")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVLAgentDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVLAgentDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vlagent"}
+		err = &parsingError{instance.Spec.ParsingError, "vlagent"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vlagent.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vlagent.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, err
 		}
 		return result, nil

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -58,33 +58,33 @@ func (r *VLClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *run
 func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vlcluster", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VLCluster{}
+	var instance vmv1.VLCluster
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vlcluster", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vlcluster", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vlcluster")
+	RegisterObjectStat(&instance, "vlcluster")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnClusterDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vlcluster"}
+		err = &parsingError{instance.Spec.ParsingError, "vlcluster"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vlcluster.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vlcluster.CreateOrUpdate(ctx, r, &instance); err != nil {
 			return result, fmt.Errorf("failed create or update vlcluster: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -64,25 +64,25 @@ func (r *VLogsReconciler) Scheme() *runtime.Scheme {
 func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vlogs", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VLogs{}
+	var instance vmv1beta1.VLogs
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vlogs", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vlogs", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vlogs")
+	RegisterObjectStat(&instance, "vlogs")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVLogsDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVLogsDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vlogs"}
+		err = &parsingError{instance.Spec.ParsingError, "vlogs"}
+		return
 	}
 	l.Info("VLogs CustomResource transited into read-only state. Please migrate to the VLSingle.")
 	return

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -59,33 +59,33 @@ func (r *VLSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runt
 func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vlsingle", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VLSingle{}
+	var instance vmv1.VLSingle
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vlsingle", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vlsingle", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vlsingle")
+	RegisterObjectStat(&instance, "vlsingle")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVLSingleDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVLSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vlsingle"}
+		err = &parsingError{instance.Spec.ParsingError, "vlsingle"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vlsingle.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vlsingle.CreateOrUpdate(ctx, r, &instance); err != nil {
 			return result, fmt.Errorf("failed create or update vlsingle: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -83,14 +83,15 @@ func (r *VMAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runti
 func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmagent", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMAgent{}
-
+	var instance vmv1beta1.VMAgent
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
+
 	// Fetch the VMAgent instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{origin: err, controller: "vmagent", requestObject: req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{origin: err, controller: "vmagent", requestObject: req}
+		return
 	}
 
 	if !instance.IsUnmanaged(nil) {
@@ -98,25 +99,24 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		defer agentSync.RUnlock()
 	}
 
-	RegisterObjectStat(instance, "vmagent")
+	RegisterObjectStat(&instance, "vmagent")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMAgentDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVMAgentDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmagent"}
+		err = &parsingError{instance.Spec.ParsingError, "vmagent"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmagent.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmagent.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, err
 		}
 		return result, nil
@@ -150,17 +150,18 @@ func (*VMAgentReconciler) IsDisabled(_ *config.BaseOperatorConf, _ sets.Set[stri
 	return false
 }
 
-func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) error {
+func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) (err error) {
 	if build.IsControllerDisabled("VMAgent") && agentReconcileLimit.MustThrottleReconcile() {
 		return nil
 	}
 	agentSync.Lock()
 	defer agentSync.Unlock()
 	var objects vmv1beta1.VMAgentList
-	if err := k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMAgentList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMAgentList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
-		return fmt.Errorf("cannot list VMAgents for %T: %w", instance, err)
+		err = fmt.Errorf("cannot list VMAgents for %T: %w", instance, err)
+		return
 	}
 	for i := range objects.Items {
 		item := &objects.Items[i]
@@ -190,9 +191,10 @@ func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Cl
 			}
 		}
 
-		if err := vmagent.CreateOrUpdateScrapeConfig(ctx, rclient, item, instance); err != nil {
-			continue
+		if configErr := vmagent.CreateOrUpdateScrapeConfig(ctx, rclient, item, instance); configErr != nil {
+			l.Error(configErr, "cannot update VMAgent scrape configuration")
+			err = configErr
 		}
 	}
-	return nil
+	return
 }

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -69,14 +69,15 @@ func (r *VMAlertReconciler) Scheme() *runtime.Scheme {
 func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmalert", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMAlert{}
+	var instance vmv1beta1.VMAlert
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmalert", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmalert", req}
+		return
 	}
 
 	if !instance.IsUnmanaged() {
@@ -84,29 +85,28 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		defer alertSync.RUnlock()
 	}
 
-	RegisterObjectStat(instance, "vmalert")
+	RegisterObjectStat(&instance, "vmalert")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMAlertDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
-		return result, nil
+		err = finalize.OnVMAlertDelete(ctx, r.Client, &instance)
+		return
 	}
 
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmalert"}
+		err = &parsingError{instance.Spec.ParsingError, "vmalert"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		maps, err := vmalert.CreateOrUpdateRuleConfigMaps(ctx, r, instance, nil)
+		maps, err := vmalert.CreateOrUpdateRuleConfigMaps(ctx, r, &instance, nil)
 		if err != nil {
 			return result, err
 		}
-		if err := vmalert.CreateOrUpdate(ctx, instance, r, maps); err != nil {
+		if err := vmalert.CreateOrUpdate(ctx, &instance, r, maps); err != nil {
 			return result, err
 		}
 		return result, nil

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -72,13 +72,14 @@ func (r *VMAlertmanagerReconciler) Scheme() *runtime.Scheme {
 func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmalertmanager", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMAlertmanager{}
+	var instance vmv1beta1.VMAlertmanager
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmalertmanager", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmalertmanager", req}
+		return
 	}
 
 	if !instance.IsUnmanaged() {
@@ -86,27 +87,26 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		defer alertmanagerSync.RUnlock()
 	}
 
-	RegisterObjectStat(instance, "vmalertmanager")
+	RegisterObjectStat(&instance, "vmalertmanager")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMAlertManagerDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVMAlertManagerDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmalertmanager"}
+		err = &parsingError{instance.Spec.ParsingError, "vmalertmanager"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmalertmanager.CreateOrUpdateConfig(ctx, r.Client, instance, nil); err != nil {
+		if err := vmalertmanager.CreateOrUpdateConfig(ctx, r.Client, &instance, nil); err != nil {
 			return result, err
 		}
-		if err := vmalertmanager.CreateOrUpdateAlertManager(ctx, instance, r); err != nil {
+		if err := vmalertmanager.CreateOrUpdateAlertManager(ctx, &instance, r); err != nil {
 			return result, err
 		}
 		return result, nil

--- a/internal/controller/operator/vmalertmanagerconfig_controller.go
+++ b/internal/controller/operator/vmalertmanagerconfig_controller.go
@@ -58,19 +58,23 @@ func (r *VMAlertmanagerConfigReconciler) Scheme() *runtime.Scheme {
 // Reconcile implements interface
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagerconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagerconfigs/status,verbs=get;update;patch
-func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmalertmanagerconfig", req.Name, "namespace", req.Namespace)
 	var instance vmv1beta1.VMAlertmanagerConfig
 	defer func() {
-		result, resultErr = handleReconcileErrWithoutStatus(ctx, r.Client, &instance, result, resultErr)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		return result, &getError{err, "vmalertmanagerconfig", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmalertmanagerconfig", req}
+		return
 	}
 
 	RegisterObjectStat(&instance, "vmalertmanagerconfig")
-
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmalertmanagerconfig"}
+		return
+	}
 	if alertmanagerReconcileLimit.MustThrottleReconcile() {
 		return
 	}
@@ -78,10 +82,11 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	alertmanagerSync.Lock()
 	defer alertmanagerSync.Unlock()
 	var objects vmv1beta1.VMAlertmanagerList
-	if err := k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAlertmanagerList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAlertmanagerList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
-		return result, fmt.Errorf("cannot list vmalertmanagers for vmalertmanagerconfig: %w", err)
+		err = fmt.Errorf("cannot list vmalertmanagers for vmalertmanagerconfig: %w", err)
+		return
 	}
 
 	for i := range objects.Items {
@@ -111,8 +116,9 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 				continue
 			}
 		}
-		if err := vmalertmanager.CreateOrUpdateConfig(ctx, r.Client, item, &instance); err != nil {
-			continue
+		if configErr := vmalertmanager.CreateOrUpdateConfig(ctx, r.Client, item, &instance); configErr != nil {
+			l.Error(configErr, "cannot update alertmanager config")
+			err = configErr
 		}
 	}
 	return

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -63,35 +63,35 @@ func (r *VMAnomalyReconciler) Init(rclient client.Client, l logr.Logger, sc *run
 func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmanomaly", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VMAnomaly{}
+	var instance vmv1.VMAnomaly
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VMAnomaly instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{origin: err, controller: "vmanomaly", requestObject: req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{origin: err, controller: "vmanomaly", requestObject: req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vmanomaly")
+	RegisterObjectStat(&instance, "vmanomaly")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMAnomalyDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVMAnomalyDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmanomaly"}
+		err = &parsingError{instance.Spec.ParsingError, "vmanomaly"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmanomaly.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmanomaly.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, err
 		}
 		return result, nil

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -69,13 +69,13 @@ func (r *VMAuthReconciler) Scheme() *runtime.Scheme {
 func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmauth", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMAuth{}
+	var instance vmv1beta1.VMAuth
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return result, &getError{err, "vmauth", req}
 	}
 
@@ -84,24 +84,25 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		defer authSync.RUnlock()
 	}
 
-	RegisterObjectStat(instance, "vmauth")
+	RegisterObjectStat(&instance, "vmauth")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMAuthDelete(ctx, r, instance); err != nil {
-			return result, fmt.Errorf("cannot remove finalizer from vmauth: %w", err)
+		if err = finalize.OnVMAuthDelete(ctx, r, &instance); err != nil {
+			err = fmt.Errorf("cannot remove finalizer from vmauth: %w", err)
 		}
-		return result, nil
+		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmauth"}
+		err = &parsingError{instance.Spec.ParsingError, "vmauth"}
+		return
 	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmauth.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmauth.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, fmt.Errorf("cannot create or update vmauth deploy: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -47,34 +47,34 @@ func (r *VMClusterReconciler) Scheme() *runtime.Scheme {
 func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmcluster", request.Name, "namespace", request.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMCluster{}
+	var instance vmv1beta1.VMCluster
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Client.Get(ctx, request.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmcluster", request}
+	if err = r.Client.Get(ctx, request.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmcluster", request}
+		return
 	}
 
-	RegisterObjectStat(instance, "vmcluster")
+	RegisterObjectStat(&instance, "vmcluster")
 
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnClusterDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
-		return result, nil
+		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
+		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmcluster"}
+		err = &parsingError{instance.Spec.ParsingError, "vmcluster"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmcluster.CreateOrUpdate(ctx, instance, r.Client); err != nil {
+		if err := vmcluster.CreateOrUpdate(ctx, &instance, r.Client); err != nil {
 			return result, fmt.Errorf("failed create or update vmcluster: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -55,40 +55,42 @@ func (r *VMDistributedReconciler) Init(rclient client.Client, l logr.Logger, sc 
 func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmdistributed", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1alpha1.VMDistributed{}
+	var instance vmv1alpha1.VMDistributed
 
 	// Handle reconcile errors
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch VMDistributed instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmdistributed", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmdistributed", req}
+		return
 	}
 
 	// Register metrics
-	RegisterObjectStat(instance, "vmdistributed")
+	RegisterObjectStat(&instance, "vmdistributed")
 
 	// Check if the instance is being deleted
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMDistributedDelete(ctx, r, instance); err != nil {
-			return result, fmt.Errorf("cannot remove finalizer from VMDistributed: %w", err)
+		if err = finalize.OnVMDistributedDelete(ctx, r, &instance); err != nil {
+			err = fmt.Errorf("cannot remove finalizer from VMDistributed: %w", err)
 		}
-		return result, nil
+		return
 	}
 	// Check parsing error
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "VMDistributed"}
+		err = &parsingError{instance.Spec.ParsingError, "VMDistributed"}
+		return
 	}
 
 	// Add finalizer if necessary
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmdistributed.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmdistributed.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, fmt.Errorf("VMDistributed %s update failed: %w", instance.Name, err)
 		}
 

--- a/internal/controller/operator/vmnodescrape_controller.go
+++ b/internal/controller/operator/vmnodescrape_controller.go
@@ -58,27 +58,29 @@ func (r *VMNodeScrapeReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmnodescrapes/finalizers,verbs=*
 func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmnodescrape", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMNodeScrape{}
+	var instance vmv1beta1.VMNodeScrape
 	ctx = logger.AddToContext(ctx, l)
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch the VMNodeScrape instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmnodescrape", req}
-	}
-
-	RegisterObjectStat(instance, "vmnodescrape")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmnodescrape"}
-	}
-
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmnodescrape", req}
 		return
 	}
 
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	RegisterObjectStat(&instance, "vmnodescrape")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmnodescrape"}
+		return
+	}
+
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 

--- a/internal/controller/operator/vmpodscrape_controller.go
+++ b/internal/controller/operator/vmpodscrape_controller.go
@@ -57,25 +57,27 @@ func (r *VMPodScrapeReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmpodscrapes/status,verbs=get;update;patch
 func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmpodscrape", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMPodScrape{}
+	var instance vmv1beta1.VMPodScrape
 	ctx = logger.AddToContext(ctx, l)
 
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VMPodScrape instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmpodscrape", req}
-	}
-
-	RegisterObjectStat(instance, "vmpodscrape")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmpodscrape"}
-	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmpodscrape", req}
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+
+	RegisterObjectStat(&instance, "vmpodscrape")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmpodscrape"}
+		return
+	}
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmprobe_controller.go
+++ b/internal/controller/operator/vmprobe_controller.go
@@ -57,25 +57,27 @@ func (r *VMProbeReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmprobes/status,verbs=get;update;patch
 func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmprobe", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMProbe{}
+	var instance vmv1beta1.VMProbe
 	ctx = logger.AddToContext(ctx, l)
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch the VMPodScrape instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmprobescrape", req}
-	}
-
-	RegisterObjectStat(instance, "vmprobescrape")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmprobescrape"}
-	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmprobescrape", req}
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+
+	RegisterObjectStat(&instance, "vmprobescrape")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmprobescrape"}
+		return
+	}
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmrule_controller.go
+++ b/internal/controller/operator/vmrule_controller.go
@@ -60,32 +60,36 @@ func (r *VMRuleReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmrules/status,verbs=get;update;patch
 func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmrule", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMRule{}
+	var instance vmv1beta1.VMRule
 	ctx = logger.AddToContext(ctx, l)
 
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch the VMRule instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmrule", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmrule", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vmrule")
-
+	RegisterObjectStat(&instance, "vmrule")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmrule"}
+		return
+	}
 	if alertReconcileLimit.MustThrottleReconcile() {
-		// fast path
-		return ctrl.Result{}, nil
+		return
 	}
 
 	alertSync.Lock()
 	defer alertSync.Unlock()
 	var objects vmv1beta1.VMAlertList
-	if err := k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAlertList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAlertList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
-		return result, fmt.Errorf("cannot list vmalerts for vmrule: %w", err)
+		err = fmt.Errorf("cannot list vmalerts for vmrule: %w", err)
+		return
 	}
 
 	for i := range objects.Items {
@@ -105,7 +109,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 				ObjectSelector:    item.Spec.RuleSelector,
 				DefaultNamespace:  instance.Namespace,
 			}
-			match, err := isSelectorsMatchesTargetCRD(ctx, r.Client, instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(ctx, r.Client, &instance, item, opts)
 			if err != nil {
 				l.Error(err, "cannot match vmalert and vmrule")
 				continue
@@ -115,9 +119,9 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 			}
 		}
 
-		_, err := vmalert.CreateOrUpdateRuleConfigMaps(ctx, r, item, instance)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot update rules configmaps: %w", err)
+		if _, configErr := vmalert.CreateOrUpdateRuleConfigMaps(ctx, r, item, &instance); configErr != nil {
+			l.Error(configErr, "cannot update rules configmaps")
+			err = configErr
 		}
 	}
 	return

--- a/internal/controller/operator/vmscrapeconfig_controller.go
+++ b/internal/controller/operator/vmscrapeconfig_controller.go
@@ -57,25 +57,27 @@ func (r *VMScrapeConfigReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmscrapeconfigs/status,verbs=get;update;patch
 func (r *VMScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmscrapeconfig", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMScrapeConfig{}
+	var instance vmv1beta1.VMScrapeConfig
 	ctx = logger.AddToContext(ctx, l)
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch the VMScrapeConfig instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmscrapeconfig", req}
-	}
-
-	RegisterObjectStat(instance, "vmscrapeconfig")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmscrapeconfig"}
-	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmscrapeconfig", req}
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+
+	RegisterObjectStat(&instance, "vmscrapeconfig")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmscrapeconfig"}
+		return
+	}
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmservicescrape_controller.go
+++ b/internal/controller/operator/vmservicescrape_controller.go
@@ -57,25 +57,27 @@ func (r *VMServiceScrapeReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmservicescrapes/status,verbs=get;update;patch
 func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmservicescrape", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMServiceScrape{}
 	ctx = logger.AddToContext(ctx, l)
+	var instance vmv1beta1.VMServiceScrape
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
 	// Fetch the VMServiceScrape instance
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmservicescrape", req}
-	}
-
-	RegisterObjectStat(instance, "vmservicescrape")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmservicescrape"}
-	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmservicescrape", req}
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+
+	RegisterObjectStat(&instance, "vmservicescrape")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmservicescrape"}
+		return
+	}
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -89,33 +89,33 @@ func (r *VMSingleReconciler) Scheme() *runtime.Scheme {
 func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmsingle", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1beta1.VMSingle{}
+	var instance vmv1beta1.VMSingle
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmsingle", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmsingle", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vmsingle")
+	RegisterObjectStat(&instance, "vmsingle")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVMSingleDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVMSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmsingle"}
+		err = &parsingError{instance.Spec.ParsingError, "vmsingle"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vmsingle.CreateOrUpdate(ctx, instance, r); err != nil {
+		if err := vmsingle.CreateOrUpdate(ctx, &instance, r); err != nil {
 			return result, fmt.Errorf("failed create or update vmsingle: %w", err)
 		}
 		return result, nil
@@ -143,7 +143,7 @@ func (*VMSingleReconciler) IsDisabled(_ *config.BaseOperatorConf, _ sets.Set[str
 	return false
 }
 
-func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) error {
+func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) (err error) {
 	if build.IsControllerDisabled("VMSingle") && vmsingleReconcileLimit.MustThrottleReconcile() {
 		return nil
 	}
@@ -151,10 +151,11 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 	defer vmsingleSync.Unlock()
 
 	var objects vmv1beta1.VMSingleList
-	if err := k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMSingleList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMSingleList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
-		return fmt.Errorf("cannot list VMSingles for %T: %w", instance, err)
+		err = fmt.Errorf("cannot list VMSingles for %T: %w", instance, err)
+		return
 	}
 
 	for i := range objects.Items {
@@ -184,9 +185,10 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 			}
 		}
 
-		if err := vmsingle.CreateOrUpdateScrapeConfig(ctx, rclient, item, instance); err != nil {
-			continue
+		if configErr := vmsingle.CreateOrUpdateScrapeConfig(ctx, rclient, item, instance); configErr != nil {
+			l.Error(configErr, "cannot update VMSingle scrape configuration")
+			err = configErr
 		}
 	}
-	return nil
+	return
 }

--- a/internal/controller/operator/vmstaticscrape_controller.go
+++ b/internal/controller/operator/vmstaticscrape_controller.go
@@ -40,21 +40,23 @@ func (r *VMStaticScrapeReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmstaticscrapes/status,verbs=get;update;patch
 func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmstaticscrape", req.Name, "namespace", req.Namespace)
-	instance := &vmv1beta1.VMStaticScrape{}
+	var instance vmv1beta1.VMStaticScrape
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vmstaticscrape", req}
-	}
-	RegisterObjectStat(instance, "vmstaticscrape")
-	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vmstaticscrape"}
-	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmstaticscrape", req}
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, instance); err != nil {
+	RegisterObjectStat(&instance, "vmstaticscrape")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmstaticscrape"}
+		return
+	}
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+		return
+	}
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -65,24 +65,28 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	l := r.Log.WithValues("vmuser", req.Name, "namespace", req.Namespace)
 	var instance vmv1beta1.VMUser
 	defer func() {
-		result, err = handleReconcileErrWithoutStatus(ctx, r.Client, &instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		return result, &getError{err, "vmuser", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vmuser", req}
+		return
 	}
-	RegisterObjectStat(&instance, "vmuser")
-
 	if !instance.DeletionTimestamp.IsZero() {
 		// need to remove finalizer and delete related resources.
-		if err := finalize.OnVMUserDelete(ctx, r, &instance); err != nil {
-			return result, fmt.Errorf("cannot remove finalizer for vmuser: %w", err)
+		if err = finalize.OnVMUserDelete(ctx, r, &instance); err != nil {
+			err = fmt.Errorf("cannot remove finalizer for vmuser: %w", err)
 		}
 		return
 	}
+	RegisterObjectStat(&instance, "vmuser")
+	if instance.Spec.ParsingError != "" {
+		err = &parsingError{instance.Spec.ParsingError, "vmuser"}
+		return
+	}
 
-	if err := finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
 
 	if authReconcileLimit.MustThrottleReconcile() {
@@ -92,10 +96,11 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	authSync.Lock()
 	defer authSync.Unlock()
 	var objects vmv1beta1.VMAuthList
-	if err := k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAuthList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, r.Client, r.BaseConf.WatchNamespaces, func(dst *vmv1beta1.VMAuthList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
-		return result, fmt.Errorf("cannot list vmauths for vmuser: %w", err)
+		err = fmt.Errorf("cannot list vmauths for vmuser: %w", err)
+		return
 	}
 
 	for i := range objects.Items {
@@ -125,8 +130,9 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 				continue
 			}
 		}
-		if err := vmauth.CreateOrUpdateConfig(ctx, r, item, &instance); err != nil {
-			return ctrl.Result{}, fmt.Errorf("cannot create or update vmauth deploy for vmuser: %w", err)
+		if configErr := vmauth.CreateOrUpdateConfig(ctx, r, item, &instance); configErr != nil {
+			l.Error(configErr, "cannot create or update vmauth deploy for vmuser")
+			err = configErr
 		}
 	}
 	return

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -58,33 +58,33 @@ func (r *VTClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *run
 func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vtcluster", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VTCluster{}
+	var instance vmv1.VTCluster
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vtcluster", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vtcluster", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vtcluster")
+	RegisterObjectStat(&instance, "vtcluster")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnClusterDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vtcluster"}
+		err = &parsingError{instance.Spec.ParsingError, "vtcluster"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vtcluster.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vtcluster.CreateOrUpdate(ctx, r, &instance); err != nil {
 			return result, fmt.Errorf("failed create or update vtcluster: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -59,33 +59,33 @@ func (r *VTSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runt
 func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vtsingle", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)
-	instance := &vmv1.VTSingle{}
+	var instance vmv1.VTSingle
 
 	defer func() {
-		result, err = handleReconcileErr(ctx, r.Client, instance, result, err)
+		result, err = handleReconcileErr(ctx, r.Client, &instance, result, err)
 	}()
 
-	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
-		return result, &getError{err, "vtsingle", req}
+	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
+		err = &getError{err, "vtsingle", req}
+		return
 	}
 
-	RegisterObjectStat(instance, "vtsingle")
+	RegisterObjectStat(&instance, "vtsingle")
 	if !instance.DeletionTimestamp.IsZero() {
-		if err := finalize.OnVTSingleDelete(ctx, r.Client, instance); err != nil {
-			return result, err
-		}
+		err = finalize.OnVTSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Spec.ParsingError != "" {
-		return result, &parsingError{instance.Spec.ParsingError, "vtsingle"}
+		err = &parsingError{instance.Spec.ParsingError, "vtsingle"}
+		return
 	}
-	if err := finalize.AddFinalizer(ctx, r.Client, instance); err != nil {
-		return result, err
+	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {
+		return
 	}
-	r.Client.Scheme().Default(instance)
+	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), func() (ctrl.Result, error) {
-		if err := vtsingle.CreateOrUpdate(ctx, r, instance); err != nil {
+		if err := vtsingle.CreateOrUpdate(ctx, r, &instance); err != nil {
 			return result, fmt.Errorf("failed create or update vtsingle: %w", err)
 		}
 		return result, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies error handling across all controllers and standardizes how status metadata is read from CRs. Adds graceful shutdown handling and better error propagation while keeping NotFound silent and requeuing on cancellations and conflicts.

- **Refactors**
  - Removed `handleReconcileErrWithoutStatus`; all controllers now use a single `handleReconcileErr`.
  - Moved `GetStatusMetadata` from Status structs to parent CRs; updated helpers (`waitForStatus`, status updates) to read metadata from the CR.
  - Added `GetStatus`/`DefaultStatusFields` for `VMAlertmanagerConfig`, `VMRule`, `VMUser`, and scrape CRs (`VMNodeScrape`, `VMPodScrape`, `VMProbe`, `VMScrapeConfig`, `VMServiceScrape`, `VMStaticScrape`); standardized controllers to use value instances and pass pointers.

- **Bug Fixes**
  - Requeue on `context.Canceled` unless caused by graceful shutdown (`operator.ErrShutdown`); keep NotFound silent and back off on conflicts.
  - Emit events only on real errors; consistent error metrics across all CRs.
  - Stop reconciliation on invalid specs via `spec.ParsingError`; `VMRule` and `VMUser` capture JSON parse errors during unmarshal.
  - Propagate errors from related-resource updates while continuing other items (VMAgent/VMSingle scrapes, alert/rule config updates).

<sup>Written for commit 551ba04be719c35b05e79ed6b5577e54826ac516. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

