### PR TITLE
use existing volume if it's name matches sts volume claim template

### DIFF
--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -222,8 +222,7 @@ type StorageSpec struct {
 func (ss *StorageSpec) IntoSTSVolume(name string, sts *appsv1.StatefulSetSpec) error {
 	podSpec := &sts.Template.Spec
 	foundVolume := false
-	for i := range podSpec.Volumes {
-		volume := &podSpec.Volumes[i]
+	for _, volume := range podSpec.Volumes {
 		if volume.Name == name {
 			foundVolume = true
 		}

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -219,23 +219,40 @@ type StorageSpec struct {
 
 // IntoSTSVolume converts storageSpec into proper volume for statefulsetSpec
 // by default, it adds emptyDir volume.
-func (ss *StorageSpec) IntoSTSVolume(name string, sts *appsv1.StatefulSetSpec) {
+func (ss *StorageSpec) IntoSTSVolume(name string, sts *appsv1.StatefulSetSpec) error {
+	podSpec := &sts.Template.Spec
+	foundVolume := false
+	for i := range podSpec.Volumes {
+		volume := &podSpec.Volumes[i]
+		if volume.Name == name {
+			foundVolume = true
+		}
+	}
 	switch {
 	case ss == nil:
-		sts.Template.Spec.Volumes = append(sts.Template.Spec.Volumes, corev1.Volume{
+		if foundVolume {
+			return nil
+		}
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: name,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		})
 	case ss.EmptyDir != nil:
-		sts.Template.Spec.Volumes = append(sts.Template.Spec.Volumes, corev1.Volume{
+		if foundVolume {
+			return fmt.Errorf("either unset storage.emptyDir or remove volume=%q from spec", name)
+		}
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: name,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: ss.EmptyDir,
 			},
 		})
 	default:
+		if foundVolume {
+			return fmt.Errorf("either unset storage.volumeClaimTemplate or remove volume=%q from spec", name)
+		}
 		claimTemplate := ss.VolumeClaimTemplate
 		stsClaim := corev1.PersistentVolumeClaim{
 			TypeMeta: metav1.TypeMeta{
@@ -255,6 +272,7 @@ func (ss *StorageSpec) IntoSTSVolume(name string, sts *appsv1.StatefulSetSpec) {
 		}
 		sts.VolumeClaimTemplates = append(sts.VolumeClaimTemplates, stsClaim)
 	}
+	return nil
 }
 
 // EmbeddedPersistentVolumeClaim is an embedded version of k8s.io/api/core/v1.PersistentVolumeClaim.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,8 @@ aliases:
 * BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/) and [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): render %SHARD_NUM% placeholder when shard count is greater than 0. See [#2001](https://github.com/VictoriaMetrics/operator/issues/2001).
 * BUGFIX: [vlcluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [vtcluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): do not ignore ExtraStorageNodes for select, when default storage is disabled. See [#1910](https://github.com/VictoriaMetrics/operator/issues/1910).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): use default stub, when no VMAuth backends are available
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): use volume from spec.volumes as persistent queue volume if its name is `persistent-queue-data`, previously emptyDir was mounted. See [#1677](https://github.com/VictoriaMetrics/operator/issues/1677).
+* BUGFIX: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): use volume from spec.vmstorage.volumes and spec.vmselect.volumes as data and cache volumes if its name is `vmstorage-db` and `vmselect-cachedir` respectively. See [#784](https://github.com/VictoriaMetrics/operator/issues/784).
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/build/container.go
+++ b/internal/controller/operator/factory/build/container.go
@@ -607,7 +607,7 @@ func AddSyslogTLSConfigToVolumes(dstVolumes []corev1.Volume, dstMounts []corev1.
 	return dstVolumes, dstMounts
 }
 
-func StorageVolumeMountsTo(volumes []corev1.Volume, mounts []corev1.VolumeMount, pvcSrc *corev1.PersistentVolumeClaimVolumeSource, storagePath, dataVolumeName string) ([]corev1.Volume, []corev1.VolumeMount, error) {
+func StorageVolumeMountsTo(volumes []corev1.Volume, mounts []corev1.VolumeMount, pvcSrc *corev1.PersistentVolumeClaimVolumeSource, storagePath, dataVolumeName string, isStatefulSet bool) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	foundMount := false
 	for _, volumeMount := range mounts {
 		rel, err := filepath.Rel(volumeMount.MountPath, storagePath)
@@ -642,6 +642,9 @@ func StorageVolumeMountsTo(volumes []corev1.Volume, mounts []corev1.VolumeMount,
 			}
 			return volumes, mounts, nil
 		}
+	}
+	if isStatefulSet {
+		return volumes, mounts, nil
 	}
 	var source corev1.VolumeSource
 	if pvcSrc != nil {

--- a/internal/controller/operator/factory/build/container_test.go
+++ b/internal/controller/operator/factory/build/container_test.go
@@ -356,10 +356,11 @@ func TestStorageVolumeMountsTo(t *testing.T) {
 		mounts          []corev1.VolumeMount
 		expectedMounts  []corev1.VolumeMount
 		wantErr         bool
+		isStatefulSet   bool
 	}
 	f := func(o opts) {
 		t.Helper()
-		gotVolumes, gotMounts, err := StorageVolumeMountsTo(o.volumes, o.mounts, o.pvcSrc, o.storagePath, DataVolumeName, false)
+		gotVolumes, gotMounts, err := StorageVolumeMountsTo(o.volumes, o.mounts, o.pvcSrc, o.storagePath, DataVolumeName, o.isStatefulSet)
 		assert.Equal(t, o.expectedMounts, gotMounts)
 		assert.Equal(t, o.expectedVolumes, gotVolumes)
 		if o.wantErr {
@@ -537,6 +538,61 @@ func TestStorageVolumeMountsTo(t *testing.T) {
 			MountPath: "/test",
 		}},
 		storagePath: "/test/data",
+		pvcSrc: &corev1.PersistentVolumeClaimVolumeSource{
+			ClaimName: "test-claim",
+		},
+		wantErr: true,
+	})
+
+	// isStatefulSet, add data volume
+	f(opts{
+		isStatefulSet:   true,
+		storagePath:     "/test",
+		expectedVolumes: nil,
+		expectedMounts: []corev1.VolumeMount{{
+			Name:      DataVolumeName,
+			MountPath: "/test",
+		}},
+	})
+
+	// isStatefulSet, mount PVC
+	f(opts{
+		isStatefulSet: true,
+		volumes: []corev1.Volume{{
+			Name: DataVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "test-claim",
+				},
+			},
+		}},
+		storagePath: "/test",
+		expectedVolumes: []corev1.Volume{{
+			Name: DataVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "test-claim",
+				},
+			},
+		}},
+		expectedMounts: []corev1.VolumeMount{{
+			Name:      DataVolumeName,
+			MountPath: "/test",
+		}},
+	})
+
+	// isStatefulSet, existing volume + pvcSrc — error
+	f(opts{
+		isStatefulSet: true,
+		volumes: []corev1.Volume{{
+			Name: DataVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				AWSElasticBlockStore: &corev1.AWSElasticBlockStoreVolumeSource{
+					VolumeID: "aws-volume",
+				},
+			},
+		}},
+		storagePath: "/test",
 		pvcSrc: &corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "test-claim",
 		},

--- a/internal/controller/operator/factory/build/container_test.go
+++ b/internal/controller/operator/factory/build/container_test.go
@@ -359,7 +359,7 @@ func TestStorageVolumeMountsTo(t *testing.T) {
 	}
 	f := func(o opts) {
 		t.Helper()
-		gotVolumes, gotMounts, err := StorageVolumeMountsTo(o.volumes, o.mounts, o.pvcSrc, o.storagePath, DataVolumeName)
+		gotVolumes, gotMounts, err := StorageVolumeMountsTo(o.volumes, o.mounts, o.pvcSrc, o.storagePath, DataVolumeName, false)
 		assert.Equal(t, o.expectedMounts, gotMounts)
 		assert.Equal(t, o.expectedVolumes, gotVolumes)
 		if o.wantErr {

--- a/internal/controller/operator/factory/vlagent/vlagent.go
+++ b/internal/controller/operator/factory/vlagent/vlagent.go
@@ -241,7 +241,9 @@ func newK8sApp(cr *vmv1.VLAgent) (client.Object, error) {
 	build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.CommonAppsParams)
 
 	if cr.Spec.TmpDataPath == nil {
-		cr.Spec.Storage.IntoSTSVolume(tmpDataVolumeName, &stsSpec.Spec)
+		if err := cr.Spec.Storage.IntoSTSVolume(tmpDataVolumeName, &stsSpec.Spec); err != nil {
+			return nil, err
+		}
 	}
 	stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.ClaimTemplates...)
 	return stsSpec, nil
@@ -271,7 +273,7 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 		args = append(args, "-envflag.enable=true")
 	}
 
-	var agentVolumeMounts []corev1.VolumeMount
+	var vmMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
 	tmpDataPath := defaultTmpDataPath
 	if cr.Spec.K8sCollector.Enabled {
@@ -333,7 +335,7 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 					},
 				},
 			})
-			agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+			vmMounts = append(vmMounts, corev1.VolumeMount{
 				Name:      logVolumeName,
 				MountPath: logVolumePath,
 				ReadOnly:  true,
@@ -362,7 +364,7 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 	}
 
 	if cr.Spec.TmpDataPath == nil {
-		agentVolumeMounts = append(agentVolumeMounts,
+		vmMounts = append(vmMounts,
 			corev1.VolumeMount{
 				Name:      tmpDataVolumeName,
 				MountPath: tmpDataPath,
@@ -380,14 +382,14 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 
 	if cr.Spec.SyslogSpec != nil {
 		args = build.AddSyslogArgsTo(args, cr.Spec.SyslogSpec, tlsServerConfigMountPath)
-		volumes, agentVolumeMounts = build.AddSyslogTLSConfigToVolumes(volumes, agentVolumeMounts, cr.Spec.SyslogSpec, tlsServerConfigMountPath)
+		volumes, vmMounts = build.AddSyslogTLSConfigToVolumes(volumes, vmMounts, cr.Spec.SyslogSpec, tlsServerConfigMountPath)
 		ports = build.AddSyslogPortsTo(ports, cr.Spec.SyslogSpec)
 	}
 
-	volumes, agentVolumeMounts = build.LicenseVolumeTo(volumes, agentVolumeMounts, cr.Spec.License, vmv1beta1.SecretsDir)
+	volumes, vmMounts = build.LicenseVolumeTo(volumes, vmMounts, cr.Spec.License, vmv1beta1.SecretsDir)
 	args = build.LicenseArgsTo(args, cr.Spec.License, vmv1beta1.SecretsDir)
 
-	agentVolumeMounts = append(agentVolumeMounts, cr.Spec.VolumeMounts...)
+	vmMounts = append(vmMounts, cr.Spec.VolumeMounts...)
 	volumes = append(volumes, cr.Spec.Volumes...)
 
 	for _, s := range cr.Spec.Secrets {
@@ -399,7 +401,7 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 				},
 			},
 		})
-		agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+		vmMounts = append(vmMounts, corev1.VolumeMount{
 			Name:      k8stools.SanitizeVolumeName("secret-" + s),
 			ReadOnly:  true,
 			MountPath: path.Join(vmv1beta1.SecretsDir, s),
@@ -422,9 +424,9 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 			ReadOnly:  true,
 			MountPath: path.Join(vmv1beta1.ConfigMapsDir, c),
 		}
-		agentVolumeMounts = append(agentVolumeMounts, cvm)
+		vmMounts = append(vmMounts, cvm)
 	}
-	volumes, agentVolumeMounts = addRemoteWriteAssetsToVolumes(volumes, agentVolumeMounts, cr)
+	volumes, vmMounts = addRemoteWriteAssetsToVolumes(volumes, vmMounts, cr)
 	args = build.AddExtraArgsOverrideDefaults(args, cr.Spec.ExtraArgs, "-")
 	sort.Strings(args)
 
@@ -436,7 +438,7 @@ func newPodSpec(cr *vmv1.VLAgent) (*corev1.PodSpec, error) {
 		Args:                     args,
 		Env:                      envs,
 		EnvFrom:                  cr.Spec.ExtraEnvsFrom,
-		VolumeMounts:             agentVolumeMounts,
+		VolumeMounts:             vmMounts,
 		Resources:                cr.Spec.Resources,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}

--- a/internal/controller/operator/factory/vlcluster/vlstorage.go
+++ b/internal/controller/operator/factory/vlcluster/vlstorage.go
@@ -210,7 +210,9 @@ func buildVLStorageSTSSpec(cr *vmv1.VLCluster) (*appsv1.StatefulSet, error) {
 	}
 	build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.VLStorage.CommonAppsParams)
 	storageSpec := cr.Spec.VLStorage.Storage
-	storageSpec.IntoSTSVolume(cr.Spec.VLStorage.GetStorageVolumeName(), &stsSpec.Spec)
+	if err := storageSpec.IntoSTSVolume(cr.Spec.VLStorage.GetStorageVolumeName(), &stsSpec.Spec); err != nil {
+		return nil, err
+	}
 	stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.VLStorage.ClaimTemplates...)
 
 	return stsSpec, nil

--- a/internal/controller/operator/factory/vlsingle/vlsingle.go
+++ b/internal/controller/operator/factory/vlsingle/vlsingle.go
@@ -195,7 +195,7 @@ func makePodSpec(r *vmv1.VLSingle) (*corev1.PodTemplateSpec, error) {
 			ClaimName: r.PrefixedName(),
 		}
 	}
-	volumes, vmMounts, err := build.StorageVolumeMountsTo(r.Spec.Volumes, r.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName)
+	volumes, vmMounts, err := build.StorageVolumeMountsTo(r.Spec.Volumes, r.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -447,7 +447,9 @@ func newK8sApp(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (client.Object, err
 		}
 		build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.CommonAppsParams)
 		stsSpec.Spec.Template.Spec.Volumes = build.AddServiceAccountTokenVolume(stsSpec.Spec.Template.Spec.Volumes, &cr.Spec.CommonAppsParams)
-		cr.Spec.StatefulStorage.IntoSTSVolume(persistentQueueMountName, &stsSpec.Spec)
+		if err := cr.Spec.StatefulStorage.IntoSTSVolume(persistentQueueMountName, &stsSpec.Spec); err != nil {
+			return nil, err
+		}
 		stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.ClaimTemplates...)
 		return stsSpec, nil
 	}
