### PR TITLE
fix spelling in code

### DIFF
--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -81,7 +81,7 @@ func getDefaultOptions() controller.Options {
 	return *defaultOptions
 }
 
-// parsingError usually occurs in case of x-preserve-unknow-fields option enable to CRD
+// parsingError usually occurs in case of x-preserve-unknown-fields option enable to CRD
 // in this case k8s api server cannot perform proper validation and it may result in bad user input for some fields
 type parsingError struct {
 	origin     string

--- a/internal/controller/operator/factory/finalize/orphaned.go
+++ b/internal/controller/operator/factory/finalize/orphaned.go
@@ -88,7 +88,7 @@ func RemoveOrphanedVPAs(ctx context.Context, rclient client.Client, cr crObject,
 	return removeOrphaned(ctx, rclient, cr, gvk, keepNames, shouldRemove)
 }
 
-// RemoveOrphanedVMServiceScrapes removes VMSeviceScrapes detached from given object
+// RemoveOrphanedVMServiceScrapes removes VMServiceScrapes detached from given object
 func RemoveOrphanedVMServiceScrapes(ctx context.Context, rclient client.Client, cr crObject, keepNames sets.Set[string], shouldRemove bool) error {
 	if build.IsControllerDisabled("VMServiceScrape") {
 		return nil

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -334,7 +334,7 @@ func performRollingUpdateOnSts(ctx context.Context, rclient client.Client, obj *
 					// evict pod to trigger re-creation
 					podEviction := policyv1.Eviction{ObjectMeta: pod.ObjectMeta}
 					if err := rclient.SubResource("eviction").Create(ctx, &pod, &podEviction); err != nil {
-						// retry distruption interrupt error:
+						// retry disruption interrupt error:
 						// https://github.com/kubernetes/kubernetes/blob/9a50e306361ea936e57fb6eb8c635f971e7bb707/pkg/registry/core/pod/storage/eviction.go#L418
 						if strings.Contains(err.Error(), "Cannot evict pod as it would violate the pod's disruption budget") {
 							return false, nil


### PR DESCRIPTION
### Describe Your Changes

fixing spelling issues in comments and text strings

No code changes !

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines]
- [x] My change adheres to [VictoriaMetrics development goals]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minor spelling errors in comments within `controllers.go`, `orphaned.go`, and `statefulset.go` to improve readability. No functional changes or behavior impact.

<sup>Written for commit dabd583feb79144fdc39197a1aa704e253df08bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

