### PR TITLE
internal/config: update VM_METRICS_VERSION to v1.139.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,11 +13,12 @@ aliases:
 
 ## tip
 
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.139.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.139.0) version
 **Update note 1**: deprecated env variables for Prometheus CRs conversion `VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR`, `VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROBE`, `VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG`. Use `-controller.disableReconcileFor` command-line flag with comma-separated list of controller names, that should be disabled.
 **Update note 2**: removed `operator_prometheus_converter_watch_events_total` metric since migration of Prometheus object watchers to controllers made this counter obsolete.
 **Update note 3**: made `controller.prometheusCRD.resyncPeriod` command line flag noop, which was relevant to Prometheus object watchers.
 
-* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.138.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.138.0) version
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.139.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.139.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.48.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.48.0).
 
 * FEATURE: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): VMSingle reuses vmagent implementation to allow scraping and relabelling. See [#1694](https://github.com/VictoriaMetrics/operator/issues/1694)

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,6 +1,6 @@
 | Environment variables |
 | --- |
-| VM_METRICS_VERSION: `v1.138.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
+| VM_METRICS_VERSION: `v1.139.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
 | VM_LOGS_VERSION: `v1.48.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
 | VM_ANOMALY_VERSION: `v1.28.5` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a> |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a> |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ var (
 	initConf sync.Once
 
 	defaultEnvs = map[string]string{
-		"VM_METRICS_VERSION":  "v1.138.0",
+		"VM_METRICS_VERSION":  "v1.139.0",
 		"VM_LOGS_VERSION":     "v1.48.0",
 		"VM_ANOMALY_VERSION":  "v1.28.5",
 		"VM_TRACES_VERSION":   "v0.7.0",


### PR DESCRIPTION
Changelog [v1.139.0](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md#v11390)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped default `VM_METRICS_VERSION` to v1.139.0 so new deployments use VictoriaMetrics v1.139.0 by default. Updated `internal/config` and docs to keep defaults in sync.

<sup>Written for commit 5310c68e5ccc04a83b1ae627ab80fa9f849fc4f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