@@ -544,7 +546,6 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 	ports = append(ports, corev1.ContainerPort{Name: "http", Protocol: "TCP", ContainerPort: intstr.Parse(cr.Spec.Port).IntVal})
 	ports = build.AppendInsertPorts(ports, cr.Spec.InsertPorts)
 
-	var agentVolumeMounts []corev1.VolumeMount
 	var crMounts []corev1.VolumeMount
 	// mount data path any way, even if user changes its value
 	// we cannot rely on value of remoteWriteSettings.
@@ -552,26 +553,11 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 	if cr.Spec.StatefulMode {
 		pqMountPath = persistentQueueSTSDir
 	}
-	agentVolumeMounts = append(agentVolumeMounts,
-		corev1.VolumeMount{
-			Name:      persistentQueueMountName,
-			MountPath: pqMountPath,
-		},
-	)
-	agentVolumeMounts = append(agentVolumeMounts, cr.Spec.VolumeMounts...)
 
-	var volumes []corev1.Volume
-	// in case for sts, we have to use persistentVolumeClaimTemplate instead
-	if !cr.Spec.StatefulMode {
-		volumes = append(volumes, corev1.Volume{
-			Name: persistentQueueMountName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		})
+	volumes, vmMounts, err := build.StorageVolumeMountsTo(cr.Spec.Volumes, cr.Spec.VolumeMounts, nil, pqMountPath, persistentQueueMountName, cr.Spec.StatefulMode)
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure persistent queue volume: %w", err)
 	}
