### PR TITLE
spelling fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ aliases:
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): VMPodScrape for VLAgent and VMAgent now uses the correct port; previously it used the wrong port and could cause scrape failures. See [#1887](https://github.com/VictoriaMetrics/operator/issues/1887).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): updated VMAuth config consolidating all VMSelects into a single read and all VMClusters into a single write backend
-* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): fix PVC being owned by StatefulSet and top-level object simultaenously. See [#1845](https://github.com/VictoriaMetrics/operator/issues/1845).
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): fix PVC being owned by StatefulSet and top-level object simultaneously. See [#1845](https://github.com/VictoriaMetrics/operator/issues/1845).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): remove unneeded finalizer from core K8s resources. See [#835](https://github.com/VictoriaMetrics/operator/issues/835).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): remove finalizers from VMServiceScrape and VMPodScrape objects, and keep finalizers on VMAgent, VMCluster, and VMAuth when DeletionTimestamp is not empty.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/) and [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): previously, ingest-only mode could still mount scrape configuration secrets when relabeling or stream aggregation was configured, which caused unexpected secret mounts and RBAC-related failures; now these secrets are not mounted in ingest-only mode, so deployments start with the expected minimal permissions and avoid related runtime errors. See [#1828](https://github.com/VictoriaMetrics/operator/issues/1828).
@@ -181,7 +181,7 @@ SECURITY: upgrade Go builder from Go1.25.4 to Go1.25.5. See [the list of issues 
 
 **It isn't recommended to use Operator  v0.64.0 because of the bug [#1583](https://github.com/VictoriaMetrics/operator/issues/1583), which incorrectly builds args for `VLCluster` resources. Upgrade to [v0.65.0](https://docs.victoriametrics.com/operator/changelog/#v0641) instead.**
 
-**Update Note 1:** This release deprecates 3rd party config-reloader containers - `jimmidyson/configmap-reload` and `quay.io/prometheus-operator/prometheus-config-reloader` in favor of own implementation - 
+**Update Note 1:** This release deprecates 3rd party config-reloader containers - `jimmidyson/configmap-reload` and `quay.io/prometheus-operator/prometheus-config-reloader` in favor of own implementation -
 [victoriametrics/operator:config-reloader](https://github.com/VictoriaMetrics/operator/tree/master/cmd/config-reloader).
 This change could be reverted by providing env variable `VM_USECUSTOMCONFIGRELOADER=false` to the operator binary.
 
@@ -281,7 +281,7 @@ To perform migration to the `VLSingle` please follow [this docs](https://docs.vi
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): respect `PodDisruptionBudget` at `StatefulSet` updates. See this [1458](https://github.com/VictoriaMetrics/operator/pull/1458) PR for details. Thanks to the @vpedosyuk for the fix.
 * BUGFIX: [VLCluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [VMCluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): do not add `spec.clusterVersion`  to the `spec.requestsLoadBalancer.spec.image.tag` as default value. See this [1365](https://github.com/VictoriaMetrics/operator/issues/1365) issue for details.
-* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly add remoteWrite `streamAggr` configuration. Previously, operator failed to mount volume with configution. Bug was introduced at v0.60.0 release at commit 8df334ccab1706d91c2bd1708dfd9096f8c8a568. See this [9c47f448908edc80e3e6e89af9e3dac0ff8eb720](https://github.com/VictoriaMetrics/operator/commit/9c47f448908edc80e3e6e89af9e3dac0ff8eb720) commit for details.
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): properly add remoteWrite `streamAggr` configuration. Previously, operator failed to mount volume with configuration. Bug was introduced at v0.60.0 release at commit 8df334ccab1706d91c2bd1708dfd9096f8c8a568. See this [9c47f448908edc80e3e6e89af9e3dac0ff8eb720](https://github.com/VictoriaMetrics/operator/commit/9c47f448908edc80e3e6e89af9e3dac0ff8eb720) commit for details.
 * BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): properly generate format URL port for `Vlogs` and `VLSingle` at `targetRef.crd`. See [1465](https://github.com/VictoriaMetrics/operator/issues/1465) this issue for details.
 
 * FEATURE: [vlcluster](https://docs.victoriametrics.com/operator/resources/vlcluster/): added the `maxUnavailable` field to VLStorage specs to allow customization of rolling update behavior. See [#1457](https://github.com/VictoriaMetrics/operator/issues/1457).
@@ -385,7 +385,7 @@ To perform migration to the `VLSingle` please follow [this docs](https://docs.vi
 **Release date:** 14 May 2025
 
 **Update Note 1:** This release by default deploys`vmagent` which contains a bug, see more details in [VictoriaMetrics#8941](https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8941).
-We recommend skipping this release and waiting for newer release. 
+We recommend skipping this release and waiting for newer release.
 If you still want to upgrade, you can override the vmagent image version by setting the environment variable: `VM_VMAGENTDEFAULT_VERSION=v1.117.1`
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.117.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v11170) version
@@ -406,7 +406,7 @@ If you still want to upgrade, you can override the vmagent image version by sett
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default VLogs  [v1.21.0](https://docs.victoriametrics.com/victorialogs/changelog/#v1210) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default  alertmanager to [0.28.1](https://github.com/prometheus/alertmanager/releases/tag/v0.28.1) version
 
-* FEATURE: [operator](https://docs.victoriametrics.com/operator/): introduce [FIPS](https://go.dev/doc/security/fips140) builds for `operator` and `config-reloader` containers with `-fips` tag prefix. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1348) for details. 
+* FEATURE: [operator](https://docs.victoriametrics.com/operator/): introduce [FIPS](https://go.dev/doc/security/fips140) builds for `operator` and `config-reloader` containers with `-fips` tag prefix. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1348) for details.
 * FEATURE: [operator](https://docs.victoriametrics.com/operator/): introduce new field `spec.configReloadAuthKeySecret` for `VMAgent`, `VMAlert` and `VMAuth` components. It instructs application to use provided value for `-configReload` auth key. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1323) for details.
 * FEATURE: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): add `msteamsv2_configs` conversion from Prometheus resource AlertmanagerConfig. See [this commit](https://github.com/VictoriaMetrics/operator/commit/5cc7457e9eef325f75d9b1d9633d161230a6e0f7) for details.
 * FEATURE: upgrade Go builder from Go1.24.0 to Go1.24.4 See [Go1.24 release notes](https://tip.golang.org/doc/go1.24).
@@ -511,7 +511,7 @@ If you still want to upgrade, you can override the vmagent image version by sett
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): Properly generate kustomize config for validation webhook. See [this commit](https://github.com/VictoriaMetrics/operator/commit/40e91d66440db52bf1cbfa9cc41f18f4879dbff0).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): reduce request latency for `validation` webhook. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1094) for details.
-* BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): properly validate `targetRef.crd.kind`. Previously it incorrectly forbid `VLogs` reference. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1241) for details. 
+* BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): properly validate `targetRef.crd.kind`. Previously it incorrectly forbid `VLogs` reference. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1241) for details.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): reduce CPU and memory usage at large scale. Now operator could skip expensive runtime validation for `VMRule` and `VMAlertmanagerConfig` objects if `-webhook.enable` is set. See [this issue](https://github.com/VictoriaMetrics/operator/issues/1245) for details.
 
 ## [v0.53.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.53.0)

--- a/docs/resources/vmagent.md
+++ b/docs/resources/vmagent.md
@@ -17,7 +17,7 @@ tags:
 The `VMAgent` CRD declaratively defines a desired [VMAgent](https://docs.victoriametrics.com/victoriametrics/vmagent/)
 setup to run in a Kubernetes cluster.
 
-It requires access to Kubernetes API and you can create RBAC for it first, it can be found 
+It requires access to Kubernetes API and you can create RBAC for it first, it can be found
 at [`examples/vmagent_rbac.yaml`](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmagent_rbac.yaml)
 Or you can use default rbac account, that will be created for `VMAgent` by operator automatically.
 
@@ -40,7 +40,7 @@ so user can set custom configuration while still benefiting from the Operator's 
 
 You can see the full actual specification of the `VMAgent` resource in the **[API docs -> VMAgent](https://docs.victoriametrics.com/operator/api/#vmagent)**.
 
-If you can't find necessary field in the specification of the custom resource, 
+If you can't find necessary field in the specification of the custom resource,
 see [Extra arguments section](https://docs.victoriametrics.com/operator/resources/vmagent/#extra-arguments).
 
 Also, you can check out the [examples](https://docs.victoriametrics.com/operator/resources/vmagent/#examples) section.
@@ -113,7 +113,7 @@ metadata:
   name: select-ns
 spec:
   # ...
-  serviceScrapeNamespaceSelector: 
+  serviceScrapeNamespaceSelector:
     matchLabels:
       kubernetes.io/metadata.name: my-namespace
   podScrapeNamespaceSelector:
@@ -178,7 +178,7 @@ spec:
 
 Deduplication is automatically enabled with `replicationFactor > 1` on `VMCluster`.
 
-After enabling deduplication you can increase replicas for VMAgent. 
+After enabling deduplication you can increase replicas for VMAgent.
 
 For instance, let's create `VMAgent` with 2 replicas:
 
@@ -214,7 +214,7 @@ It uses the following formula for calculation: `requests.storage/count(remoteWri
 
 Example of configuration for `StatefulMode`:
 
-```yaml 
+```yaml
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
@@ -283,18 +283,18 @@ spec:
   # ...
 ```
 
-This configuration produces `5` deployments with `2` replicas at each. 
+This configuration produces `5` deployments with `2` replicas at each.
 Each deployment has its own shard num and scrapes only `1/5` of all targets.
 
 Also, you can use special placeholder `%SHARD_NUM%` in fields of `VMAgent` specification
-and operator will replace it with current shard num of vmagent when creating deployment or statefullset for vmagent.
+and operator will replace it with current shard num of vmagent when creating deployment or statefulset for vmagent.
 
 In the example above, the `%SHARD_NUM%` placeholder is used in the `podAntiAffinity` section,
 which recommend to scheduler that pods with the same shard num (label `shard-num` in the pod template)
-are not deployed on the same node. You can use another `topologyKey` for availability zone or region instead of nodes. 
+are not deployed on the same node. You can use another `topologyKey` for availability zone or region instead of nodes.
 
-**Note** that at the moment operator doesn't use `-promscrape.cluster.replicationFactor` parameter of `VMAgent` and 
-creates `replicaCount` of replicas for each shard (which leads greater resource consumption). 
+**Note** that at the moment operator doesn't use `-promscrape.cluster.replicationFactor` parameter of `VMAgent` and
+creates `replicaCount` of replicas for each shard (which leads greater resource consumption).
 This will be fixed in the future, more details can be seen in [this issue](https://github.com/VictoriaMetrics/operator/issues/604).
 
 Also see [this example](https://github.com/VictoriaMetrics/operator/blob/master/config/examples/vmagent_stateful_with_sharding.yaml).
@@ -391,7 +391,7 @@ spec:
     clusterid: some_cluster
 ```
 
-`VMAgent` CR supports relabeling with [custom configMap](https://docs.victoriametrics.com/operator/resources/vmagent/#relabeling-config-in-configmap) 
+`VMAgent` CR supports relabeling with [custom configMap](https://docs.victoriametrics.com/operator/resources/vmagent/#relabeling-config-in-configmap)
 or [inline defined at CRD](https://docs.victoriametrics.com/operator/resources/vmagent/#inline-relabeling-config).
 
 ### Relabeling config in Configmap
@@ -424,7 +424,7 @@ data:
 
 Second, add `relabelConfig` to `VMagent` spec for global relabeling for all remoteWrite targets with name of `Configmap` - `vmagent-relabel` and key `remote-write-relabel.yaml`.
 
-For relabeling per remoteWrite target, add `urlRelabelConfig` name of `Configmap` - `vmagent-relabel` 
+For relabeling per remoteWrite target, add `urlRelabelConfig` name of `Configmap` - `vmagent-relabel`
 and key `target-1-relabel.yaml` to one of remoteWrite target for relabeling only for this target:
 
 ```yaml
@@ -658,7 +658,7 @@ spec:
     # ...
 ```
 
-If these parameters are not specified, then, 
+If these parameters are not specified, then,
 by default all `VMAgent` pods have resource requests and limits from the default values of the following [operator parameters](https://docs.victoriametrics.com/operator/configuration/):
 
 - `VM_VMAGENTDEFAULT_RESOURCE_LIMIT_MEM` - default memory limit for `VMAgent` pods,
@@ -668,7 +668,7 @@ by default all `VMAgent` pods have resource requests and limits from the default
 
 These default parameters will be used if:
 
-- `VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES` is set to `true` (default value), 
+- `VM_VMAGENTDEFAULT_USEDEFAULTRESOURCES` is set to `true` (default value),
 - `VMAgent` CR doesn't have `resources` field in `spec` section.
 
 Field `resources` in vmagent spec have higher priority than operator parameters.
@@ -715,7 +715,7 @@ spec:
     kafka.consumer.topic.format: influx
     kafka.consumer.topic: metrics-by-telegraf
     kafka.consumer.topic.groupID: some-id
-    
+
   # ...other fields...
 ```
 
@@ -740,7 +740,7 @@ spec:
   # more details about kafka integration you can read on https://docs.victoriametrics.com/victoriametrics/vmagent/#kafka-integration
   remoteWrite:
     # sasl with username and password
-    - url: kafka://broker-1:9092/?topic=prom-rw-1&security.protocol=SASL_SSL&sasl.mechanisms=PLAIN 
+    - url: kafka://broker-1:9092/?topic=prom-rw-1&security.protocol=SASL_SSL&sasl.mechanisms=PLAIN
       # it requires to create kubernetes secret `kafka-basic-auth` with keys `username` and `password` in the same namespace
       basicAuth:
         username:

--- a/docs/resources/vmcluster.md
+++ b/docs/resources/vmcluster.md
@@ -30,8 +30,8 @@ There is a strict order for these objects creation and reconciliation:
 1. Then it syncs `VMSelect` with the same manner;
 1. `VMInsert` is the last object to sync.
 
-All [statefulsets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) are created 
-with [OnDelete](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#on-delete) update type. 
+All [statefulsets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) are created
+with [OnDelete](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#on-delete) update type.
 It allows to manually manage the rolling update process for Operator by deleting pods one by one and waiting for the ready status.
 
 Rolling update process may be configured by the operator env variables.
@@ -88,10 +88,10 @@ spec:
  Network scheme with load-balancing:
  ![CR](vmcluster_with_balancer.webp)
 
-The `requestsLoadBalancer` feature works transparently and is managed entirely by the `VMCluster` operator, 
-with no direct access to the underlying [VMAuth](https://docs.victoriametrics.com/victoriametrics/vmauth/) configuration. 
-If you need more control over load balancing behavior, 
-or want to combine request routing with authentication or (m)TLS, 
+The `requestsLoadBalancer` feature works transparently and is managed entirely by the `VMCluster` operator,
+with no direct access to the underlying [VMAuth](https://docs.victoriametrics.com/victoriametrics/vmauth/) configuration.
+If you need more control over load balancing behavior,
+or want to combine request routing with authentication or (m)TLS,
 consider deploying a standalone [VMAuth](https://docs.victoriametrics.com/operator/resources/vmauth/) resource instead of enabling `requestsLoadBalancer`.
 
 ## High availability
@@ -126,7 +126,7 @@ kind: VMCluster
 metadata:
   name: example-persistent
 spec:
-  replicationFactor: 2       
+  replicationFactor: 2
   vmstorage:
     replicaCount: 10
     storageDataPath: "/vm-data"
@@ -232,7 +232,7 @@ spec:
   clusterVersion: v1.110.13-cluster
 ```
 
-Also, you can specify `imagePullSecrets` if you are pulling images from private repo, 
+Also, you can specify `imagePullSecrets` if you are pulling images from private repo,
 but `imagePullSecrets` is global setting for all `VMCluster` specification:
 
 ```yaml
@@ -334,7 +334,7 @@ Also, you can specify requests without limits - in this case default values for 
 
 ## Enterprise features
 
-VMCluster supports following features 
+VMCluster supports following features
 from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/#victoriametrics-enterprise):
 
 - [Downsampling](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#downsampling)
@@ -343,7 +343,7 @@ from [VictoriaMetrics Enterprise](https://docs.victoriametrics.com/victoriametri
 - [mTLS for cluster components](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#mtls-protection)
 - [Backup automation](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/)
 
-VMCluster doesn't support yet feature 
+VMCluster doesn't support yet feature
 [Automatic discovery for vmstorage nodes](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#automatic-vmstorage-discovery).
 
 For using Enterprise version of [vmcluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/) you need to:
@@ -416,8 +416,8 @@ spec:
 ### Advanced per-tenant statistic
 
 For using [Advanced per-tenant statistic](https://docs.victoriametrics.com/victoriametrics/pertenantstatistic/)
-you only need to [enable Enterprise version of vmcluster components](https://docs.victoriametrics.com/operator/resources/vmcluster/#enterprise-features) 
-and operator will automatically create 
+you only need to [enable Enterprise version of vmcluster components](https://docs.victoriametrics.com/operator/resources/vmcluster/#enterprise-features)
+and operator will automatically create
 [Scrape objects](https://docs.victoriametrics.com/operator/resources/vmagent/#scraping) for cluster components.
 
 ```yaml
@@ -474,7 +474,7 @@ spec:
     extraVolumeMounts:
       - name: mtls
         mountPath: /etc/mtls
-      
+
   vminsert:
     extraArgs:
       # using enterprise features: mTLS protection
@@ -490,7 +490,7 @@ spec:
     extraVolumeMounts:
       - name: mtls
         mountPath: /etc/mtls
-      
+
   vmstorage:
     extraEnvs:
       - name: POD
@@ -561,13 +561,13 @@ stringData:
 
 ```
 
-Example commands for generating certificates you can read 
+Example commands for generating certificates you can read
 on [this page](https://gist.github.com/f41gh7/76ed8e5fb1ebb9737fe746bae9175ee6#generate-self-signed-ca-with-key).
 
 ### Backup automation
 
 You can check [vmbackupmanager documentation](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) for backup automation.
-It contains a description of the service and its features. This section covers vmbackumanager integration in vmoperator.
+It contains a description of the service and its features. This section covers vmbackupmanager integration in vmoperator.
 
 `VMCluster` has built-in backup configuration, it uses `vmbackupmanager` - proprietary tool for backups.
 It supports incremental backups (hourly, daily, weekly, monthly) with popular object storages (aws s3, google cloud storage).

--- a/docs/resources/vmdistributed.md
+++ b/docs/resources/vmdistributed.md
@@ -61,7 +61,7 @@ spec:
       replicaCount: 1
       unauthorizedUserAccessSpec:
         targetRefs:
-          - name: read 
+          - name: read
           - name: write
   zoneCommon:
     vmagent:
@@ -98,7 +98,7 @@ spec:
       replicaCount: 1
       unauthorizedUserAccessSpec:
         targetRefs:
-          - name: read 
+          - name: read
           - name: write
   zoneCommon:
     vmagent:
@@ -166,7 +166,7 @@ VMDistributed creates or becomes an owner of existing VMAuth, VMAgent and VMClus
 - Objects must be referred to by name; label selectors are not supported for cluster selection.
 
 ### Authorization
-By default VMDistributed provides no access to read/write endpoints. Instead it provides preconfigured named backebds `read` and `write`, which can be referenced in `spec.vmauth.spec.unauthorizedUserAccessSpec` section for provide unauthorized access or in VMUser spec for authorized access.
+By default VMDistributed provides no access to read/write endpoints. Instead it provides preconfigured named backends `read` and `write`, which can be referenced in `spec.vmauth.spec.unauthorizedUserAccessSpec` section for provide unauthorized access or in VMUser spec for authorized access.
 
 To provide unauthorized access to the distributed setup need to add `spec.vmauth.spec.unauthorizedUserAccessSpec` section, where `read`, `write` backends should be referenced:
 
@@ -176,7 +176,7 @@ spec:
     spec:
       unauthorizedUserAccessSpec:
         targetRefs:
-          - name: read 
+          - name: read
           - name: write
 ```
 

--- a/docs/resources/vmsingle.md
+++ b/docs/resources/vmsingle.md
@@ -222,7 +222,7 @@ After that you can pass [Downsampling](https://docs.victoriametrics.com/victoria
 flag to `VMSingle` with [extraArgs](https://docs.victoriametrics.com/operator/resources/#extra-arguments) too.
 
 Here are complete example for [Downsampling](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#downsampling):
- 
+
 ```yaml
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
@@ -272,7 +272,7 @@ spec:
 ### Backup automation
 
 You can check [vmbackupmanager documentation](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/) for backup automation.
-It contains a description of the service and its features. This section covers vmbackumanager integration in vmoperator.
+It contains a description of the service and its features. This section covers vmbackupmanager integration in vmoperator.
 
 `VMSingle` has built-in backup configuration, it uses `vmbackupmanager` - proprietary tool for backups.
 It supports incremental backups (hourly, daily, weekly, monthly) with popular object storages (aws s3, google cloud storage).
@@ -314,7 +314,7 @@ stringData:
     [default]
     aws_access_key_id = your_access_key_id
     aws_secret_access_key = your_secret_access_key
-``` 
+```
 
 You can read more about backup configuration options and mechanics [here](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/)
 
@@ -361,10 +361,10 @@ Steps:
         credentialsSecret:
           name: remote-storage-keys
           key: credentials
-          
+
       extraArgs:
         runOnStart: "true"
-        
+
       initContainers:
         - name: vmrestore
           image: victoriametrics/vmrestore:latest
@@ -378,7 +378,7 @@ Steps:
             - -storageDataPath=/victoria-metrics-data
             - -src=s3://your_bucket/folder/latest
             - -credsFilePath=/etc/vm/creds/credentials
-    
+
       # ...other fields...
     ```
 1. Apply it, and db will be restored from S3


### PR DESCRIPTION
### Describe Your Changes

fixing spelling issues in comments and text strings

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines]
- [x] My change adheres to [VictoriaMetrics development goals]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes typos and wording across docs for `vmagent`, `vmcluster`, `vmdistributed`, `vmsingle`, and the changelog. Improves clarity in examples and descriptions with no behavior or API changes.

- **Bug Fixes**
  - Corrected misspellings (e.g., “simultaneously”, “configuration”, “statefulset”, “backends”, “vmbackupmanager”).
  - Cleaned up YAML/Markdown formatting and spacing in examples.
  - No changes to APIs, defaults, or semantics.

<sup>Written for commit 1b0dfe766a26090e2c8e51dfc1a2b82de2aaa269. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

