### PR TITLE
vmalertmanager: do not ignore tracing config, when to alertmanagerconfig CRs are collected

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): recreate STS if immutable fields changed.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): wait for STS deletion in case of recreation without throwing an error.
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): ignore VMAuth update/delete operations if controller is disabled.
+* BUGFIX: [vmalertmanager](https://docs.victoriametrics.com/operator/resources/vmalertmanager/): fixed ignored tracing config, when no alertmanagerconfig CRs collected. See [#1983](https://github.com/VictoriaMetrics/operator/issues/1983).
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/vmalertmanager/config.go
+++ b/internal/controller/operator/factory/vmalertmanager/config.go
@@ -18,12 +18,8 @@ type parsedObjects struct {
 }
 
 func (pos *parsedObjects) buildConfig(cr *vmv1beta1.VMAlertmanager, baseCfg []byte, ac *build.AssetsCache) ([]byte, error) {
-	if len(pos.configs.All()) == 0 {
+	if len(pos.configs.All()) == 0 && cr.Spec.TracingConfig == nil {
 		return baseCfg, nil
-	}
-	var globalConfigOpts globalAlertmanagerConfig
-	if err := yaml.Unmarshal(baseCfg, &globalConfigOpts); err != nil {
-		return nil, fmt.Errorf("cannot parse global config options: %w", err)
 	}
 	var baseYAMLCfg alertmanagerConfig
 	if err := yaml.Unmarshal(baseCfg, &baseYAMLCfg); err != nil {
@@ -63,49 +59,56 @@ func (pos *parsedObjects) buildConfig(cr *vmv1beta1.VMAlertmanager, baseCfg []by
 			})
 		}
 	}
-	var subRoutes []yaml.MapSlice
-	var timeIntervals []yaml.MapSlice
-	pos.configs.ForEachCollectSkipInvalid(func(cfg *vmv1beta1.VMAlertmanagerConfig) error {
-		if !build.MustSkipRuntimeValidation() {
-			if err := cfg.Validate(); err != nil {
-				return err
-			}
+
+	if len(pos.configs.All()) > 0 {
+		var globalConfigOpts globalAlertmanagerConfig
+		if err := yaml.Unmarshal(baseCfg, &globalConfigOpts); err != nil {
+			return nil, fmt.Errorf("cannot parse global config options: %w", err)
 		}
-		var receiverCfgs []yaml.MapSlice
-		for _, receiver := range cfg.Spec.Receivers {
-			receiverCfg, err := buildReceiver(cfg, receiver, &globalConfigOpts, ac)
+		var subRoutes []yaml.MapSlice
+		var timeIntervals []yaml.MapSlice
+		pos.configs.ForEachCollectSkipInvalid(func(cfg *vmv1beta1.VMAlertmanagerConfig) error {
+			if !build.MustSkipRuntimeValidation() {
+				if err := cfg.Validate(); err != nil {
+					return err
+				}
+			}
+			var receiverCfgs []yaml.MapSlice
+			for _, receiver := range cfg.Spec.Receivers {
+				receiverCfg, err := buildReceiver(cfg, receiver, &globalConfigOpts, ac)
+				if err != nil {
+					return err
+				}
+				if len(receiverCfg) > 0 {
+					receiverCfgs = append(receiverCfgs, receiverCfg)
+				}
+			}
+			mtis, err := buildGlobalTimeIntervals(cfg)
 			if err != nil {
 				return err
 			}
-			if len(receiverCfg) > 0 {
-				receiverCfgs = append(receiverCfgs, receiverCfg)
+			if cfg.Spec.Route != nil {
+				route, err := buildRoute(cfg, cfg.Spec.Route, true, cr)
+				if err != nil {
+					return err
+				}
+				subRoutes = append(subRoutes, route)
 			}
-		}
-		mtis, err := buildGlobalTimeIntervals(cfg)
-		if err != nil {
-			return err
-		}
-		if cfg.Spec.Route != nil {
-			route, err := buildRoute(cfg, cfg.Spec.Route, true, cr)
-			if err != nil {
-				return err
+			baseYAMLCfg.Receivers = append(baseYAMLCfg.Receivers, receiverCfgs...)
+			for _, rule := range cfg.Spec.InhibitRules {
+				baseYAMLCfg.InhibitRules = append(baseYAMLCfg.InhibitRules, buildInhibitRule(cfg.Namespace, rule, !cr.Spec.DisableNamespaceMatcher))
 			}
-			subRoutes = append(subRoutes, route)
+			if len(mtis) > 0 {
+				timeIntervals = append(timeIntervals, mtis...)
+			}
+			return nil
+		})
+		if len(subRoutes) > 0 {
+			baseYAMLCfg.Route.Routes = append(baseYAMLCfg.Route.Routes, subRoutes...)
 		}
-		baseYAMLCfg.Receivers = append(baseYAMLCfg.Receivers, receiverCfgs...)
-		for _, rule := range cfg.Spec.InhibitRules {
-			baseYAMLCfg.InhibitRules = append(baseYAMLCfg.InhibitRules, buildInhibitRule(cfg.Namespace, rule, !cr.Spec.DisableNamespaceMatcher))
+		if len(timeIntervals) > 0 {
+			baseYAMLCfg.TimeIntervals = append(baseYAMLCfg.TimeIntervals, timeIntervals...)
 		}
-		if len(mtis) > 0 {
-			timeIntervals = append(timeIntervals, mtis...)
-		}
-		return nil
-	})
-	if len(subRoutes) > 0 {
-		baseYAMLCfg.Route.Routes = append(baseYAMLCfg.Route.Routes, subRoutes...)
-	}
-	if len(timeIntervals) > 0 {
-		baseYAMLCfg.TimeIntervals = append(baseYAMLCfg.TimeIntervals, timeIntervals...)
 	}
 	if cr.Spec.TracingConfig != nil {
 		tracingCfg, err := buildTracingConfig(cr, ac)

--- a/internal/controller/operator/factory/vmalertmanager/config_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/config_test.go
@@ -67,6 +67,66 @@ func TestBuildConfig(t *testing.T) {
 		assert.Equal(t, o.want, string(data))
 	}
 
+	// tracing without discovered objects
+	f(opts{
+		cr: &vmv1beta1.VMAlertmanager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: vmv1beta1.VMAlertmanagerSpec{
+				EnforcedNamespaceLabel:  "alert-namespace",
+				ConfigNamespaceSelector: &metav1.LabelSelector{},
+				TracingConfig: &vmv1beta1.VMAlertmanagerTracingConfig{
+					Endpoint: "http://example.com",
+					TLSConfig: &vmv1beta1.TLSClientConfig{
+						CASecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "ca",
+							},
+							Key: "key",
+						},
+					},
+					Compression: "gzip",
+					HTTPHeaders: map[string]string{
+						"name": "value",
+					},
+				},
+			},
+		},
+		baseCfg: []byte(`global:
+ time_out: 1min
+ smtp_smarthost: some:443
+`),
+		predefinedObjects: []runtime.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			},
+		},
+		want: `global:
+  smtp_smarthost: some:443
+  time_out: 1min
+route:
+  receiver: blackhole
+receivers:
+- name: blackhole
+templates: []
+tracing:
+  tls_config:
+    ca_file: /etc/alertmanager/tls_assets/default_ca_key
+  compression: gzip
+  http_headers:
+    name: value
+  endpoint: http://example.com
+`,
+	})
+
 	// override the top namespace matcher
 	f(opts{
 		cr: &vmv1beta1.VMAlertmanager{

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -62,7 +62,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
 				Eventually(func() error {
 					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 				if verify != nil {
 					var created vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
 				Eventually(func() error {
 					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 				for _, step := range steps {
 					if step.setup != nil {
@@ -162,7 +162,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
 					Eventually(func() error {
 						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 					var updated vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1983

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vmalertmanager` ignoring tracing config when no `VMAlertmanagerConfig` CRs are collected. Tracing settings from the `VMAlertmanager` resource are now applied even without discovered configs.

- **Bug Fixes**
  - Apply tracing config when no `VMAlertmanagerConfig` objects are found (fixes #1983).
  - Add unit test for the tracing-only config path.

<sup>Written for commit 49c70d0ce85c75da93cabec7fef6da2dabb8831f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