-
-	volumes = append(volumes, cr.Spec.Volumes...)
 
 	if !ptr.Deref(cr.Spec.IngestOnlyMode, false) {
 		args = append(args,
@@ -609,23 +595,23 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 		}
 		crMounts = append(crMounts, m)
 		m.ReadOnly = true
-		agentVolumeMounts = append(agentVolumeMounts, m)
-		agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+		vmMounts = append(vmMounts, m)
+		vmMounts = append(vmMounts, corev1.VolumeMount{
 			Name:      string(build.TLSAssetsResourceKind),
 			MountPath: tlsAssetsDir,
 			ReadOnly:  true,
 		})
-		agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+		vmMounts = append(vmMounts, corev1.VolumeMount{
 			Name:      string(build.SecretConfigResourceKind),
 			MountPath: confDir,
 			ReadOnly:  true,
 		})
 
 	}
-	mountsLen := len(agentVolumeMounts)
-	volumes, agentVolumeMounts = build.StreamAggrVolumeTo(volumes, agentVolumeMounts, cr)
-	volumes, agentVolumeMounts = build.RelabelVolumeTo(volumes, agentVolumeMounts, cr)
-	crMounts = append(crMounts, agentVolumeMounts[mountsLen:]...)
+	mountsLen := len(vmMounts)
+	volumes, vmMounts = build.StreamAggrVolumeTo(volumes, vmMounts, cr)
+	volumes, vmMounts = build.RelabelVolumeTo(volumes, vmMounts, cr)
+	crMounts = append(crMounts, vmMounts[mountsLen:]...)
 	for _, s := range cr.Spec.Secrets {
 		volumes = append(volumes, corev1.Volume{
 			Name: k8stools.SanitizeVolumeName("secret-" + s),
@@ -635,7 +621,7 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 				},
 			},
 		})
