### PR TITLE
Reconcile and track status tests

### DIFF
--- a/internal/controller/operator/reconcile_and_track_status_test.go
+++ b/internal/controller/operator/reconcile_and_track_status_test.go
@@ -13,15 +13,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
 
 func TestReconcileAndTrackStatus(t *testing.T) {
+	nsn := types.NamespacedName{Name: "test-vmalert", Namespace: "default"}
+
 	type opts struct {
 		object     *vmv1beta1.VMAlert
-		cb         func() (ctrl.Result, error)
+		cb         func(client.Client) (ctrl.Result, error)
 		wantStatus vmv1beta1.UpdateStatus
 		wantResult ctrl.Result
 		wantErr    bool
@@ -30,7 +33,9 @@ func TestReconcileAndTrackStatus(t *testing.T) {
 	f := func(o opts) {
 		t.Helper()
 		fclient := k8stools.GetTestClientWithObjects([]runtime.Object{o.object})
-		result, err := reconcileAndTrackStatus(context.Background(), fclient, o.object, o.cb)
+		result, err := reconcileAndTrackStatus(context.Background(), fclient, o.object, func() (ctrl.Result, error) {
+			return o.cb(fclient)
+		})
 		if o.wantErr {
 			assert.Error(t, err)
 		} else {
@@ -39,125 +44,172 @@ func TestReconcileAndTrackStatus(t *testing.T) {
 		assert.Equal(t, o.wantResult, result)
 
 		got := &vmv1beta1.VMAlert{}
-		assert.NoError(t, fclient.Get(context.Background(), types.NamespacedName{
-			Name:      o.object.Name,
-			Namespace: o.object.Namespace,
-		}, got))
+		assert.NoError(t, fclient.Get(context.Background(), nsn, got))
 		assert.Equal(t, o.wantStatus, got.Status.UpdateStatus)
 	}
 
-	// paused object: callback not called, status set to paused
+	noop := func(_ client.Client) (ctrl.Result, error) { return ctrl.Result{}, nil }
+
+	// object created (no prior status): callback succeeds → operational
 	f(opts{
 		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
-			Spec: vmv1beta1.VMAlertSpec{
-				CommonAppsParams: vmv1beta1.CommonAppsParams{
-					Paused: true,
-				},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       vmv1beta1.VMAlertSpec{SelectAllByDefault: true},
+		},
+		cb:         noop,
+		wantStatus: vmv1beta1.UpdateStatusOperational,
+	})
+
+	// spec unchanged: callback succeeds → operational
+	unchangedSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: true}
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       unchangedSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				LastAppliedSpec: unchangedSpec.DeepCopy(),
 			},
 		},
-		cb: func() (ctrl.Result, error) {
+		cb:         noop,
+		wantStatus: vmv1beta1.UpdateStatusOperational,
+	})
+
+	// retryable conflict error, operational → expanding
+	opSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: true}
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       opSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational},
+				LastAppliedSpec: opSpec.DeepCopy(),
+			},
+		},
+		cb: func(_ client.Client) (ctrl.Result, error) {
+			return ctrl.Result{}, k8serrors.NewConflict(schema.GroupResource{Group: "apps", Resource: "deployments"}, "test", fmt.Errorf("conflict"))
+		},
+		wantStatus: vmv1beta1.UpdateStatusExpanding,
+	})
+
+	// retryable wait interrupted, operational → expanding
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       opSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational},
+				LastAppliedSpec: opSpec.DeepCopy(),
+			},
+		},
+		cb: func(_ client.Client) (ctrl.Result, error) {
+			return ctrl.Result{}, wait.ErrorInterrupted(fmt.Errorf("timeout"))
+		},
+		wantStatus: vmv1beta1.UpdateStatusExpanding,
+	})
+
+	// operational → expanding → operational
+	prevSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: true}
+	newSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: false}
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       newSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational},
+				LastAppliedSpec: prevSpec.DeepCopy(),
+			},
+		},
+		cb: func(c client.Client) (ctrl.Result, error) {
+			got := &vmv1beta1.VMAlert{}
+			assert.NoError(t, c.Get(context.Background(), nsn, got))
+			assert.Equal(t, vmv1beta1.UpdateStatusExpanding, got.Status.UpdateStatus)
+			return ctrl.Result{}, nil
+		},
+		wantStatus: vmv1beta1.UpdateStatusOperational,
+	})
+
+	pausedSpec := vmv1beta1.VMAlertSpec{
+		SelectAllByDefault: true,
+		CommonAppsParams:   vmv1beta1.CommonAppsParams{Paused: true},
+	}
+	// object created as paused: callback not called, status set to paused
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       pausedSpec,
+		},
+		cb: func(_ client.Client) (ctrl.Result, error) {
 			t.Fatal("callback must not be called when object is paused")
 			return ctrl.Result{}, nil
 		},
 		wantStatus: vmv1beta1.UpdateStatusPaused,
 	})
 
