### PR TITLE
vmdistributed: filter vmauth targets by owner reference

### DIFF
--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -12,14 +12,24 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 )
 
-func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) vmv1beta1.TargetRef {
+func hasOwnerReference(owners []metav1.OwnerReference, owner *metav1.OwnerReference) bool {
+	for i := range owners {
+		o := &owners[i]
+		if o.APIVersion == owner.APIVersion && o.Kind == owner.Kind && o.Name == owner.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, owner *metav1.OwnerReference, excludeIds ...int) vmv1beta1.TargetRef {
 	var nsns []vmv1beta1.NamespacedName
 	for i := range vmClusters {
 		if slices.Contains(excludeIds, i) {
 			continue
 		}
 		vmCluster := vmClusters[i]
-		if vmCluster.CreationTimestamp.IsZero() {
+		if vmCluster.CreationTimestamp.IsZero() || !hasOwnerReference(vmCluster.OwnerReferences, owner) {
 			continue
 		}
 		nsns = append(nsns, vmv1beta1.NamespacedName{
@@ -44,14 +54,14 @@ func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) vm
 	}
 }
 
-func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, excludeIds ...int) vmv1beta1.TargetRef {
+func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, owner *metav1.OwnerReference, excludeIds ...int) vmv1beta1.TargetRef {
 	var nsns []vmv1beta1.NamespacedName
 	for i := range vmAgents {
 		if slices.Contains(excludeIds, i) {
 			continue
 		}
 		vmAgent := vmAgents[i]
-		if vmAgent.CreationTimestamp.IsZero() {
+		if vmAgent.CreationTimestamp.IsZero() || !hasOwnerReference(vmAgent.OwnerReferences, owner) {
 			continue
 		}
 		nsns = append(nsns, vmv1beta1.NamespacedName{
@@ -89,8 +99,9 @@ func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, 
 		Spec: *cr.Spec.VMAuth.Spec.DeepCopy(),
 	}
 	var targetRefs []vmv1beta1.TargetRef
-	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, excludeIds...))
-	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, excludeIds...))
+	owner := cr.AsOwner()
+	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, &owner, excludeIds...))
+	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, &owner, excludeIds...))
 	vmAuth.Spec.DefaultTargetRefs = targetRefs
 	return &vmAuth
 }

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
@@ -20,12 +20,13 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/reconcile"
 )
 
-func newVMAgent(name, namespace string) *vmv1beta1.VMAgent {
+func newVMAgent(name, namespace string, owner metav1.OwnerReference) *vmv1beta1.VMAgent {
 	return &vmv1beta1.VMAgent{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: metav1.Now(),
+			OwnerReferences:   []metav1.OwnerReference{owner},
 		},
 		Spec: vmv1beta1.VMAgentSpec{
 			CommonAppsParams: vmv1beta1.CommonAppsParams{
@@ -35,13 +36,14 @@ func newVMAgent(name, namespace string) *vmv1beta1.VMAgent {
 	}
 }
 
-func newVMCluster(name, namespace, version string) *vmv1beta1.VMCluster {
+func newVMCluster(name, namespace, version string, owner metav1.OwnerReference) *vmv1beta1.VMCluster {
 	return &vmv1beta1.VMCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              name,
 			Namespace:         namespace,
 			Labels:            map[string]string{"tenant": "default"},
 			CreationTimestamp: metav1.Now(),
+			OwnerReferences:   []metav1.OwnerReference{owner},
 		},
 		Spec: vmv1beta1.VMClusterSpec{
 			ClusterVersion: version,
@@ -84,26 +86,6 @@ func beforeEach(o opts) *testData {
 		vmagents:   make([]*vmv1beta1.VMAgent, 0, zonesCount),
 	}
 	namespace := "default"
-	dzs := make([]vmv1alpha1.VMDistributedZone, zonesCount)
-	var predefinedObjects []runtime.Object
-	for i := range dzs {
-		name := fmt.Sprintf("vmcluster-%d", i+1)
-		vmCluster := newVMCluster(name, namespace, "v1.0.0")
-		vmAgent := newVMAgent(name, namespace)
-		zs.vmclusters = append(zs.vmclusters, vmCluster)
-		zs.vmagents = append(zs.vmagents, vmAgent)
-		predefinedObjects = append(predefinedObjects, vmAgent, vmCluster)
-		dzs[i] = vmv1alpha1.VMDistributedZone{
-			Name: name,
-			VMCluster: vmv1alpha1.VMDistributedZoneCluster{
-				Name: name,
-				Spec: vmCluster.Spec,
-			},
-			VMAgent: vmv1alpha1.VMDistributedZoneAgent{
-				Name: name,
-			},
-		}
-	}
 	cr := &vmv1alpha1.VMDistributed{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "VMDistributed",
@@ -114,11 +96,31 @@ func beforeEach(o opts) *testData {
 			Namespace: namespace,
 		},
 		Spec: vmv1alpha1.VMDistributedSpec{
-			Zones: dzs,
+			Zones: make([]vmv1alpha1.VMDistributedZone, zonesCount),
 			VMAuth: vmv1alpha1.VMDistributedAuth{
 				Name: "vmauth-proxy",
 			},
 		},
+	}
+	var predefinedObjects []runtime.Object
+	owner := cr.AsOwner()
+	for i := range cr.Spec.Zones {
+		name := fmt.Sprintf("vmcluster-%d", i+1)
+		vmCluster := newVMCluster(name, namespace, "v1.0.0", owner)
+		vmAgent := newVMAgent(name, namespace, owner)
+		zs.vmclusters = append(zs.vmclusters, vmCluster)
+		zs.vmagents = append(zs.vmagents, vmAgent)
+		predefinedObjects = append(predefinedObjects, vmAgent, vmCluster)
+		cr.Spec.Zones[i] = vmv1alpha1.VMDistributedZone{
+			Name: name,
+			VMCluster: vmv1alpha1.VMDistributedZoneCluster{
+				Name: name,
+				Spec: vmCluster.Spec,
+			},
+			VMAgent: vmv1alpha1.VMDistributedZoneAgent{
+				Name: name,
+			},
+		}
 	}
 
 	predefinedObjects = append(predefinedObjects, cr)


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1988
downside of this solution: migration from distributed chart with a use of existing vmauth may lead to downtime till first zone becomes available after upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters VMAuth targets to include only VMAgents and VMClusters owned by the same VMDistributed. This prevents VMAuth from routing to unrelated resources.

- **Bug Fixes**
  - Added owner reference check when building VMAuth `DefaultTargetRefs` for VMAgents and VMClusters.
  - Updated tests to set owner references and validate the new filtering behavior.

<sup>Written for commit 983c6af8b8a40a63b69d347001b3ce8d6c50f8ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