-		agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+		vmMounts = append(vmMounts, corev1.VolumeMount{
 			Name:      k8stools.SanitizeVolumeName("secret-" + s),
 			ReadOnly:  true,
 			MountPath: path.Join(vmv1beta1.SecretsDir, s),
@@ -658,11 +644,11 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 			ReadOnly:  true,
 			MountPath: path.Join(vmv1beta1.ConfigMapsDir, c),
 		}
-		agentVolumeMounts = append(agentVolumeMounts, cvm)
+		vmMounts = append(vmMounts, cvm)
 		crMounts = append(crMounts, cvm)
 	}
 
-	volumes, agentVolumeMounts = build.LicenseVolumeTo(volumes, agentVolumeMounts, cr.Spec.License, vmv1beta1.SecretsDir)
+	volumes, vmMounts = build.LicenseVolumeTo(volumes, vmMounts, cr.Spec.License, vmv1beta1.SecretsDir)
 	args = build.LicenseArgsTo(args, cr.Spec.License, vmv1beta1.SecretsDir)
 
 	relabelKeys := []string{globalRelabelingName}
@@ -685,7 +671,7 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 		Args:                     args,
 		Env:                      envs,
 		EnvFrom:                  cr.Spec.ExtraEnvsFrom,
-		VolumeMounts:             agentVolumeMounts,
+		VolumeMounts:             vmMounts,
 		Resources:                cr.Spec.Resources,
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
@@ -712,7 +698,6 @@ func newPodSpec(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) (*corev1.PodSpec, 
 		configReloader := build.ConfigReloaderContainer(false, cr, crMounts, ss)
 		operatorContainers = append(operatorContainers, configReloader)
 	}