-	// object created, status set to operational
+	// operational → paused
 	f(opts{
 		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
-			Spec: vmv1beta1.VMAlertSpec{
-				SelectAllByDefault: true,
-			},
-		},
-		cb: func() (ctrl.Result, error) {
-			return ctrl.Result{}, nil
-		},
-		wantStatus: vmv1beta1.UpdateStatusOperational,
-	})
-
-	// spec unchanged, callback succeeds: status set to operational
-	unchangedSpec := vmv1beta1.VMAlertSpec{
-		SelectAllByDefault: true,
-	}
-	f(opts{
-		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
-			Spec: unchangedSpec,
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       pausedSpec,
 			Status: vmv1beta1.VMAlertStatus{
-				LastAppliedSpec: unchangedSpec.DeepCopy(),
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational},
+				LastAppliedSpec: pausedSpec.DeepCopy(),
 			},
 		},
-		cb: func() (ctrl.Result, error) {
+		cb: func(_ client.Client) (ctrl.Result, error) {
+			t.Fatal("callback must not be called when object is paused")
 			return ctrl.Result{}, nil
 		},
+		wantStatus: vmv1beta1.UpdateStatusPaused,
+	})
+
+	// paused → operational
+	unpausedSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: true}
+	f(opts{
+		object: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       unpausedSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusPaused},
+				LastAppliedSpec: pausedSpec.DeepCopy(),
+			},
+		},
+		cb:         noop,
 		wantStatus: vmv1beta1.UpdateStatusOperational,
 	})
 
-	// conflict: status set to expanding, no error returned
+	// expanding → operational
+	expandingSpec := vmv1beta1.VMAlertSpec{SelectAllByDefault: true}
 	f(opts{
 		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
+			Spec:       expandingSpec,
+			Status: vmv1beta1.VMAlertStatus{
+				StatusMetadata:  vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusExpanding},
+				LastAppliedSpec: expandingSpec.DeepCopy(),
 			},
 		},
-		cb: func() (ctrl.Result, error) {
-			return ctrl.Result{}, k8serrors.NewConflict(schema.GroupResource{Group: "apps", Resource: "deployments"}, "test", fmt.Errorf("conflict"))
-		},
-		wantStatus: vmv1beta1.UpdateStatusExpanding,
-		wantErr:    false,
-	})
-
-	// wait interrupted: status set to expanding, no error returned
-	f(opts{
-		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
-		},
-		cb: func() (ctrl.Result, error) {
-			return ctrl.Result{}, wait.ErrorInterrupted(fmt.Errorf("timeout"))
-		},
-		wantStatus: vmv1beta1.UpdateStatusExpanding,
-		wantErr:    false,
+		cb:         noop,
+		wantStatus: vmv1beta1.UpdateStatusOperational,
 	})
 
 	// non-retryable error: status set to failed, error returned
 	f(opts{
 		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
 		},
-		cb: func() (ctrl.Result, error) {
+		cb: func(_ client.Client) (ctrl.Result, error) {
 			return ctrl.Result{}, fmt.Errorf("some reconciliation error")
 		},
 		wantStatus: vmv1beta1.UpdateStatusFailed,
 		wantErr:    true,
 	})
 
-	// propagate custom result
+	// propagate custom result on success
 	f(opts{
 		object: &vmv1beta1.VMAlert{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmalert",
-				Namespace: "default",
-			},
+			ObjectMeta: metav1.ObjectMeta{Name: "test-vmalert", Namespace: "default"},
 		},
-		cb: func() (ctrl.Result, error) {
+		cb: func(_ client.Client) (ctrl.Result, error) {
 			return ctrl.Result{Requeue: true}, nil
 		},
 		wantStatus: vmv1beta1.UpdateStatusOperational,

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -62,7 +62,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
 				Eventually(func() error {
 					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 				if verify != nil {
 					var created vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -149,7 +149,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
 				Eventually(func() error {
 					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 				for _, step := range steps {
 					if step.setup != nil {
@@ -162,7 +162,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
 					Eventually(func() error {
 						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 					var updated vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())


### PR DESCRIPTION
Add unit tests for operational -> expanding, expanding -> operational, paused -> operational, operational -> paused state changes. Also adds cases for retryable conflict, retryable wait interrupt and non-retryable errors