### PR TITLE
operator/deployment: replace httpGet probes with tcpSocket

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,14 +74,12 @@ spec:
             drop:
             - "ALL"
         livenessProbe:
-          httpGet:
-            path: /health
+          tcpSocket:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
-          httpGet:
-            path: /ready
+          tcpSocket:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ aliases:
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.137.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.137.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0).
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): use `tcpSocket` probes for the operator deployment instead of `httpGet`, so that probes work correctly with both plain-text and TLS health-probe servers. See [#1824](https://github.com/VictoriaMetrics/operator/issues/1824).
 
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): VMSingle reuses vmagent implementation to allow scraping and relabelling. See [#1694](https://github.com/VictoriaMetrics/operator/issues/1694)
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): perform statefulset pods deletion instead of eviction when maxUnavailable set to 100%, which is important for [minimum downtime strategy](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#minimum-downtime-strategy). See [#1706](https://github.com/VictoriaMetrics/operator/issues/1706).


### PR DESCRIPTION
## What

Replace `livenessProbe` and `readinessProbe` `httpGet` actions with `tcpSocket` in the operator deployment manifest.

## Why
The current `httpGet` probes fail when the health-probe server is served over TLS, because the kubelet sends a plain HTTP request.

`tcpSocket` probes only check that the port is accepting connections — agnostic to HTTP vs HTTPS — so they work correctly for both configurations.

Fixes #1824

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the operator deployment’s liveness/readiness `httpGet` probes with `tcpSocket` so health checks work over both HTTP and HTTPS. Fixes #1824 by avoiding plain-HTTP requests against TLS health endpoints.

<sup>Written for commit a207047b47198fe7461e1760dbb97448dd894f26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