-	var err error
 	ic, err = k8stools.MergePatchContainers(ic, cr.Spec.InitContainers)
 	if err != nil {
 		return nil, fmt.Errorf("cannot apply patch for initContainers: %w", err)

--- a/internal/controller/operator/factory/vmagent/vmagent_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_test.go
@@ -457,6 +457,72 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 	})
 
+	// generate vmagent daemonset with predefined volume for persistent queue data
+	f(opts{
+		cr: &vmv1beta1.VMAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-agent-with-existing-volume",
+				Namespace: "default",
+			},
+			Spec: vmv1beta1.VMAgentSpec{
+				RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
+					{URL: "http://remote-write"},
+				},
+				CommonAppsParams: vmv1beta1.CommonAppsParams{
+					Volumes: []corev1.Volume{{
+						Name: "persistent-queue-data",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/host/path/cache",
+							},
+						},
+					}},
+				},
+				DaemonSetMode: true,
+			},
+		},
+		validate: func(ctx context.Context, fclient client.Client, cr *vmv1beta1.VMAgent) {
+			var ds appsv1.DaemonSet
+			assert.NoError(t, fclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.PrefixedName()}, &ds))
+			expected := []corev1.Volume{
+				{
+					Name: "persistent-queue-data",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/host/path/cache",
+						},
+					},
+				},
+				{
+					Name: "tls-assets",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "tls-assets-vmagent-example-agent-with-existing-volume",
+						},
+					},
+				},
+				{
+					Name: "config-out",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "vmagent-example-agent-with-existing-volume",
+						},
+					},
+				},
+			}
+			assert.Equal(t, ds.Spec.Template.Spec.Volumes, expected)
+		},
+		predefinedObjects: []runtime.Object{
+			k8stools.NewReadyDeployment("vmagent-example-agent", "default"),
+		},
+	})
+
 	// generate vmagent sharded statefulset with prevSpec
 	f(opts{
 		cr: &vmv1beta1.VMAgent{

--- a/internal/controller/operator/factory/vmalertmanager/statefulset.go
+++ b/internal/controller/operator/factory/vmalertmanager/statefulset.go
@@ -74,7 +74,9 @@ func newStsForAlertManager(cr *vmv1beta1.VMAlertmanager) (*appsv1.StatefulSet, e
 		statefulset.Spec.PersistentVolumeClaimRetentionPolicy = cr.Spec.PersistentVolumeClaimRetentionPolicy
 	}
 	build.StatefulSetAddCommonParams(statefulset, &cr.Spec.CommonAppsParams)
-	cr.Spec.Storage.IntoSTSVolume(cr.GetVolumeName(), &statefulset.Spec)
+	if err := cr.Spec.Storage.IntoSTSVolume(cr.GetVolumeName(), &statefulset.Spec); err != nil {
+		return nil, err
+	}
 	statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, cr.Spec.Volumes...)
 
 	return statefulset, nil

--- a/internal/controller/operator/factory/vmanomaly/statefulset.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset.go
@@ -161,7 +161,9 @@ func newK8sApp(cr *vmv1.VMAnomaly, configHash string, ac *build.AssetsCache) (*a
 	}
 	build.StatefulSetAddCommonParams(app, &cr.Spec.CommonAppsParams)
 	app.Spec.Template.Spec.Volumes = append(app.Spec.Template.Spec.Volumes, cr.Spec.Volumes...)
-	cr.Spec.Storage.IntoSTSVolume(cr.GetVolumeName(), &app.Spec)
+	if err := cr.Spec.Storage.IntoSTSVolume(cr.GetVolumeName(), &app.Spec); err != nil {
+		return nil, err
+	}
 	app.Spec.VolumeClaimTemplates = append(app.Spec.VolumeClaimTemplates, cr.Spec.ClaimTemplates...)
 	return app, nil
 }

--- a/internal/controller/operator/factory/vmcluster/vmcluster.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster.go
@@ -536,7 +536,9 @@ func genVMSelectSpec(cr *vmv1beta1.VMCluster) (*appsv1.StatefulSet, error) {
 	}
 	build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.VMSelect.CommonAppsParams)
 	if cr.Spec.VMSelect.CacheMountPath != "" {
-		cr.Spec.VMSelect.StorageSpec.IntoSTSVolume(cr.Spec.VMSelect.GetCacheMountVolumeName(), &stsSpec.Spec)
+		if err := cr.Spec.VMSelect.StorageSpec.IntoSTSVolume(cr.Spec.VMSelect.GetCacheMountVolumeName(), &stsSpec.Spec); err != nil {
+			return nil, err
+		}
 	}
 	stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.VMSelect.ClaimTemplates...)
 	return stsSpec, nil
