### PR TITLE
test: add tests for useProxyProtocol setting

### DIFF
--- a/test/e2e/vlagent_test.go
+++ b/test/e2e/vlagent_test.go
@@ -375,6 +375,25 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 					Expect(hasVolumeMount(vmc.VolumeMounts, "/var/run/secrets/kubernetes.io/serviceaccount")).To(HaveOccurred())
 				},
 			),
+			Entry("with UseProxyProtocol", "proxy-protocol",
+				&vmv1.VLAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1.VLAgentSpec{
+						CommonAppsParams: vmv1beta1.CommonAppsParams{
+							ReplicaCount: ptr.To[int32](1),
+							ExtraArgs: map[string]string{
+								"httpListenAddr.useProxyProtocol": "true",
+							},
+						},
+						RemoteWrite: []vmv1.VLAgentRemoteWriteSpec{{URL: "http://localhost:9428/internal/insert"}},
+					},
+				},
+				nil,
+				func(cr *vmv1.VLAgent) {},
+			),
 		)
 		type testStep struct {
 			setup  func(*vmv1.VLAgent)

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -54,6 +54,86 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				},
 			},
 		}
+		DescribeTable("should create vlcluster",
+			func(name string, cr *vmv1.VLCluster, verify func(cr *vmv1.VLCluster)) {
+				cr.Name = name
+				cr.Namespace = namespace
+				nsn.Name = name
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				Eventually(func() error {
+					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
+				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				if verify != nil {
+					var created vmv1.VLCluster
+					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
+					verify(&created)
+				}
+			},
+			Entry("with UseProxyProtocol on all components", "proxy-protocol",
+				&vmv1.VLCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+					},
+					Spec: vmv1.VLClusterSpec{
+						VLInsert: &vmv1.VLInsert{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						VLSelect: &vmv1.VLSelect{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						VLStorage: &vmv1.VLStorage{
+							RetentionPeriod: "1",
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+					},
+				},
+				nil,
+			),
+			Entry("with RequestsLoadBalancer enabled", "with-lb",
+				&vmv1.VLCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+					},
+					Spec: vmv1.VLClusterSpec{
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
+							Enabled: true,
+						},
+						VLInsert: &vmv1.VLInsert{},
+						VLSelect: &vmv1.VLSelect{},
+						VLStorage: &vmv1.VLStorage{
+							RetentionPeriod: "1",
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+							},
+						},
+					},
+				},
+				func(cr *vmv1.VLCluster) {
+					var dep appsv1.Deployment
+					nss := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer)}
+					Expect(k8sClient.Get(ctx, nss, &dep)).ToNot(HaveOccurred())
+					var svc corev1.Service
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
+					Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)))
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
+					Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)))
+				},
+			),
+		)
+
 		type testStep struct {
 			setup  func(*vmv1.VLCluster)
 			modify func(*vmv1.VLCluster)

--- a/test/e2e/vlsingle_test.go
+++ b/test/e2e/vlsingle_test.go
@@ -153,6 +153,23 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						Expect(ts.Containers[0].VolumeMounts[1].Name).To(Equal("unused"))
 
 					}),
+				Entry("with UseProxyProtocol", "proxy-protocol",
+					&vmv1.VLSingle{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+						},
+						Spec: vmv1.VLSingleSpec{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+							RetentionPeriod: "1",
+						},
+					},
+					func(cr *vmv1.VLSingle) {},
+				),
 			)
 
 			baseVLSingle := &vmv1.VLSingle{

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -387,6 +387,65 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					Expect(vmc.VolumeMounts).To(HaveLen(5))
 					Expect(hasVolumeMount(vmc.VolumeMounts, "/var/run/secrets/kubernetes.io/serviceaccount")).ToNot(HaveOccurred())
 				}),
+			Entry("with UseProxyProtocol in deployment mode", "proxy-protocol-deploy",
+				&vmv1beta1.VMAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1beta1.VMAgentSpec{
+						CommonAppsParams: vmv1beta1.CommonAppsParams{
+							ReplicaCount: ptr.To[int32](1),
+							ExtraArgs: map[string]string{
+								"httpListenAddr.useProxyProtocol": "true",
+							},
+						},
+						RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
+							{URL: "http://localhost:8428"},
+						},
+					},
+				}, nil, func(cr *vmv1beta1.VMAgent) {},
+			),
+			Entry("with UseProxyProtocol in statefulset mode", "proxy-protocol-sts",
+				&vmv1beta1.VMAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1beta1.VMAgentSpec{
+						CommonAppsParams: vmv1beta1.CommonAppsParams{
+							ReplicaCount: ptr.To[int32](1),
+							ExtraArgs: map[string]string{
+								"httpListenAddr.useProxyProtocol": "true",
+							},
+						},
+						StatefulMode: true,
+						RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
+							{URL: "http://localhost:8428"},
+						},
+					},
+				}, nil, func(cr *vmv1beta1.VMAgent) {},
+			),
+			Entry("with UseProxyProtocol in daemonset mode", "proxy-protocol-ds",
+				&vmv1beta1.VMAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1beta1.VMAgentSpec{
+						CommonAppsParams: vmv1beta1.CommonAppsParams{
+							ReplicaCount: ptr.To[int32](1),
+							ExtraArgs: map[string]string{
+								"httpListenAddr.useProxyProtocol": "true",
+							},
+						},
+						DaemonSetMode: true,
+						RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
+							{URL: "http://localhost:8428"},
+						},
+					},
+				}, nil, func(cr *vmv1beta1.VMAgent) {},
+			),
 		)
 		type testStep struct {
 			setup  func(*vmv1beta1.VMAgent)

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -337,6 +337,80 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 					}
 				},
 			),
