### PR TITLE
address issues found by cubic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ aliases:
 **Update note 1**: deprecated env variables for Prometheus CRs conversion `VM_ENABLEDPROMETHEUSCONVERTER_PODMONITOR`, `VM_ENABLEDPROMETHEUSCONVERTER_SERVICESCRAPE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROMETHEUSRULE`, `VM_ENABLEDPROMETHEUSCONVERTER_PROBE`, `VM_ENABLEDPROMETHEUSCONVERTER_SCRAPECONFIG`. Use `-controller.disableReconcileFor` command-line flag with comma-separated list of controller names, that should be disabled.
 **Update note 2**: removed `operator_prometheus_converter_watch_events_total` metric since migration of Prometheus object watchers to controllers made this counter obsolete.
 **Update note 3**: made `controller.prometheusCRD.resyncPeriod` command line flag noop, which was relevant to Prometheus object watchers.
-**Update note 4**: `-eula` flag is not set by default anymore for VMBackup and VMRestore. To avoid VMCluster/VMSingle rollouts set `spec.vmstorage.vmBackup.acceptEula: true` for VMCluster and `spec.vmBackup.acceptEula: true"` for VMSingle and replace it with `spec.license` during VMSingle/VMCluster upgrade.
+**Update note 4**: `-eula` flag is not set by default anymore for VMBackup and VMRestore. To avoid VMCluster/VMSingle rollouts set `spec.vmstorage.vmBackup.acceptEula: true` for VMCluster and `spec.vmBackup.acceptEula: true` for VMSingle and replace it with `spec.license` during VMSingle/VMCluster upgrade.
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.139.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.139.0) version
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.50.0).

--- a/internal/controller/operator/promalertmanagerconfig_controller.go
+++ b/internal/controller/operator/promalertmanagerconfig_controller.go
@@ -85,7 +85,7 @@ func (r *PromAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	if err = reconcile.VMAlertmanagerConfig(ctx, r.Client, cr, nil, owner, true); err != nil {
-		l.Error(err, "failed to reconcile VMPodScrape from AlertmanagerConfig")
+		l.Error(err, "failed to reconcile VMAlertmanagerConfig from AlertmanagerConfig")
 	}
 	return
 }


### PR DESCRIPTION
address issues found in 0.68 release PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misleading error log in the PromAlertmanagerConfig reconciler and corrects a typo in the changelog’s EULA note for VMSingle to improve debugging and docs clarity for the 0.68 release.

- **Bug Fixes**
  - Controller: Log now says "VMAlertmanagerConfig" instead of "VMPodScrape" on reconcile errors.
  - Docs: Removed stray quote in Update note 4; correct example is `spec.vmBackup.acceptEula: true` for VMSingle.

<sup>Written for commit 74497b345b740714c52517ac356ff05184d10e33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

