### PR TITLE
minor logs update

### DIFF
--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -280,7 +280,7 @@ func performRollingUpdateOnSts(ctx context.Context, rclient client.Client, obj *
 
 	updatedNeeded := len(podsForUpdate) != 0 || len(updatedPods) != 0
 	if !updatedNeeded {
-		l.Info("no pod needs to be updated")
+		l.V(1).Info("no pod needs to be updated")
 		return nil
 	}
 


### PR DESCRIPTION
set log level for `no pod needs to be updated` message to debug

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the log level for "no pod needs to be updated" during StatefulSet rolling updates from Info to debug (`l.V(1).Info`) to reduce noise in production logs. The message now shows only when verbose logging is enabled.

<sup>Written for commit 269acd554b124a29d58b07f6611e12c63597c4a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

