### PR TITLE
do not use cluster tag for vm lb

### DIFF
--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -449,7 +449,7 @@ func addVMClusterDefaults(objI any) {
 	}
 	if cr.Spec.RequestsLoadBalancer.Enabled {
 		cpLB := cp
-		cpLB.tag = setTag(cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion, cp.tag)
+		cpLB.tag = cr.Spec.RequestsLoadBalancer.Spec.ComponentVersion
 		addRequestsLoadBalancerDefaults(&cr.Spec.RequestsLoadBalancer, &cpLB)
 	}
 }

--- a/internal/controller/operator/factory/build/defaults_test.go
+++ b/internal/controller/operator/factory/build/defaults_test.go
@@ -405,26 +405,6 @@ func TestClusterComponentVersionDefaults(t *testing.T) {
 			addVLClusterDefaults(cr)
 			return cr.Spec.VLStorage.Image.Tag
 		},
-		"VMCluster/RequestsLoadBalancer": func(o opts) string {
-			cr := &vmv1beta1.VMCluster{
-				Spec: vmv1beta1.VMClusterSpec{
-					ClusterVersion: o.clusterVersion,
-					RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
-						Enabled: true,
-						Spec: vmv1beta1.VMAuthLoadBalancerSpec{
-							ComponentVersion: o.componentVersion,
-							CommonAppsParams: vmv1beta1.CommonAppsParams{
-								Image: vmv1beta1.Image{
-									Tag: o.imageTag,
-								},
-							},
-						},
-					},
-				},
-			}
-			addVMClusterDefaults(cr)
-			return cr.Spec.RequestsLoadBalancer.Spec.Image.Tag
-		},
 	}
 
 	for _, creator := range crCreators {
@@ -468,6 +448,26 @@ func TestClusterComponentVersionDefaults(t *testing.T) {
 
 	cfg := getCfg()
 	crCreators = map[string]func(o opts) string{
+		"VMCluster/RequestsLoadBalancer": func(o opts) string {
+			cr := &vmv1beta1.VMCluster{
+				Spec: vmv1beta1.VMClusterSpec{
+					ClusterVersion: o.clusterVersion,
+					RequestsLoadBalancer: vmv1beta1.VMAuthLoadBalancer{
+						Enabled: true,
+						Spec: vmv1beta1.VMAuthLoadBalancerSpec{
+							ComponentVersion: o.componentVersion,
+							CommonAppsParams: vmv1beta1.CommonAppsParams{
+								Image: vmv1beta1.Image{
+									Tag: o.imageTag,
+								},
+							},
+						},
+					},
+				},
+			}
+			addVMClusterDefaults(cr)
+			return cr.Spec.RequestsLoadBalancer.Spec.Image.Tag
+		},
 		"VLCluster/RequestsLoadBalancer": func(o opts) string {
 			cr := &vmv1.VLCluster{
 				Spec: vmv1.VLClusterSpec{


### PR DESCRIPTION
vm cluster components versioning is not compatible with vmauth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop deriving the VMCluster RequestsLoadBalancer image tag from the cluster tag. The LB now uses its own `componentVersion`, fixing version mismatches with `vmauth`.

- **Bug Fixes**
  - In `addVMClusterDefaults`, set LB tag to `RequestsLoadBalancer.Spec.ComponentVersion` instead of `setTag(..., cluster tag)`.
  - Updated tests to assert the LB image tag equals the component version.

<sup>Written for commit f44f5d5ec8f5dc938f23f6343b295897d228593d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

