### PR TITLE
vmbackup: add eula flag for upgrade tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ aliases:
 **Update note 1**: deprecated env variables for Prometheus CRs conversion `VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR`, `VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROBE`, `VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG`. Use `-controller.disableReconcileFor` command-line flag with comma-separated list of controller names, that should be disabled.
 **Update note 2**: removed `operator_prometheus_converter_watch_events_total` metric since migration of Prometheus object watchers to controllers made this counter obsolete.
 **Update note 3**: made `controller.prometheusCRD.resyncPeriod` command line flag noop, which was relevant to Prometheus object watchers.
+**Update note 4**: `-eula` flag is not set by default anymore for VMBackup and VMRestore. To avoid VMCluster/VMSingle rollouts set `spec.vmstorage.vmBackup.acceptEula: true` for VMCluster and `spec.vmBackup.acceptEula: true"` for VMSingle and replace it with `spec.license` during VMSingle/VMCluster upgrade.
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.139.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.139.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.49.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.49.0).

--- a/internal/controller/operator/factory/build/backup.go
+++ b/internal/controller/operator/factory/build/backup.go
@@ -55,15 +55,21 @@ func VMBackupManager(
 		fmt.Sprintf("-snapshot.createURL=%s", snapshotCreateURL),
 		fmt.Sprintf("-snapshot.deleteURL=%s", snapshotDeleteURL),
 	}
-
+	if cr.AcceptEULA {
+		args = append(args, "-eula")
+	}
 	if cr.LogLevel != nil {
 		args = append(args, fmt.Sprintf("-loggerLevel=%s", *cr.LogLevel))
 	}
 	if cr.LogFormat != nil {
 		args = append(args, fmt.Sprintf("-loggerFormat=%s", *cr.LogFormat))
 	}
-	for arg, value := range cr.ExtraArgs {
-		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+	for key, value := range cr.ExtraArgs {
+		arg := fmt.Sprintf("-%s", key)
+		if len(value) != 0 {
+			arg = fmt.Sprintf("%s=%s", arg, value)
+		}
+		args = append(args, arg)
 	}
 	if cr.Concurrency != nil {
 		args = append(args, fmt.Sprintf("-concurrency=%d", *cr.Concurrency))
@@ -169,15 +175,21 @@ func VMRestore(
 	args := []string{
 		fmt.Sprintf("-storageDataPath=%s", storagePath),
 	}
-
+	if cr.AcceptEULA {
+		args = append(args, "-eula")
+	}
 	if cr.LogLevel != nil {
 		args = append(args, fmt.Sprintf("-loggerLevel=%s", *cr.LogLevel))
 	}
 	if cr.LogFormat != nil {
 		args = append(args, fmt.Sprintf("-loggerFormat=%s", *cr.LogFormat))
 	}
-	for arg, value := range cr.ExtraArgs {
-		args = append(args, fmt.Sprintf("-%s=%s", arg, value))
+	for key, value := range cr.ExtraArgs {
+		arg := fmt.Sprintf("-%s", key)
+		if len(value) != 0 {
+			arg = fmt.Sprintf("%s=%s", arg, value)
+		}
+		args = append(args, arg)
 	}
 	if cr.Concurrency != nil {
 		args = append(args, fmt.Sprintf("-concurrency=%d", *cr.Concurrency))

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -819,6 +819,7 @@ var _ = Describe("operator upgrade", Label("upgrade"), func() {
 						Image: vmv1beta1.Image{
 							Tag: "v1.136.0-enterprise",
 						},
+						AcceptEULA: true,
 					}
 					cr.Spec.License = &vmv1beta1.License{
 						KeyRef: &corev1.SecretKeySelector{
@@ -841,6 +842,7 @@ var _ = Describe("operator upgrade", Label("upgrade"), func() {
 						Image: vmv1beta1.Image{
 							Tag: "v1.136.0-enterprise",
 						},
+						AcceptEULA: true,
 					}
 					cr.Spec.License = &vmv1beta1.License{
 						KeyRef: &corev1.SecretKeySelector{
@@ -863,6 +865,7 @@ var _ = Describe("operator upgrade", Label("upgrade"), func() {
 						Image: vmv1beta1.Image{
 							Tag: "v1.136.0-enterprise",
 						},
+						AcceptEULA: true,
 					}
 					cr.Spec.License = &vmv1beta1.License{
 						KeyRef: &corev1.SecretKeySelector{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `acceptEula` support for VMBackup/VMRestore and set it in upgrade tests for `v1.136.0-enterprise`. Also render empty `extraArgs` as `-flag` and update the CHANGELOG with EULA migration guidance.

- **Migration**
  - VMCluster: set `spec.vmstorage.vmBackup.acceptEula: true` to avoid rollouts; migrate to `spec.license` during upgrade.
  - VMSingle: set `spec.vmBackup.acceptEula: true` to avoid rollouts; migrate to `spec.license` during upgrade.

<sup>Written for commit 0a33bdf6e9960a041c7720f980a560eb2f8aba37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

