### PR TITLE
feat: add update_message field to SlackConfig

### DIFF
--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -647,6 +647,10 @@ type SlackConfig struct {
 	// A list of Slack actions that are sent with each notification.
 	// +optional
 	Actions []SlackAction `json:"actions,omitempty"`
+	// Whether to update the original message in-place instead of sending a new one.
+	// available since alertmanager v0.32.0
+	// +optional
+	UpdateMessage *bool `json:"update_message,omitempty" yaml:"update_message,omitempty"`
 	// HTTP client configuration.
 	// +optional
 	HTTPConfig *HTTPConfig `json:"http_config,omitempty" yaml:"http_config,omitempty"`

--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -648,7 +648,8 @@ type SlackConfig struct {
 	// +optional
 	Actions []SlackAction `json:"actions,omitempty"`
 	// Whether to update the original message in-place instead of sending a new one.
-	// available since alertmanager v0.32.0
+	// Requires Slack Bot API and chat:write scope.
+	// Available since alertmanager v0.32.0.
 	// +optional
 	UpdateMessage *bool `json:"update_message,omitempty" yaml:"update_message,omitempty"`
 	// HTTP client configuration.

--- a/api/operator/v1beta1/zz_generated.deepcopy.go
+++ b/api/operator/v1beta1/zz_generated.deepcopy.go
@@ -3249,6 +3249,11 @@ func (in *SlackConfig) DeepCopyInto(out *SlackConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UpdateMessage != nil {
+		in, out := &in.UpdateMessage, &out.UpdateMessage
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HTTPConfig != nil {
 		in, out := &in.HTTPConfig, &out.HTTPConfig
 		*out = new(HTTPConfig)

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -8265,6 +8265,8 @@ spec:
                             type: string
                           title_link:
                             type: string
+                          update_message:
+                            type: boolean
                           username:
                             type: string
                         type: object

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,8 @@ aliases:
 * FEATURE: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): VMAgent CRs running in DaemonSet mode now support configuring rolling update strategy behavior.
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): Dry-run mode. See [#1832](https://github.com/VictoriaMetrics/operator/issues/1832).
 
+* FEATURE: [vmalertmanagerconfig](https://docs.victoriametrics.com/operator/resources/vmalertmanagerconfig/): add `update_message` field to `SlackConfig`. This allows alertmanager to edit the original Slack message in-place when alert status changes instead of sending a new one. Requires alertmanager v0.32.0+. See [#2064](https://github.com/VictoriaMetrics/operator/issues/2064).
+
 * BUGFIX: [vmbackupmanager](https://docs.victoriametrics.com/operator/): remove deprecated `-eula` flag from vmbackupmanager and vmrestore container args. See [#1319](https://github.com/VictoriaMetrics/operator/issues/1319).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): VMPodScrape for VLAgent and VMAgent now uses the correct port; previously it used the wrong port and could cause scrape failures. See [#1887](https://github.com/VictoriaMetrics/operator/issues/1887).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): updated VMAuth config consolidating all VMSelects into a single read and all VMClusters into a single write backend

--- a/docs/api.md
+++ b/docs/api.md
@@ -2733,6 +2733,7 @@ Appears in: [Receiver](#receiver)
 | thumb_url<a href="#slackconfig-thumb_url" id="slackconfig-thumb_url">#</a><br/>_string_ | _(Optional)_<br/> |
 | title<a href="#slackconfig-title" id="slackconfig-title">#</a><br/>_string_ | _(Optional)_<br/> |
 | title_link<a href="#slackconfig-title_link" id="slackconfig-title_link">#</a><br/>_string_ | _(Optional)_<br/> |
+| update_message<a href="#slackconfig-update_message" id="slackconfig-update_message">#</a><br/>_boolean_ | _(Optional)_<br/>UpdateMessage controls whether the original Slack message is updated in-place<br />when the alert status changes, instead of sending a new message.<br />Requires api_url pointing to https://slack.com/api/chat.postMessage<br />and a Bot Token with chat:write and chat:update scopes.<br />Available since Alertmanager v0.32.0. |
 | username<a href="#slackconfig-username" id="slackconfig-username">#</a><br/>_string_ | _(Optional)_<br/> |
 
 #### SlackConfirmationField

--- a/docs/api.md
+++ b/docs/api.md
@@ -2733,7 +2733,7 @@ Appears in: [Receiver](#receiver)
 | thumb_url<a href="#slackconfig-thumb_url" id="slackconfig-thumb_url">#</a><br/>_string_ | _(Optional)_<br/> |
 | title<a href="#slackconfig-title" id="slackconfig-title">#</a><br/>_string_ | _(Optional)_<br/> |
 | title_link<a href="#slackconfig-title_link" id="slackconfig-title_link">#</a><br/>_string_ | _(Optional)_<br/> |
-| update_message<a href="#slackconfig-update_message" id="slackconfig-update_message">#</a><br/>_boolean_ | _(Optional)_<br/>UpdateMessage controls whether the original Slack message is updated in-place<br />when the alert status changes, instead of sending a new message.<br />Requires api_url pointing to https://slack.com/api/chat.postMessage<br />and a Bot Token with chat:write and chat:update scopes.<br />Available since Alertmanager v0.32.0. |
+| update_message<a href="#slackconfig-update_message" id="slackconfig-update_message">#</a><br/>_boolean_ | _(Optional)_<br/>Whether to update the original message in-place instead of sending a new one.<br />available since alertmanager v0.32.0 |
 | username<a href="#slackconfig-username" id="slackconfig-username">#</a><br/>_string_ | _(Optional)_<br/> |
 
 #### SlackConfirmationField

--- a/docs/api.md
+++ b/docs/api.md
@@ -2733,7 +2733,7 @@ Appears in: [Receiver](#receiver)
 | thumb_url<a href="#slackconfig-thumb_url" id="slackconfig-thumb_url">#</a><br/>_string_ | _(Optional)_<br/> |
 | title<a href="#slackconfig-title" id="slackconfig-title">#</a><br/>_string_ | _(Optional)_<br/> |
 | title_link<a href="#slackconfig-title_link" id="slackconfig-title_link">#</a><br/>_string_ | _(Optional)_<br/> |
-| update_message<a href="#slackconfig-update_message" id="slackconfig-update_message">#</a><br/>_boolean_ | _(Optional)_<br/>Whether to update the original message in-place instead of sending a new one.<br />available since alertmanager v0.32.0 |
+| update_message<a href="#slackconfig-update_message" id="slackconfig-update_message">#</a><br/>_boolean_ | _(Optional)_<br/>Whether to update the original message in-place instead of sending a new one.<br />Requires Slack Bot API and chat:write scope.<br />Available since alertmanager v0.32.0. |
 | username<a href="#slackconfig-username" id="slackconfig-username">#</a><br/>_string_ | _(Optional)_<br/> |
 
 #### SlackConfirmationField

--- a/internal/controller/operator/factory/converter/v1alpha1/apis.go
+++ b/internal/controller/operator/factory/converter/v1alpha1/apis.go
@@ -332,6 +332,8 @@ func convertReceivers(promReceivers []promv1alpha1.Receiver) []vmv1beta1.Receive
 				ThumbURL:    obj.ThumbURL,
 				LinkNames:   ptr.Deref(obj.LinkNames, false),
 				MrkdwnIn:    obj.MrkdwnIn,
+				// TODO: uncomment once prometheus-operator adds UpdateMessage to SlackConfig
+				// UpdateMessage: obj.UpdateMessage,
 				Actions: convertSliceStruct(obj.Actions, func(s promv1alpha1.SlackAction) vmv1beta1.SlackAction {
 					return vmv1beta1.SlackAction{
 						Type:  s.Type,

--- a/internal/controller/operator/factory/vmalertmanager/config.go
+++ b/internal/controller/operator/factory/vmalertmanager/config.go
@@ -996,6 +996,9 @@ func (cb *configBuilder) buildSlack(slack vmv1beta1.SlackConfig) error {
 	if slack.ShortFields {
 		temp = append(temp, yaml.MapItem{Key: "short_fields", Value: slack.ShortFields})
 	}
+	if slack.UpdateMessage != nil {
+		temp = append(temp, yaml.MapItem{Key: "update_message", Value: *slack.UpdateMessage})
+	}
 	if len(slack.MrkdwnIn) > 0 {
 		temp = append(temp, yaml.MapItem{Key: "mrkdwn_in", Value: slack.MrkdwnIn})
 	}

--- a/internal/controller/operator/factory/vmalertmanager/config_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/config_test.go
@@ -709,13 +709,14 @@ templates: []
 											Name: "slack",
 										},
 									},
-									SendResolved: ptr.To(true),
-									Text:         "some-text",
-									Title:        "some-title",
-									LinkNames:    false,
-									ThumbURL:     "some-url",
-									Pretext:      "text-1",
-									Username:     "some-user",
+									SendResolved:  ptr.To(true),
+									UpdateMessage: ptr.To(true),
+									Text:          "some-text",
+									Title:         "some-title",
+									LinkNames:     false,
+									ThumbURL:      "some-url",
+									Pretext:       "text-1",
+									Username:      "some-user",
 									Actions: []vmv1beta1.SlackAction{
 										{
 											Name: "deny",
@@ -775,6 +776,7 @@ receivers:
     text: some-text
     title: some-title
     thumb_url: some-url
+    update_message: true
     actions:
     - name: deny
       text: text-5


### PR DESCRIPTION
## Summary

Add `update_message` field to `SlackConfig` in `VMAlertmanagerConfig` CRD.

This allows alertmanager to edit the original Slack message in-place when alert status changes (firing → resolved), instead of sending a separate message.

Available since alertmanager v0.32.0.

Closes #2064

## Checklist

- [x] `make build`
- [x] `make lint`
- [x] `make test`
- [x] `make docs`

This PR is AI assisted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `update_message` to Slack receiver config to let Alertmanager update the original Slack message when alert status changes instead of sending a new one. Requires Alertmanager v0.32.0 and a Slack Bot token with `chat:write`; addresses #2064.

- **New Features**
  - Introduced `update_message` (boolean) in Slack config for `VMAlertmanagerConfig`; rendered into Alertmanager YAML when set and covered by tests.
  - Updated CRD schema (with descriptions), docs (`api.md`), and CHANGELOG.

<sup>Written for commit c7a35bef88db0262a12e2013ae1ce231d67b44e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



