### PR TITLE
chore: migrate Openshift bundles to FBC

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+catalog/
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,6 @@ jobs:
           make manifests
           make api-gen
           make docs
-          make olm
           # check for uncommited changes to crds, docs or API
           git diff --exit-code
           make test

--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -38,7 +38,7 @@ jobs:
           repository: ${{ matrix.repo.upstream }}
           ref: main
           token: ${{ secrets.VM_BOT_GH_TOKEN }}
-          path: __k8s-operatorhub-repo
+          path: __operatorhub-repo
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
@@ -48,15 +48,20 @@ jobs:
           passphrase: ${{ secrets.VM_BOT_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-          workdir: __k8s-operatorhub-repo
+          workdir: __operatorhub-repo
 
       - uses: dawidd6/action-download-artifact@1f8785ff7a5130826f848e7f72725c85d241860f
         with:
           name: olm
-          workflow: main.yaml
+          workflow: release.yaml
           github_token: ${{ secrets.VM_BOT_GH_TOKEN }}
           run_id: ${{ github.event.workflow_run.id }}
           path: bundle
+
+      - name: Install opm
+        run: |
+          curl -sL https://github.com/operator-framework/operator-registry/releases/download/v1.65.0/linux-amd64-opm -o /usr/local/bin/opm
+          chmod +x /usr/local/bin/opm
 
       - name: Add operatorhub bundle
         id: update
@@ -65,41 +70,47 @@ jobs:
             echo "No bundle directory found"
             exit 1;
           fi
-          OPERATOR_DIR=__k8s-operatorhub-repo/operators/victoriametrics-operator
-          CATALOGS_DIR=__k8s-operatorhub-repo/catalogs
+          CATALOGS_DIR=__operatorhub-repo/catalogs
+          NEW_VERSION=$(ls bundle | head -1)
+          CATALOG_FILE=${CATALOGS_DIR}/latest/victoriametrics-operator/catalog.yaml
+          mkdir -p ${CATALOGS_DIR}/latest/victoriametrics-operator
 
-          mkdir -p ${CATALOGS_DIR}
-          mkdir -p ${OPERATOR_DIR}
-
-          export OLD_VERSION=$(find ${OPERATOR_DIR}/* ! -path "*/catalog-templates" -maxdepth 0 -type d -exec basename {} \; | sort -V -r | head -1)
-          export OLD_ENTRY="victoriametrics-operator.v${OLD_VERSION}"
-
-          export NEW_VERSION=$(ls bundle | head -1)
-
-          if [ ! -z $OLD_VERSION ]; then
-            export MANIFEST_PATH=bundle/${NEW_VERSION}/manifests/victoriametrics-operator.clusterserviceversion.yaml
-            yq -i '.spec.replaces = "victoriametrics-operator.v" + strenv(OLD_VERSION)' $MANIFEST_PATH
+          # Save existing catalog as PREV_CATALOG before overwriting
+          if [ -f "${CATALOG_FILE}" ]; then
+            cp "${CATALOG_FILE}" /tmp/vm-prev-catalog.yaml
+            PREV_CATALOG=/tmp/vm-prev-catalog.yaml
           fi
 
-          mv bundle/* ${OPERATOR_DIR}/
-          if [ -f ${OPERATOR_DIR}/Makefile ]; then
-            if [ ! -z $OLD_VERSION ]; then
-              yq -i -I2 '.catalog_templates.[].replaces = strenv(OLD_ENTRY)' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
-            fi
-          else
-            rm -f ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
+          PREVIOUS_VERSION=$(yq 'select(.schema == "olm.channel") | .entries[0].name' \
+            ${PREV_CATALOG} 2>/dev/null || true)
+
+          opm render bundle/${NEW_VERSION} --output=yaml > /tmp/vm-bundle-rendered.yaml
+          yq 'select(.schema == "olm.package")' "${PREV_CATALOG}" > /tmp/vm-catalog-header.yaml
+          echo "---" >> /tmp/vm-catalog-header.yaml
+          yq '.entries[] | select(.schema == "olm.channel")' \
+            bundle/${NEW_VERSION}/catalog-templates/latest.yaml >> /tmp/vm-catalog-header.yaml
+
+          # Include previous bundles from PREV_CATALOG (excludes current version to avoid duplicates)
+          yq "select(.schema == \"olm.bundle\" and .name != \"victoriametrics-operator.v${NEW_VERSION}\")" \
+            "${PREV_CATALOG}" > /tmp/vm-prev-bundles.yaml
+          yq eval-all '.' /tmp/vm-catalog-header.yaml /tmp/vm-bundle-rendered.yaml /tmp/vm-prev-bundles.yaml > ${CATALOG_FILE}
+
+          if [ -n "${PREVIOUS_VERSION}" ]; then
+            yq -i '(select(.schema == "olm.channel") | .entries[0]).replaces = strenv(PREVIOUS_VERSION)' ${CATALOG_FILE}
           fi
+          opm validate ${CATALOGS_DIR}/latest/victoriametrics-operator
+
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: ${{ steps.update.outputs.VERSION != '' }}
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
-          add-paths: operators/victoriametrics-operator,catalogs
+          add-paths: catalogs
           commit-message: 'victoriametrics-operator: ${{ steps.update.outputs.VERSION }}'
           signoff: true
           committer: "Github Actions <${{ steps.import-gpg.outputs.email }}>"
-          path: __k8s-operatorhub-repo
+          path: __operatorhub-repo
           push-to-fork: ${{ matrix.repo.fork }}
           branch: vm-operator-release-${{ steps.update.outputs.VERSION }}
           token: ${{ secrets.VM_BOT_GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           make lint test build build-installer
           echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
           echo ${{secrets.QUAY_ACCESSKEY}} | docker login quay.io --username '${{secrets.QUAY_USER}}' --password-stdin
-          make publish
+          TAG=${TAG} make publish
           TAG=${TAG} REGISTRY=quay.io make olm
           gh release upload ${{github.event.release.tag_name}} ./dist/install-no-webhook.yaml#install-no-webhook.yaml --clobber || echo "fix me NOT enough security permissions"
           gh release upload ${{github.event.release.tag_name}} ./dist/install-with-webhook.yaml#install-with-webhook.yaml --clobber || echo "fix me NOT enough security permissions"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ report.xml
 /bin/
 /build*
 /bundle*
+/catalog*
 release
 operator.zip
 coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 
 olm: operator-sdk opm yq docs
 	$(eval DIGEST = $(shell $(CONTAINER_TOOL) buildx imagetools inspect $(REGISTRY)/$(ORG)/$(REPO):$(TAG)-ubi --format "{{print .Manifest.Digest}}"))
-	rm -rf bundle*
+	rm -rf bundle* catalog
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manifests && \
 		$(KUSTOMIZE) edit set image manager=$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)
@@ -291,17 +291,29 @@ olm: operator-sdk opm yq docs
 		-q --overwrite --version $(VERSION) \
 		--channels=beta --default-channel=beta --output-dir=bundle/$(VERSION)
 	$(OPERATOR_SDK) bundle validate ./bundle/$(VERSION)
-	cp config/manifests/release-config.yaml bundle/$(VERSION)/
-	$(YQ) -i '.metadata.annotations.containerImage = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"' \
-		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
-	$(YQ) -i '.spec.install.spec.deployments[0].spec.template.containers[0].image = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"' \
-		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
-	$(YQ) -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"' \
-		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
-	$(YQ) -i '.spec.relatedImages = [{"name": "victoriametrics-operator", "image": "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"}]' \
+	$(YQ) -i '.metadata.annotations.containerImage = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)" | .spec.install.spec.deployments[0].spec.template.containers[0].image = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)" | .spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"' \
 		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.annotations."com.redhat.openshift.versions" = "v4.12-v4.21"' \
 		bundle/$(VERSION)/metadata/annotations.yaml
+	mkdir -p bundle/$(VERSION)/catalog-templates catalog/latest
+	$(YQ) '.entries[] | select(.schema == "olm.channel") | .entries[] | select(.name != "victoriametrics-operator.v$(VERSION)") | .name' config/manifests/catalog-templates/latest.yaml > /tmp/vm-prev-names.txt
+	$(YQ) '.entries[] | select(.schema == "olm.channel") | .entries[] | select(.name != "victoriametrics-operator.v$(VERSION)") | .replaces | select(.)' config/manifests/catalog-templates/latest.yaml > /tmp/vm-prev-replaces.txt
+	PREV_HEAD=$$(grep -Fxvf /tmp/vm-prev-replaces.txt /tmp/vm-prev-names.txt | head -1); \
+	test -n "$$PREV_HEAD" || { echo "Error: could not determine previous channel head from catalog template"; exit 1; }; \
+	PREV_HEAD="$$PREV_HEAD" $(YQ) -i '(.entries[] | select(.schema == "olm.channel")).entries = [{"name": "victoriametrics-operator.v$(VERSION)", "replaces": strenv(PREV_HEAD)}] + (.entries[] | select(.schema == "olm.channel") | .entries | map(select(.name != "victoriametrics-operator.v$(VERSION)")))' \
+		config/manifests/catalog-templates/latest.yaml; \
+	PREV_HEAD="$$PREV_HEAD" $(YQ) -i '.spec.relatedImages = [{"name": "victoriametrics-operator", "image": "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"}] | .spec.replaces = strenv(PREV_HEAD)' \
+		bundle/$(VERSION)/manifests/victoriametrics-operator.clusterserviceversion.yaml
+	cp config/manifests/catalog-templates/latest.yaml bundle/$(VERSION)/catalog-templates/latest.yaml
+	{ $(YQ) '.entries[] | select(.schema == "olm.package")' \
+	      bundle/$(VERSION)/catalog-templates/latest.yaml; \
+	  echo "---"; \
+	  $(YQ) '(.entries[] | select(.schema == "olm.channel")) | .entries = [.entries[0]]' \
+	      bundle/$(VERSION)/catalog-templates/latest.yaml; \
+	  $(OPM) render bundle/$(VERSION) --output=yaml | \
+	      $(YQ) '(select(.schema == "olm.bundle") | .image) = "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)" | (select(.schema == "olm.bundle") | .relatedImages) = [{"name": "victoriametrics-operator", "image": "$(REGISTRY)/$(ORG)/$(REPO)@$(DIGEST)"}]'; \
+	} > catalog/latest/catalog.yaml
+	$(OPM) validate catalog/latest
 
 ##@ Deployment
 

--- a/config/manifests/catalog-templates/latest.yaml
+++ b/config/manifests/catalog-templates/latest.yaml
@@ -1,0 +1,69 @@
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: victoriametrics-operator
+    defaultChannel: beta
+    icon:
+      base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAARuklEQVR4nOxdfawc11U/5+7nc/xmdl+WuvkwoaX8UTXkA5WAmsQfaRulpC44IuEjLaoS2hSswh8JSFAELVQCCYKg0DZOUwSFELWBNtSBVGka28ShIkXEDo7yB3GD65rU9PnNzD5/7NfMQWf23H3X45l9W8fu3n0zP+nZ783O3jln7u/ee+7vnjujoECuURAg5ygIkHMUBMg5CgLkHAUBco6CADlHQYCcoyBAzlEQIOcoCJBzFATIOQoC5BwFAXKOggA5R0GAnKMgQM5RECDnKAiQcxQEyDkKAuQcBQFyjoIAOUdBgJyjIEDOURAg5ygIkHOUp23ABQZm/J72N435O/nZmkHyJswSMOVHV1QkP+cTyugx9bWSPzOHWSKArgCUyg0n+E651WrNdTqderVarQ8Gg1o5iqpUqZSjKCojYlxpRIRKqQH2+4OBUr1yudzt9Xqder3eWVxcPA0AgwmuVRL76AIR8ILAdgLomzpIaWGlVqu1gXq9jYR4BQFcgYiXE9ElAPADANAEAAcBLiKAOQCoypBXWuWaoVyvhwCnCeAkALQBwAOA7yLiq0T0bQQ4jESHsVo9sri4eCyFkCjXm5SsU4GNBECppDNaXaPRuAIArkWi6wDgGgD4EQC4DADmENPdIMrslbM+SC1olfK5hzgKAP8NAPsJ8TkAeN73/cOJ08tCBKuGCtsIUDYrfmF+/m2k1E8DwDsA4EpErI7OJNJ3Une3+sai4VfyfxOrBYHmMfN/8zrxsBQXZJCEiHoAcBAAnsIo+qel5eV/y/Jx2rCJACVpIeWm43wIEO9BgCv1jZXWpocCNOKBaftAxrivbSuPeo0hUQ8C0U6v3X5AfLCGBNO+eRpx5TcajS1I9NeIyN09V7oeP80AcBZgBoIlRIxnD0R0mBDf7/v+HoPwU4UNN3RU+QpgN6x0oaUJArZZAVd0qIewCGCrLSSwRglURL8Dw8rvSsS+ViofxJeq+Dby1QbYQIC4FyKAQ2hbiHyeQSsK0iE5NPUe2AYCxF1guVq9NyI6oBBrPAeftlEXAD32jX1kX+VYEQMIlARM1abjPIVK3ShxQHXahp0n9Hj8pyh6xmu33yEEVzaohTb0AKCjZb4xXru9iYgek4CpP+OjAtvejyuf6DH2TSq/ZEPlg2WBFok91Ol2P1+r1TYqxLdKN2nDfP97BUnkX4mIPusHwZ1yfOqRvwmbCABy05SQ4Mv1Wq2OiJsMsWVWSBC3bkQsEdEf+UHw63Lcim7fhG0EAFPp63S7T83V68uIeIscCy0atrIQivjD9t7rBcHHDZutG85sIoBKuUHl053Os7Vq9ZsKcbucYzMJhpXPzZzol7wg2GmsCJq+pfk6FdjWpaZ1kRUOpBYc5xZCfEKODSzMZhrZhETvWmq3v6JtT5xn1TBgS0sqNZvNq+TGJDV/voFVvqFquBR8EhHLKTd2muiLTSfZRqn8asJGvYAVia9W9L42EGDYrUfRg03X/UgGCWJN4Hi7/Y2Q6BoCeJWja0sEI57jV9gmto1tlMo3bVupfPYxih60ZSibugEGTiulPt5wnN8zpkmmfXxDK+12++VBGF5FRC+JVjBNEvRkjv8S28S2Sbdv2qR9CNk39lGSSKyATQQgIgKl1EebrvuAsaRqdpXcpVaWl5cXvSC4lqJo3xRJoNW9fWwL25Qy5mvBh9gn9k3yGqwIAMEyAgwXhYg6iHjPguv+oxwPEwFfX/7ueu32jVNQDZPq3o1si9hkVr5OAQP2hX1i30xfbYBNBNCoxOsAiLc1XXevjKcDaV0aA90zeEGwnYh2SkyQnG6db8S9UjzmE+3ka8vxZA5jRf6uxj4g3iZrG5ULaNs5wUYCgKydcxe7qek4/+k4zoLu/o1zdBCFXhB8CAA+hoh6uLgQ06yRusfXkmuioU1oxMMA28y2sw82L2zZSgAYkUCpt5QQX3Bd9416Smicoyu6tOT7PL7+iihwyUp5rYjJxmXzNfhaRmxiki0eithWtpltt7nywRIC6ISQtHk9k4DH28sUwAHXdd+qp4TGOTpYrHhB8EAEkNUtnytGww2XzdeQVp4cbuJglG1kW9lmtj2t8mnFrqnHAtYQQBG9CGfeHA0eb/nYegXw3ILj3KKnhMY5pIcI3/cfwyh6GwCcOg+CkRZ4TnGZXLYR6ZuVH0/92Da2kW0Vm88Y87Vviuig6fs0YQMB4i40UurPiOiEZAQlK02nUSMgPtFwnPcZs4GzVcPl5a9HAFcR0dHXIBj1JNg7GhJdzWVmqHsxyWKbhlI1ZkjVffaNfWRfTd+nCVsIUPJ9/7AKw+uI6LhUWhoJwni9WKnPLbjufSNSpAhGQRAcigB+lIj2n4NWoAWe/VzGGIEnrmy2hW2SLiE5bQXpSZhMx9lH2TVkRVLI1LsgA3Erb7Val4b9/j5EfENGAKWjcRUR3e8HwX1yPJlooXsN1XTdXYj4UzImqzE6fGhM8/7FC4Jtcr3kRo7RtRqu+ycK8V7ZwwApjUqT6ZVSpXLD4uLi/xYbQ7IRt/xWqzUf9vt7EfHaDBLobJsyAfyd5/vvk+OZFdV03U8i4q/KTp1BIsGEZHNXmf8lok95QbAjWUbyGs1G428R4L0y3pdS7qeu/OdLlcrmxcXF5YwVwqnBNgKA2XIXXPdJQHy7tNw0EUV3rU96QfCujNY6Wn5tOs6dgPj7iPjGtAsT0TeB6He9dvvh5HeTtjVd9wlEvHk124Doa0tBcHOGbVOHjQSARMv9PCLeITc6GfSBOV6DUls8zwtSWpmpDZQWXPftgHgDRNHG+FOljgDRvqUg+Jo+J2WaF5fZbDZdiKI9iHjNmN5pIMT8ghcEP5f0ySbYRIDkvpCzum8iCjP2CGoSfIsQN/u+/z8pS7IwYQtMOycuq9Fo/BAS8dD0g2MqP5JcwHHDiDV7YKxISjBQSmzFjgOqTrf7z3P1OiLiVuMzTHyPu9wFILqrVq8/1e12jxiCjUZkPH+gZGw6NUmVmpEkAs/XEfF1GQJPNIxN442gH/OC4DfNPICErVOP/jVsmAYySpdeeum6lCnUmVJvFO0YI/VqwchRAN9oOs6tKesHoANIaeXmT9rDG4bdvuPcymVy2WkCzxlScRTtGCMVx1NZ8dWKxmcDAeJs31MnT36u0WhsTln501Jv2Wu3PwVEd8jxNKl31H2jUo8vuO4vCwnSIvTVbIp7FS6Dy5LjaQLPSCpm22Ib0xNB4xVC9pF9NfY7TBW2EID/uVwB7Gk0GltTWi5pYiwFwaOEeJNRGWmCURRnlyB+xsgwoglbnR6G4gweLoOGWRxRmsCjScc2sW3GUvBZAST7xj6yr6bv04QNBIiBACdgmFH7dNNxfn6c1Ov7/m4a7hryM1RDJRlGoVLqow3XfUiOhzJ2Zz0ypmoIPA9JBk9oxiOmLXJtn21hm8ZJxewT+2b6agOsIQCttK4IlXqk4Tgf1nPulATRiu/7B0Cpq4nocIber4brLtRXiHc3XPfJVqs1L+dRIhjUUXmPz+Fz+TuGcpim7nHMcZhtiG05WyrWscqAfWGfdDxAFqW0W0MAo8sMiShSSn1iodH4g4wE0XiI8DzvW0KC5zP0fpTgkEnwzqjff5kro7Vu3SVGMBi3cD7Gn/E5fK4h8GSqe3zt2IazdYdRIij7wL4Yj7sBW6aAYMMYZKRL70bELcZcfyj1Ej3oBcE9cm6m3t9w3a8kKi6JgX54ExGdJoCDCoCnitwsN+LwKWRzxsOo0lppXzZ7ftUPgltWWydouu5ORPygIRVrjWCPFwRbbdgkYlMPYCLuniUZ5IMLrvtFOZ6cJuqKivwguJkAHpbhIO3Bkjo45M/mFOKPA+Jt/BP/DjAnn6UFeyvqHsDDfra0ayaCflEq/1xmId832ESAZIWhkSC6vek4zwBAbWyCqO+/NyK6X5I4KKV1KamkOEDkCpcfHeiVU+5JPJ3jMrlsvoYcz0oErcW2Im43EkEneSbhVGADAYY2IH5b/k4KPDo38Iam6z4/Pz/fGpMgqmR5+D5R5LJyA3UAWDYeH5vWQrXAw+XcJ2WnlRvHAGwb28i2ZkjFofh69Azfp4ipG6BbAwH8lfxdTWm5Okv4zeVS6QXHcd6UkSAat+Il37+fougX5fi55gaOehYui8vUvUdaIijbxLaxjWPyGKri62dN36cJGwgQSkbQngjgLnnCZlrLHSaIAlxSQjxwseP8REaCaDxEeO32IyIY9c4hN1DnAva4DC4rQ+CJZx5sSwlxP9uWsU6gexJmwV22PCMQLAtM9AMjfwaJviTHsqTX4bEo2uYtLz8+tnLWr39zVCo9jYivnzBFW0/zvqPC8KbjJ068lLHZcyjwzM+/G5TaNYm9hLhdEkutqHywpAfQCHVWLyi1SR7XniX1xjcPS6VdC657d4beHwdgXIGDKDJzAyM5PzQe5xrKsUjnFvB3pPLTBB69TnA322DYf3YuoPZBqU1GVrEVlQ+2rEgZiMfJTqfzyty6dY8B0S8g4kVGBWsoY/n1PfVard/pdvca6pv55pBKr9c70el2H6rVapcjwI/xXJwDOxymgcVLuLLjBzkW8YNgW6/XOzlG4ImarvvbiPjnohskN7HCKFsJwAOlftLzvP9IkYqnDpuGABPDp4IsLGykMHwGEa8YE1hRLK4A/IXn+78mx5Nd7Io402xeBRwgEl0PiK+PPyX6DiA+C0r9ved5L6xaRqPxCQT4sEwfk1nJYAwjh7FUunFpaemIbbmAGrYSABIpWHsR8eoJUrAe9YJALxcnRZq0PALdapPHkku5K4mgrvsFRLx9ghS1A6DU5owUNWtgMwHAuPHlpus+iYhbxwRyOkH0X72hUtcd84welXivT9oxDV1GTWzYNEZu1pW/W2yw6t0AabCdAGDewIbrPqoQf3aC1vdSPwy3nDhx4v9WaX1mWnga4u+uX7/+dZVSac+YOf6oF4qI/sEPgtuTttsKm2YBWRgJMnxjiejTY54FMBKMqqXSf/EUMEUwMjHudW9xwMZlcFmrVL7eTPJpo/LP1+bUCwrbZgFZOJcEUYcQP1Cfm9vX6XQOpSSIjoPO4NnCwSECOJROpGQi6G9kJIJai1khAJhJHKc7nd31avW7qNStGU8Q1a2vggDvn6vVXu50u/sT7/ZLw+g1dU3HuRMBvmyWlTh39ERQiqIdXhD8sZFONnWJd1LMEgFMlDvd7r/P1WovAsAdxrsFTRKMniqKSt1Wr9UGohWQsT9QJTJ+9AOdPoJK/aUcSxN4Vh4KCXC7127/TUYiqPWYhSAwC7qb3oxEX0WACqWngY82kxLA44D4W57nHUwrsNlsXglEf4gA7x6z2bOvr0WI7/R9f6/N07zVMMsEAK3RxxU31AoWMqZoZGQYQSz6ED0LAK/I528AxOuB6HrJGMra7Kmnmksyxz+YsQNpZjDrBADd+i6++OLLosGASfDDY7SCgfEk77Mg6d9pXT4YU8xDqlzefPz48aOz3PI11gIBQFfEhg0bLup2Ok8rxOvGkMB8p5+pA4x7N2Fc+RHRc7V6/aZjx46lrRPMJNYKASCxb3+XjONZgtGkMHMBH/d8f1vyWrOOWZ0FpCEavXKm03mkXqtdhsNkz+gcXzmjBR6OGz7jBYGZYWTNcu5rxVoiACQEo10JwSj6HpTPMCHw3DtrAs+kWGsEgKRgNFerHUXE92RoBWnQ+wd4OvCBpSD401kUeCbFWooBkhilbcnbRnZJd94zRCATkX6/L08DkWib8daPtH0GawJrmQAaplbwJUR8E6y8jl5X6mhmSEQvg1Lb18IcfxLkgQBgTNnKjUZjBxDdiQBvAYB18vkpAngREB/2ff+ThvY/89O81ZAXAkAyem+tW3fJoFrdwL+Xe71ji6dOvZp1boG1AxyjC4z7bM0iV84mkBYEFiiQL8xCSliBC4iCADlHQYCcoyBAzlEQIOcoCJBzFATIOQoC5BwFAXKOggA5R0GAnKMgQM5RECDnKAiQcxQEyDkKAuQcBQFyjoIAOUdBgJyjIEDOURAg5ygIkHMUBMg5CgLkHAUBco6CADnH/wcAAP//XWOHWC5Ltq8AAAAASUVORK5CYII=
+      mediatype: image/png
+  - schema: olm.channel
+    package: victoriametrics-operator
+    name: beta
+    entries:
+      - name: victoriametrics-operator.v0.68.4
+        replaces: victoriametrics-operator.v0.68.3
+      - name: victoriametrics-operator.v0.68.3
+        replaces: victoriametrics-operator.v0.68.2
+      - name: victoriametrics-operator.v0.68.2
+        replaces: victoriametrics-operator.v0.68.1
+      - name: victoriametrics-operator.v0.68.1
+        replaces: victoriametrics-operator.v0.67.0
+      - name: victoriametrics-operator.v0.67.0
+        replaces: victoriametrics-operator.v0.66.1
+      - name: victoriametrics-operator.v0.66.1
+        replaces: victoriametrics-operator.v0.66.0
+      - name: victoriametrics-operator.v0.66.0
+        replaces: victoriametrics-operator.v0.65.0
+      - name: victoriametrics-operator.v0.65.0
+        replaces: victoriametrics-operator.v0.64.1
+      - name: victoriametrics-operator.v0.64.1
+        replaces: victoriametrics-operator.v0.64.0
+      - name: victoriametrics-operator.v0.64.0
+        replaces: victoriametrics-operator.v0.63.0
+      - name: victoriametrics-operator.v0.63.0
+        replaces: victoriametrics-operator.v0.62.0
+      - name: victoriametrics-operator.v0.62.0
+        replaces: victoriametrics-operator.v0.61.2
+      - name: victoriametrics-operator.v0.61.2
+        replaces: victoriametrics-operator.v0.61.1
+      - name: victoriametrics-operator.v0.61.1
+        replaces: victoriametrics-operator.v0.61.0
+      - name: victoriametrics-operator.v0.61.0
+        replaces: victoriametrics-operator.v0.60.2
+      - name: victoriametrics-operator.v0.60.2
+        replaces: victoriametrics-operator.v0.60.1
+      - name: victoriametrics-operator.v0.60.1
+        replaces: victoriametrics-operator.v0.60.0
+      - name: victoriametrics-operator.v0.60.0
+        replaces: victoriametrics-operator.v0.59.2
+      - name: victoriametrics-operator.v0.59.2
+        replaces: victoriametrics-operator.v0.59.1
+      - name: victoriametrics-operator.v0.59.1
+        replaces: victoriametrics-operator.v0.59.0
+      - name: victoriametrics-operator.v0.59.0
+        replaces: victoriametrics-operator.v0.58.1
+      - name: victoriametrics-operator.v0.58.1
+        replaces: victoriametrics-operator.v0.58.0
+      - name: victoriametrics-operator.v0.58.0
+        replaces: victoriametrics-operator.v0.57.0
+      - name: victoriametrics-operator.v0.57.0
+        replaces: victoriametrics-operator.v0.56.0
+      - name: victoriametrics-operator.v0.56.0
+        replaces: victoriametrics-operator.v0.55.0
+      - name: victoriametrics-operator.v0.55.0
+        replaces: victoriametrics-operator.v0.54.1
+      - name: victoriametrics-operator.v0.54.1
+        replaces: victoriametrics-operator.v0.53.0
+      - name: victoriametrics-operator.v0.53.0
+        replaces: victoriametrics-operator.v0.52.0
+      - name: victoriametrics-operator.v0.52.0

--- a/config/manifests/release-config.yaml
+++ b/config/manifests/release-config.yaml
@@ -1,5 +1,0 @@
-catalog_templates:
-  - template_name: v4.12-v4.16.yaml
-    channels: [beta]
-  - template_name: latest.yaml
-    channels: [beta]


### PR DESCRIPTION
Cleanup release scripts and manifests, move most of the logic into Makefile.

See https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_onboarding/ for FBC details.

Fixes #2037 

TODO:
* [x] Find a way to test this safely
Generated 0.68.4 bundle using this Makefile and its identical to the generated catalog bundle
* [x] Support channels - beta / latest / lts?
Now defined in the file