@@ -962,7 +964,9 @@ func buildVMStorageSpec(ctx context.Context, cr *vmv1beta1.VMCluster) (*appsv1.S
 	}
 	build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.VMStorage.CommonAppsParams)
 	storageSpec := cr.Spec.VMStorage.Storage
-	storageSpec.IntoSTSVolume(cr.Spec.VMStorage.GetStorageVolumeName(), &stsSpec.Spec)
+	if err := storageSpec.IntoSTSVolume(cr.Spec.VMStorage.GetStorageVolumeName(), &stsSpec.Spec); err != nil {
+		return nil, err
+	}
 	stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.VMStorage.ClaimTemplates...)
 
 	return stsSpec, nil

--- a/internal/controller/operator/factory/vmcluster/vmcluster_test.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -387,7 +388,16 @@ func TestCreateOrUpdate(t *testing.T) {
 				VMSelect: &vmv1beta1.VMSelect{
 					CommonAppsParams: vmv1beta1.CommonAppsParams{
 						ReplicaCount: ptr.To(int32(0)),
+						Volumes: []corev1.Volume{{
+							Name: "vmselect-cachedir",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/host/path/cache",
+								},
+							},
+						}},
 					},
+					CacheMountPath: "/cache",
 					VPA: &vmv1beta1.EmbeddedVPA{
 						UpdatePolicy: &vpav1.PodUpdatePolicy{
 							UpdateMode: ptr.To(vpav1.UpdateModeRecreate),
@@ -411,13 +421,17 @@ func TestCreateOrUpdate(t *testing.T) {
 			c.VPAAPIEnabled = true
 		},
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster) {
-			var got vpav1.VerticalPodAutoscaler
+			var vpaGot vpav1.VerticalPodAutoscaler
 			component := vmv1beta1.ClusterComponentSelect
-			vpaName := cr.PrefixedName(component)
-			assert.NoError(t, rclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: vpaName}, &got))
-			expected := vpav1.VerticalPodAutoscaler{
+			selectName := cr.PrefixedName(component)
+			nsn := types.NamespacedName{
+				Namespace: cr.Namespace,
+				Name:      selectName,
+			}
+			assert.NoError(t, rclient.Get(ctx, nsn, &vpaGot))
+			vpaExpected := vpav1.VerticalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            vpaName,
+					Name:            selectName,
 					Namespace:       cr.Namespace,
 					Labels:          cr.FinalLabels(component),
 					ResourceVersion: "1",
@@ -425,7 +439,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				},
 				Spec: vpav1.VerticalPodAutoscalerSpec{
 					TargetRef: &autoscalingv1.CrossVersionObjectReference{
-						Name:       vpaName,
+						Name:       selectName,
 						Kind:       "StatefulSet",
 						APIVersion: "apps/v1",
 					},
@@ -443,7 +457,18 @@ func TestCreateOrUpdate(t *testing.T) {
 					},
 				},
 			}
