### PR TITLE
chore: skip load docker-image on podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,9 @@ load-kind: docker-build kind
 	else \
 		$(KUBECTL) cluster-info --context kind-kind; \
 	fi; \
-	$(KIND) load docker-image $(REGISTRY)/$(ORG)/$(REPO):$(TAG); \
+	if [ "$(CONTAINER_TOOL)" != "podman" ]; then \
+		$(KIND) load docker-image $(REGISTRY)/$(ORG)/$(REPO):$(TAG); \
+	fi
 
 deploy-kind: OVERLAY=config/base-with-webhook
 deploy-kind: load-kind deploy


### PR DESCRIPTION
kind crashes when load-image is used on podman. I think I'm the only one using it and I push images to local registry anyway, so lets skip this step when CONTAINER_TOOL is `podman`