### PR TITLE
test: avoid using ElementsMatch in unit tests

### DIFF
--- a/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
+++ b/internal/controller/operator/factory/reconcile/statefulset_pvc_expand_test.go
@@ -181,7 +181,7 @@ func Test_updateSTSPVC(t *testing.T) {
 			LabelSelector: labels.SelectorFromSet(o.sts.Spec.Selector.MatchLabels),
 		}
 		assert.NoError(t, cl.List(ctx, &pvcs, listOpts))
-		assert.ElementsMatch(t, o.expected, pvcs.Items)
+		assert.Equal(t, o.expected, pvcs.Items)
 	}
 
 	buildSTS := func(fns ...func(*appsv1.StatefulSet)) *appsv1.StatefulSet {

--- a/internal/controller/operator/factory/vmalertmanager/alertmanager_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/alertmanager_test.go
@@ -190,7 +190,7 @@ func TestCreateOrUpdateAlertManager(t *testing.T) {
 				}
 			}
 
-			assert.ElementsMatch(t, clusterPeers, []string{
+			assert.Equal(t, clusterPeers, []string{
 				"--cluster.peer=vmalertmanager-test-am-0.vmalertmanager-test-am.monitoring:9094",
 				"--cluster.peer=vmalertmanager-test-am-1.vmalertmanager-test-am.monitoring:9094",
 				"--cluster.peer=vmalertmanager-test-am-2.vmalertmanager-test-am.monitoring:9094",
@@ -225,7 +225,7 @@ func TestCreateOrUpdateAlertManager(t *testing.T) {
 				}
 			}
 
-			assert.ElementsMatch(t, clusterPeers, []string{
+			assert.Equal(t, clusterPeers, []string{
 				"--cluster.peer=vmalertmanager-test-am-0.vmalertmanager-test-am.monitoring.svc.example.com.:9094",
 				"--cluster.peer=vmalertmanager-test-am-1.vmalertmanager-test-am.monitoring.svc.example.com.:9094",
 				"--cluster.peer=vmalertmanager-test-am-2.vmalertmanager-test-am.monitoring.svc.example.com.:9094",

--- a/internal/controller/operator/factory/vmsingle/vmsingle_test.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle_test.go
@@ -102,7 +102,7 @@ func TestCreateOrUpdateService(t *testing.T) {
 		}
 		assert.NoError(t, fclient.Get(ctx, nsn, &got))
 		assert.Equal(t, got.Name, o.want.Name)
-		assert.ElementsMatch(t, got.Spec.Ports, o.want.Spec.Ports)
+		assert.Equal(t, got.Spec.Ports, o.want.Spec.Ports)
 	}
 
 	// base service test


### PR DESCRIPTION
Avoid using imprecise ElementsMatch - use Equal, so that the order would always be preserved