-			assert.Equal(t, got, expected)
+			assert.Equal(t, vpaGot, vpaExpected)
+			var stsSelectGot appsv1.StatefulSet
+			assert.NoError(t, rclient.Get(ctx, nsn, &stsSelectGot))
+			volumesSelectExpected := []corev1.Volume{{
+				Name: "vmselect-cachedir",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/host/path/cache",
+					},
+				},
+			}}
+			assert.Equal(t, stsSelectGot.Spec.Template.Spec.Volumes, volumesSelectExpected)
 		},
 	})
 
@@ -455,6 +480,14 @@ func TestCreateOrUpdate(t *testing.T) {
 				VMStorage: &vmv1beta1.VMStorage{
 					CommonAppsParams: vmv1beta1.CommonAppsParams{
 						ReplicaCount: ptr.To(int32(0)),
+						Volumes: []corev1.Volume{{
+							Name: "vmstorage-db",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/host/path/storage",
+								},
+							},
+						}},
 					},
 					VPA: &vmv1beta1.EmbeddedVPA{
 						UpdatePolicy: &vpav1.PodUpdatePolicy{
@@ -475,11 +508,15 @@ func TestCreateOrUpdate(t *testing.T) {
 		validate: func(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMCluster) {
 			component := vmv1beta1.ClusterComponentStorage
 			var got vpav1.VerticalPodAutoscaler
-			vpaName := cr.PrefixedName(component)
-			assert.NoError(t, rclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: vpaName}, &got))
+			storageName := cr.PrefixedName(component)
+			nsn := types.NamespacedName{
+				Namespace: cr.Namespace,
+				Name:      storageName,
+			}
+			assert.NoError(t, rclient.Get(ctx, nsn, &got))
 			expected := vpav1.VerticalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            vpaName,
+					Name:            storageName,
 					Namespace:       cr.Namespace,
 					Labels:          cr.FinalLabels(component),
 					ResourceVersion: "1",
@@ -487,7 +524,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				},
 				Spec: vpav1.VerticalPodAutoscalerSpec{
 					TargetRef: &autoscalingv1.CrossVersionObjectReference{
-						Name:       vpaName,
+						Name:       storageName,
 						Kind:       "StatefulSet",
 						APIVersion: "apps/v1",
 					},
@@ -502,6 +539,18 @@ func TestCreateOrUpdate(t *testing.T) {
 				},
 			}
 			assert.Equal(t, got, expected)
+
+			var stsStorageGot appsv1.StatefulSet
+			assert.NoError(t, rclient.Get(ctx, nsn, &stsStorageGot))
+			volumesStorageExpected := []corev1.Volume{{
+				Name: "vmstorage-db",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/host/path/storage",
+					},
+				},
+			}}
+			assert.Equal(t, stsStorageGot.Spec.Template.Spec.Volumes, volumesStorageExpected)
 		},
 	})
 

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -213,7 +213,7 @@ func newPodSpec(ctx context.Context, cr *vmv1beta1.VMSingle) (*corev1.PodTemplat
 		}
 	}
 
