### PR TITLE
defaults: do not use clusterversion for vl/vt requests load balancer tag

### DIFF
--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -598,7 +598,7 @@ func addVTClusterDefaults(objI any) {
 
 	if cr.Spec.RequestsLoadBalancer.Enabled {
 		cpLB := cp
-		cpLB.tag = setTag(cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion, cp.tag)
+		cpLB.tag = cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion
 		addRequestsLoadBalancerDefaults(&cr.Spec.RequestsLoadBalancer, &cpLB)
 	}
 }
@@ -638,7 +638,7 @@ func addVLClusterDefaults(objI any) {
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled {
 		cpLB := cp
-		cpLB.tag = setTag(cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion, cp.tag)
+		cpLB.tag = cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion
 		addRequestsLoadBalancerDefaults(&cr.Spec.RequestsLoadBalancer, &cpLB)
 	}
 }

--- a/internal/controller/operator/factory/build/defaults_test.go
+++ b/internal/controller/operator/factory/build/defaults_test.go
@@ -425,6 +425,49 @@ func TestClusterComponentVersionDefaults(t *testing.T) {
 			addVMClusterDefaults(cr)
 			return cr.Spec.RequestsLoadBalancer.Spec.Image.Tag
 		},
+	}
+
+	for _, creator := range crCreators {
+		f := func(o opts) {
+			t.Helper()
+			actual := creator(o)
+			if o.expectedTag != "" || o.imageTag != "" || o.clusterVersion != "" || o.componentVersion != "" {
+				assert.Equal(t, o.expectedTag, actual)
+			} else {
+				assert.NotEmpty(t, actual)
+			}
+		}
+
+		// clusterVersion only
+		f(opts{
+			clusterVersion: "v1.0.0",
+			expectedTag:    "v1.0.0",
+		})
+
+		// componentVersion only
+		f(opts{
+			componentVersion: "v1.1.0",
+			expectedTag:      "v1.1.0",
+		})
+
+		// both versions present, component takes precedence
+		f(opts{
+			clusterVersion:   "v1.0.0",
+			componentVersion: "v1.1.0",
+			expectedTag:      "v1.1.0",
+		})
+
+		// image tag takes highest precedence
+		f(opts{
+			clusterVersion:   "v1.0.0",
+			componentVersion: "v1.1.0",
+			imageTag:         "v1.2.0",
+			expectedTag:      "v1.2.0",
+		})
+	}
+
+	cfg := getCfg()
+	crCreators = map[string]func(o opts) string{
 		"VLCluster/RequestsLoadBalancer": func(o opts) string {
 			cr := &vmv1.VLCluster{
 				Spec: vmv1.VLClusterSpec{
@@ -467,44 +510,42 @@ func TestClusterComponentVersionDefaults(t *testing.T) {
 		},
 	}
 
-	for name, creator := range crCreators {
-		t.Run(name, func(t *testing.T) {
-			f := func(o opts) {
-				t.Helper()
-				actual := creator(o)
-				if o.expectedTag != "" || o.imageTag != "" || o.clusterVersion != "" || o.componentVersion != "" {
-					assert.Equal(t, o.expectedTag, actual)
-				} else {
-					assert.NotEmpty(t, actual)
-				}
+	for _, creator := range crCreators {
+		f := func(o opts) {
+			t.Helper()
+			actual := creator(o)
+			if o.expectedTag != "" || o.imageTag != "" || o.clusterVersion != "" || o.componentVersion != "" {
+				assert.Equal(t, o.expectedTag, actual)
+			} else {
+				assert.NotEmpty(t, actual)
 			}
+		}
 
-			// clusterVersion only
-			f(opts{
-				clusterVersion: "v1.0.0",
-				expectedTag:    "v1.0.0",
-			})
+		// clusterVersion only
+		f(opts{
+			clusterVersion: "v1.0.0",
+			expectedTag:    cfg.MetricsVersion,
+		})
 
-			// componentVersion only
-			f(opts{
-				componentVersion: "v1.1.0",
-				expectedTag:      "v1.1.0",
-			})
+		// componentVersion only
+		f(opts{
+			componentVersion: "v1.1.0",
+			expectedTag:      "v1.1.0",
+		})
 
-			// both versions present, component takes precedence
-			f(opts{
-				clusterVersion:   "v1.0.0",
-				componentVersion: "v1.1.0",
-				expectedTag:      "v1.1.0",
-			})
+		// both versions present, component takes precedence
+		f(opts{
+			clusterVersion:   "v1.0.0",
+			componentVersion: "v1.1.0",
+			expectedTag:      "v1.1.0",
+		})
 
-			// image tag takes highest precedence
-			f(opts{
-				clusterVersion:   "v1.0.0",
-				componentVersion: "v1.1.0",
-				imageTag:         "v1.2.0",
-				expectedTag:      "v1.2.0",
-			})
+		// image tag takes highest precedence
+		f(opts{
+			clusterVersion:   "v1.0.0",
+			componentVersion: "v1.1.0",
+			imageTag:         "v1.2.0",
+			expectedTag:      "v1.2.0",
 		})
 	}
 }


### PR DESCRIPTION
unset VL/VT clusterVersion for requests load balancer as it is not applicable for VMAuth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the RequestsLoadBalancer ComponentVersion directly for VT/VL clusters, ignoring the clusterVersion. The VMAuth tag is now independent from the cluster tag; image tag still overrides, and if only clusterVersion is set we fall back to the default metrics version.

<sup>Written for commit 01d4189149952e6cec1f5d743f1910ec9d461b88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

