### PR TITLE
vmdistributed: use default vmauth stub, when no healthy zones available

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,7 +45,7 @@ aliases:
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): apply scrape class relabellings before job ones. See [#1997](https://github.com/VictoriaMetrics/operator/issues/1997).
 * BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/) and [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): render %SHARD_NUM% placeholder when shard count is greater than 0. See [#2001](https://github.com/VictoriaMetrics/operator/issues/2001).
 * BUGFIX: [vlcluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [vtcluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): do not ignore ExtraStorageNodes for select, when default storage is disabled. See [#1910](https://github.com/VictoriaMetrics/operator/issues/1910).
-* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): skip VMAuth update, when there're no healthy zones available
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): use default stub, when no VMAuth backends are available
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -11,6 +11,8 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 )
 
+const defaultStubAddr = "http://127.0.0.1:9999"
+
 func hasOwnerReference(owners []metav1.OwnerReference, owner *metav1.OwnerReference) bool {
 	for i := range owners {
 		o := &owners[i]
@@ -37,18 +39,25 @@ func vmClusterTargetRef(vmClusters []*vmv1beta1.VMCluster, owner *metav1.OwnerRe
 			Namespace: vmCluster.Namespace,
 		})
 	}
-	return vmv1beta1.TargetRef{
+	ref := vmv1beta1.TargetRef{
 		Name: "read",
 		URLMapCommon: vmv1beta1.URLMapCommon{
 			LoadBalancingPolicy: ptr.To("first_available"),
 			RetryStatusCodes:    []int{500, 502, 503},
 		},
 		Paths: []string{"/select/.+", "/admin/tenants"},
-		CRD: &vmv1beta1.CRDRef{
+	}
+	if len(nsns) > 0 {
+		ref.CRD = &vmv1beta1.CRDRef{
 			Kind:    "VMCluster/vmselect",
 			Objects: nsns,
-		},
+		}
+	} else {
+		ref.Static = &vmv1beta1.StaticRef{
+			URL: defaultStubAddr,
+		}
 	}
+	return ref
 }
 
 func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, owner *metav1.OwnerReference, excludeIds ...int) vmv1beta1.TargetRef {
@@ -66,18 +75,25 @@ func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, owner *metav1.OwnerReferenc
 			Namespace: vmAgent.Namespace,
 		})
 	}
-	return vmv1beta1.TargetRef{
+	ref := vmv1beta1.TargetRef{
 		Name: "write",
 		URLMapCommon: vmv1beta1.URLMapCommon{
 			LoadBalancingPolicy: ptr.To("first_available"),
 			RetryStatusCodes:    []int{500, 502, 503},
 		},
 		Paths: []string{"/insert/.+", "/api/v1/write"},
-		CRD: &vmv1beta1.CRDRef{
+	}
+	if len(nsns) > 0 {
+		ref.CRD = &vmv1beta1.CRDRef{
 			Kind:    "VMAgent",
 			Objects: nsns,
-		},
+		}
+	} else {
+		ref.Static = &vmv1beta1.StaticRef{
+			URL: defaultStubAddr,
+		}
 	}
+	return ref
 }
 
 func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) *vmv1beta1.VMAuth {
@@ -94,15 +110,8 @@ func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, 
 	}
 	var targetRefs []vmv1beta1.TargetRef
 	owner := cr.AsOwner()
-	if ref := vmAgentTargetRef(vmAgents, &owner, excludeIds...); len(ref.CRD.Objects) > 0 {
-		targetRefs = append(targetRefs, ref)
-	}
-	if ref := vmClusterTargetRef(vmClusters, &owner, excludeIds...); len(ref.CRD.Objects) > 0 {
-		targetRefs = append(targetRefs, ref)
-	}
-	if len(targetRefs) == 0 {
-		return nil
-	}
+	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, &owner, excludeIds...))
+	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, &owner, excludeIds...))
 	vmAuth.Spec.DefaultTargetRefs = targetRefs
 	return &vmAuth
 }

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
@@ -317,7 +317,7 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 		},
 	})
 
-	// skip VMAuth update, when distributed setup has a single zone
+	// update VMAuth even, when no healthy zones available
 	f(args{
 		cr: &vmv1alpha1.VMDistributed{
 			ObjectMeta: objectMeta,
@@ -379,6 +379,11 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
 			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
 
+			// update LB config
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+
 			// reconcile VMCluster
 			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
 			{Verb: "Update", Kind: "VMCluster", Resource: vmClusterName},
@@ -390,6 +395,7 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 
 			// reconcile VMAuth
 			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
 			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
 		},
 	})


### PR DESCRIPTION
skip updating vmauth, when no healthy zones available since vmauth fails when no backends available

Alternatively makes sense to render some static content, when no backend set, but requires either adding a sidecar or adding this feature to vmauth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a static stub backend for `VMAuth` in `vmdistributed` when no healthy zones are available so configs stay valid and the controller still updates `VMAuth`.

- **Bug Fixes**
  - Always populate `DefaultTargetRefs` for read/write; if no `VMCluster`/`VMAgent` targets exist, set `Static` to `http://127.0.0.1:9999`.
  - Add a reconcile test to verify `VMAuth` updates even with no healthy zones; update the changelog.

<sup>Written for commit aeee07754e7aaf2a10cd4b596751bcf96454ddad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