-	volumes, vmMounts, err := build.StorageVolumeMountsTo(cr.Spec.Volumes, cr.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName)
+	volumes, vmMounts, err := build.StorageVolumeMountsTo(cr.Spec.Volumes, cr.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/operator/factory/vtcluster/storage.go
+++ b/internal/controller/operator/factory/vtcluster/storage.go
@@ -207,7 +207,9 @@ func buildVTStorageSTSSpec(cr *vmv1.VTCluster) (*appsv1.StatefulSet, error) {
 	}
 	build.StatefulSetAddCommonParams(stsSpec, &cr.Spec.Storage.CommonAppsParams)
 	storageSpec := cr.Spec.Storage.Storage
-	storageSpec.IntoSTSVolume(cr.Spec.Storage.GetStorageVolumeName(), &stsSpec.Spec)
+	if err := storageSpec.IntoSTSVolume(cr.Spec.Storage.GetStorageVolumeName(), &stsSpec.Spec); err != nil {
+		return nil, err
+	}
 	stsSpec.Spec.VolumeClaimTemplates = append(stsSpec.Spec.VolumeClaimTemplates, cr.Spec.Storage.ClaimTemplates...)
 
 	return stsSpec, nil

--- a/internal/controller/operator/factory/vtsingle/vtsingle.go
+++ b/internal/controller/operator/factory/vtsingle/vtsingle.go
@@ -194,7 +194,7 @@ func makePodSpec(r *vmv1.VTSingle) (*corev1.PodTemplateSpec, error) {
 			ClaimName: r.PrefixedName(),
 		}
 	}
-	volumes, vmMounts, err := build.StorageVolumeMountsTo(r.Spec.Volumes, r.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName)
+	volumes, vmMounts, err := build.StorageVolumeMountsTo(r.Spec.Volumes, r.Spec.VolumeMounts, pvcSrc, storagePath, build.DataVolumeName, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- for CRs, that manage statefulsets, like vmagent, vmcluster, vlcluster, vtcluster, vlagent, vmanomaly and vmalertmanager - 
skips emptyDir mount of already defined volume matches default expected volumeClaimTemplate (#784 and #810)
- additionally for VMAgent in daemonset mode emptyDir is not mounted if volume already defined (#1677)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use existing user-defined volumes when their names match the default data/cache volume names instead of auto-creating and mounting emptyDir/PVC. This fixes persistent storage mounts across StatefulSet-based CRs and vmagent in DaemonSet mode, and prevents config conflicts.

- **Bug Fixes**
  - vmagent (DaemonSet): use `persistent-queue-data` from spec.volumes; stop mounting emptyDir. See #1677.
  - vmcluster: use `vmstorage-db` from spec.vmstorage.volumes and `vmselect-cachedir` from spec.vmselect.volumes for storage/cache. See #784.
  - All StatefulSet-based CRs (vmagent, vmcluster, vlcluster, vtcluster, vlagent, vmanomaly, vmalertmanager): detect and use matching volumes; return a clear error if a matching volume exists alongside `storage.emptyDir` or a volumeClaimTemplate.

- **Refactors**
  - Faster volume lookup and added tests for `StorageVolumeMountsTo`, vmagent DaemonSet, and vmcluster volume reuse.

<sup>Written for commit 04b5a7242a45dd0f96802b678dea971b943f80a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