+			Entry("with UseProxyProtocol on all components", "proxy-protocol",
+				&vmv1beta1.VMCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1beta1.VMClusterSpec{
+						RetentionPeriod: "1",
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						VMInsert: &vmv1beta1.VMInsert{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+					},
+				},
+				nil,
+			),
+			Entry("with RequestsLoadBalancer enabled", "with-lb",
+				&vmv1beta1.VMCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1beta1.VMClusterSpec{
+						RetentionPeriod: "1",
+						RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
+							Enabled: true,
+						},
+						VMStorage: &vmv1beta1.VMStorage{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+							},
+						},
+						VMSelect: &vmv1beta1.VMSelect{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+							},
+						},
+						VMInsert: &vmv1beta1.VMInsert{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+							},
+						},
+					},
+				},
+				func(cr *vmv1beta1.VMCluster) {
+					var lbDep appsv1.Deployment
+					nss := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer)}
+					Expect(k8sClient.Get(ctx, nss, &lbDep)).ToNot(HaveOccurred())
+					var svc corev1.Service
+					Expect(k8sClient.Get(ctx, nss, &svc)).ToNot(HaveOccurred())
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
+					Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
+				},
+			),
 		)
 	})
 	Context("update", func() {

--- a/test/e2e/vmsingle_test.go
+++ b/test/e2e/vmsingle_test.go
@@ -493,6 +493,17 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						},
 					},
 				),
+				Entry("by enabling UseProxyProtocol", "proxy-protocol", false,
+					baseSingle.DeepCopy(),
+					testStep{
+						modify: func(cr *vmv1beta1.VMSingle) {
+							cr.Spec.ExtraArgs = map[string]string{
+								"httpListenAddr.useProxyProtocol": "true",
+							}
+						},
+						verify: func(cr *vmv1beta1.VMSingle) {},
+					},
+				),
 			)
 		},
 		)

--- a/test/e2e/vtcluster_test.go
+++ b/test/e2e/vtcluster_test.go
@@ -39,6 +39,57 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 			})).ToNot(HaveOccurred())
 			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VTCluster{})
 		})
+
+		DescribeTable("should create", func(name string, cr *vmv1.VTCluster, verify func(cr *vmv1.VTCluster)) {
+			nsn.Name = name
+			cr.Name = name
+			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			Eventually(func() error {
+				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
+			}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+
+			var created vmv1.VTCluster
+			Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
+			verify(&created)
+		},
+			Entry("with UseProxyProtocol on all components", "proxy-protocol",
+				&vmv1.VTCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      nsn.Name,
+					},
+					Spec: vmv1.VTClusterSpec{
+						Storage: &vmv1.VTStorage{
+							RetentionPeriod: "1",
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						Select: &vmv1.VTSelect{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+						Insert: &vmv1.VTInsert{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+						},
+					},
+				},
+				func(cr *vmv1.VTCluster) {},
+			),
+		)
+
 		baseVTCluster := &vmv1.VTCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,

--- a/test/e2e/vtsingle_test.go
+++ b/test/e2e/vtsingle_test.go
@@ -153,6 +153,23 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 						Expect(ts.Containers[0].VolumeMounts[1].Name).To(Equal("unused"))
 
 					}),
+				Entry("with UseProxyProtocol", "proxy-protocol",
+					&vmv1.VTSingle{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+						},
+						Spec: vmv1.VTSingleSpec{
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								ReplicaCount: ptr.To[int32](1),
+								ExtraArgs: map[string]string{
+									"httpListenAddr.useProxyProtocol": "true",
+								},
+							},
+							RetentionPeriod: "1",
+						},
+					},
+					func(cr *vmv1.VTSingle) {},
+				),
 			)
 
 			baseVTSingle := &vmv1.VTSingle{


### PR DESCRIPTION
Ensure that we configure correct healthchecks for components with proxy protocol enabled on all deployment types.

Previously we had issues with that, hopefully https://github.com/VictoriaMetrics/operator/pull/1916 has fixed all of those