### PR TITLE
fix: Race with Prometheus Operator CR conversion

### DIFF
--- a/internal/controller/operator/factory/k8stools/client_utils.go
+++ b/internal/controller/operator/factory/k8stools/client_utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -151,8 +152,10 @@ type ObjectWatcherForNamespaces struct {
 }
 
 // NewObjectWatcherForNamespaces returns a watcher for events at multiple namespaces for given object
-// in case of empty namespaces, performs cluster wide watch
-func NewObjectWatcherForNamespaces[T any, PT listing[T]](ctx context.Context, rclient client.WithWatch, crdTypeName string, namespaces []string) (watch.Interface, error) {
+// in case of empty namespaces, performs cluster wide watch.
+// An optional metav1.ListOptions may be passed to forward watch options (e.g. ResourceVersion,
+// SendInitialEvents, TimeoutSeconds) to the underlying watch requests.
+func NewObjectWatcherForNamespaces[T any, PT listing[T]](ctx context.Context, rclient client.WithWatch, crdTypeName string, namespaces []string, opts ...metav1.ListOptions) (watch.Interface, error) {
 	initMetrics.Do(func() {
 		metrics.Registry.MustRegister(activeWatchers, watchEventsTotalByType)
 	})
@@ -167,7 +170,13 @@ func NewObjectWatcherForNamespaces[T any, PT listing[T]](ctx context.Context, rc
 
 	addWatcher := func(ns string) error {
 		dst := PT(new(T))
-		w, err := rclient.Watch(localCtx, dst, &client.ListOptions{Namespace: ns})
+		listOpt := &client.ListOptions{Namespace: ns}
+		if len(opts) > 0 {
+			// copy to avoid aliasing across multiple addWatcher calls
+			rawOpts := opts[0]
+			listOpt.Raw = &rawOpts
+		}
+		w, err := rclient.Watch(localCtx, dst, listOpt)
 		if err != nil {
 			cancel()
 			return err

--- a/internal/controller/operator/vmprometheusconverter_controller.go
+++ b/internal/controller/operator/vmprometheusconverter_controller.go
@@ -98,7 +98,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1.PrometheusRuleList](ctx, rclient, "prometheus_rules", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1.PrometheusRuleList](ctx, rclient, "prometheus_rules", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1.PrometheusRule{},
@@ -126,7 +126,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1.PodMonitorList](ctx, rclient, "pod_monitors", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1.PodMonitorList](ctx, rclient, "pod_monitors", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1.PodMonitor{},
@@ -154,7 +154,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1.ServiceMonitorList](ctx, rclient, "service_monitors", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1.ServiceMonitorList](ctx, rclient, "service_monitors", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1.ServiceMonitor{},
@@ -182,7 +182,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1alpha1.AlertmanagerConfigList](ctx, rclient, "alertmanager_configs", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1alpha1.AlertmanagerConfigList](ctx, rclient, "alertmanager_configs", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1alpha1.AlertmanagerConfig{},
@@ -211,7 +211,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1.ProbeList](ctx, rclient, "probes", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1.ProbeList](ctx, rclient, "probes", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1.Probe{},
@@ -239,7 +239,7 @@ func NewConverterController(ctx context.Context, baseClient *kubernetes.Clientse
 					return &objects, nil
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return k8stools.NewObjectWatcherForNamespaces[promv1alpha1.ScrapeConfigList](ctx, rclient, "scrape_configs", baseConf.WatchNamespaces)
+					return k8stools.NewObjectWatcherForNamespaces[promv1alpha1.ScrapeConfigList](ctx, rclient, "scrape_configs", baseConf.WatchNamespaces, options)
 				},
 			}, rclient),
 			&promv1alpha1.ScrapeConfig{},
@@ -734,10 +734,20 @@ func isMetaEqual(left, right metav1.Object) bool {
 		equality.Semantic.DeepEqual(left.GetOwnerReferences(), right.GetOwnerReferences())
 }
 
+// discoveryClient is the subset of the Kubernetes discovery interface used by sharedAPIDiscoverer.
+// The real implementation is *kubernetes.Clientset; tests use a fake.
+type discoveryClient interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
 // sharedAPIDiscoverer must reduce GET API calls for kubernetes api server
 // it will perform 1 single GET request per group
 type sharedAPIDiscoverer struct {
-	baseClient *kubernetes.Clientset
+	baseClient discoveryClient
+	// pollInterval controls how often API discovery is retried.
+	// Zero means the default of 5 seconds, which is used in production.
+	// Tests may set a shorter interval to avoid slow test runs.
+	pollInterval time.Duration
 
 	mu               sync.Mutex
 	kindReadyByGroup map[string]map[string]chan struct{}
@@ -775,7 +785,12 @@ func (s *sharedAPIDiscoverer) subscribeForGroupKind(ctx context.Context, group, 
 }
 
 func (s *sharedAPIDiscoverer) startPollFor(ctx context.Context, group string) {
-	tick := time.NewTicker(time.Second * 5)
+	interval := s.pollInterval
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
 	for {
 		select {
 		case <-tick.C:
@@ -786,24 +801,40 @@ func (s *sharedAPIDiscoverer) startPollFor(ctx context.Context, group string) {
 				}
 				continue
 			}
+			// Collect channels to notify while holding the mutex, then send
+			// outside the lock. Sending while holding the lock would block any
+			// goroutine that calls subscribeForGroupKind concurrently, which
+			// could cause a late subscriber to miss its notification.
 			s.mu.Lock()
+			var toNotify []chan struct{}
 			for _, r := range api.APIResources {
 				notify, ok := s.kindReadyByGroup[group][r.Kind]
 				if ok {
-					notify <- struct{}{}
+					toNotify = append(toNotify, notify)
 					delete(s.kindReadyByGroup[group], r.Kind)
 				}
 			}
 			l := len(s.kindReadyByGroup[group])
+			if l == 0 {
+				// Remove the group entry so that any subscriber arriving after
+				// this goroutine exits will see the group as absent and start a
+				// fresh polling goroutine instead of waiting forever.
+				delete(s.kindReadyByGroup, group)
+			}
 			s.mu.Unlock()
+			for _, ch := range toNotify {
+				select {
+				case ch <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			}
 			if l == 0 {
 				// no subscribers left
-				// exit
 				return
 			}
 		case <-ctx.Done():
 			return
 		}
 	}
-
 }

--- a/internal/controller/operator/vmprometheusconverter_controller_test.go
+++ b/internal/controller/operator/vmprometheusconverter_controller_test.go
@@ -1,9 +1,13 @@
 package operator
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_mergeLabelsWithStrategy(t *testing.T) {
@@ -66,4 +70,96 @@ func Test_mergeLabelsWithStrategy(t *testing.T) {
 		mergeStrategy: MetaMergeLabelsVMPriority,
 		want:          map[string]string{"label1": "value1", "label2": "value4", "missinglabel": "value10"},
 	})
+}
+
+// newTestSharedAPIDiscoverer creates a sharedAPIDiscoverer with a fast poll interval
+// and a fake kubernetes client pre-configured with the given API resources.
+func newTestSharedAPIDiscoverer(resources []*metav1.APIResourceList) *sharedAPIDiscoverer {
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.Fake.Resources = resources
+	return &sharedAPIDiscoverer{
+		baseClient:       fakeClient.Discovery(),
+		pollInterval:     10 * time.Millisecond,
+		kindReadyByGroup: map[string]map[string]chan struct{}{},
+	}
+}
+
+// Test_sharedAPIDiscoverer_allSubscribersNotified verifies that all subscribers for a
+// group are notified when the API becomes available.
+func Test_sharedAPIDiscoverer_allSubscribersNotified(t *testing.T) {
+	const group = "monitoring.coreos.com/v1"
+	sd := newTestSharedAPIDiscoverer([]*metav1.APIResourceList{
+		{
+			GroupVersion: group,
+			APIResources: []metav1.APIResource{
+				{Kind: "ServiceMonitor"},
+				{Kind: "PodMonitor"},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	chSvc := sd.subscribeForGroupKind(ctx, group, "ServiceMonitor")
+	chPod := sd.subscribeForGroupKind(ctx, group, "PodMonitor")
+
+	for _, ch := range []chan struct{}{chSvc, chPod} {
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for subscriber notification")
+		}
+	}
+}
+
+// Test_sharedAPIDiscoverer_lateSubscriberGetsNotified verifies the fix for the
+// late-subscriber race: if a goroutine subscribes after the polling goroutine has
+// already exited (because all prior subscribers were notified), it must still be
+// notified via a new polling goroutine.
+//
+// Before the fix, startPollFor did not delete the group entry from kindReadyByGroup
+// when it exited. A late subscriber would add itself to the existing (orphaned) group
+// map, but no polling goroutine would ever send to its channel.
+func Test_sharedAPIDiscoverer_lateSubscriberGetsNotified(t *testing.T) {
+	const group = "monitoring.coreos.com/v1"
+	sd := newTestSharedAPIDiscoverer([]*metav1.APIResourceList{
+		{
+			GroupVersion: group,
+			APIResources: []metav1.APIResource{
+				{Kind: "ServiceMonitor"},
+				{Kind: "PodMonitor"},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First subscriber: triggers the initial polling goroutine.
+	chSvc := sd.subscribeForGroupKind(ctx, group, "ServiceMonitor")
+	select {
+	case <-chSvc:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for ServiceMonitor notification")
+	}
+
+	// After chSvc was notified, the polling goroutine exited and (with the fix)
+	// deleted the group entry. Give it a moment to complete the cleanup.
+	time.Sleep(20 * time.Millisecond)
+
+	// Verify the group was removed from the map, so a late subscriber starts fresh.
+	sd.mu.Lock()
+	_, groupExists := sd.kindReadyByGroup[group]
+	sd.mu.Unlock()
+	assert.False(t, groupExists, "group entry should be deleted after all subscribers notified")
+
+	// Late subscriber: the group is gone, so subscribeForGroupKind must recreate
+	// the entry and start a new polling goroutine.
+	chPod := sd.subscribeForGroupKind(ctx, group, "PodMonitor")
+	select {
+	case <-chPod:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for PodMonitor notification (late-subscriber bug)")
+	}
 }


### PR DESCRIPTION
Due to a race in the operator, conversion of Prometheus Operator CRs was unreliable and could fail to occur when the operator was first installed in a kube cluster.

This **LLM-assisted** patch fixes the issue, and adds a test case to validate the fix. I'll review the change more closely then mark this non-draft and ready for review, but quite frankly it would've taken me weeks to find and identify this issue so the effectiveness of my review may be questionable.

Details added in comment to keep LLM material separate: https://github.com/VictoriaMetrics/operator/pull/1999#issuecomment-4129206752

Fixes https://github.com/VictoriaMetrics/operator/issues/1998