### PR TITLE
fix: sort any unhealthy zone first in VMDistributed

### DIFF
--- a/internal/controller/operator/factory/vmdistributed/zone.go
+++ b/internal/controller/operator/factory/vmdistributed/zone.go
@@ -45,8 +45,10 @@ func (zs *zones) Len() int {
 func (zs *zones) Less(i, j int) bool {
 	statusI := zs.vmclusters[i].Status
 	statusJ := zs.vmclusters[j].Status
-	if statusI.UpdateStatus != statusJ.UpdateStatus {
-		return statusI.UpdateStatus == vmv1beta1.UpdateStatusFailed
+	isNonOperationalI := statusI.UpdateStatus != vmv1beta1.UpdateStatusOperational
+	isNonOperationalJ := statusJ.UpdateStatus != vmv1beta1.UpdateStatusOperational
+	if isNonOperationalI != isNonOperationalJ {
+		return isNonOperationalI
 	}
 	isZeroI := zs.vmclusters[i].CreationTimestamp.IsZero()
 	isZeroJ := zs.vmclusters[j].CreationTimestamp.IsZero()

--- a/internal/controller/operator/factory/vmdistributed/zone_test.go
+++ b/internal/controller/operator/factory/vmdistributed/zone_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -244,4 +245,189 @@ func TestWaitForEmptyPQ(t *testing.T) {
 		timeout: 500 * time.Millisecond,
 		errMsg:  "context deadline exceeded",
 	})
+}
+
+func TestZonesSorting(t *testing.T) {
+	now := metav1.Now()
+
+	type opts struct {
+		clusters   []*vmv1beta1.VMCluster
+		hasChanges []bool
+		wantNames  []string
+		validate   func(*zones)
+	}
+
+	f := func(o opts) {
+		t.Helper()
+		zs := &zones{
+			vmclusters: o.clusters,
+			vmagents:   make([]*vmv1beta1.VMAgent, len(o.clusters)),
+			hasChanges: make([]bool, len(o.clusters)),
+		}
+		for i := range o.clusters {
+			zs.vmagents[i] = &vmv1beta1.VMAgent{
+				ObjectMeta: metav1.ObjectMeta{Name: o.clusters[i].Name},
+			}
+		}
+		if o.hasChanges != nil {
+			zs.hasChanges = o.hasChanges
+		}
+		sort.Sort(zs)
+		names := make([]string, len(zs.vmclusters))
+		for i, c := range zs.vmclusters {
+			names[i] = c.Name
+		}
+		assert.Equal(t, o.wantNames, names)
+		if o.validate != nil {
+			o.validate(zs)
+		}
+	}
+
+	// failed zones sort before operational
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-a", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-b", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusFailed}},
+			},
+		},
+		wantNames: []string{"zone-b", "zone-a"},
+	})
+
+	// failed and expanding zones are both non-operational: fall through to next criteria (name)
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-b", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusFailed}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-a", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusExpanding}},
+			},
+		},
+		wantNames: []string{"zone-a", "zone-b"},
+	})
+
+	// expanding zones sort before operational
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-a", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-b", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusExpanding}},
+			},
+		},
+		wantNames: []string{"zone-b", "zone-a"},
+	})
+
+	// new zones (zero CreationTimestamp) sort before existing
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-existing", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-new"},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+		},
+		wantNames: []string{"zone-new", "zone-existing"},
+	})
+
+	// higher observedGeneration sorts first
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-low-gen", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 1},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-high-gen", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 5},
+				},
+			},
+		},
+		wantNames: []string{"zone-high-gen", "zone-low-gen"},
+	})
+
+	// equal status and generation sorts by name ascending
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-b", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 3},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-a", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 3},
+				},
+			},
+		},
+		wantNames: []string{"zone-a", "zone-b"},
+	})
+
+	// priority order: status > zero-timestamp > generation > name
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-operational-gen1", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 1},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-operational-gen5", CreationTimestamp: now},
+				Status: vmv1beta1.VMClusterStatus{
+					StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational, ObservedGeneration: 5},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-new"},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-failed", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusFailed}},
+			},
+		},
+		wantNames: []string{"zone-failed", "zone-new", "zone-operational-gen5", "zone-operational-gen1"},
+	})
+
+	// swap keeps vmagents and hasChanges in sync
+	f(opts{
+		clusters: []*vmv1beta1.VMCluster{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-b", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "zone-a", CreationTimestamp: now},
+				Status:     vmv1beta1.VMClusterStatus{StatusMetadata: vmv1beta1.StatusMetadata{UpdateStatus: vmv1beta1.UpdateStatusOperational}},
+			},
+		},
+		hasChanges: []bool{true, false},
+		wantNames:  []string{"zone-a", "zone-b"},
+		validate: func(zs *zones) {
+			assert.Equal(t, zs.vmclusters[0].Name, zs.vmagents[0].Name)
+			assert.Equal(t, zs.vmclusters[1].Name, zs.vmagents[1].Name)
+			assert.False(t, zs.hasChanges[0])
+			assert.True(t, zs.hasChanges[1])
+		},
+	})
+
 }


### PR DESCRIPTION
Any zone which is not Operating - that is Failed on Extending - should be picked up first. The reason for this is that timed out zone update won't change the zone status to Failed and it would be considered functioning.

This commit also adds unit tests for zone sorting