### PR TITLE
Fix several divergences between VMSingle and VMAgent scraping implementations

### DIFF
--- a/api/operator/v1beta1/common_scrapeparams.go
+++ b/api/operator/v1beta1/common_scrapeparams.go
@@ -121,7 +121,7 @@ func (o *OAuth2) validate() error {
 		return fmt.Errorf("cannot specify both Secret and ConfigMap for client_id field")
 	}
 	if o.TLSConfig != nil {
-		if err := o.validate(); err != nil {
+		if err := o.TLSConfig.Validate(); err != nil {
 			return fmt.Errorf("invalid tls_config: %w", err)
 		}
 	}

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -395,6 +396,34 @@ func (cr *VMSingle) Validate() error {
 		}
 		if len(cr.Spec.VolumeMounts) == 0 && !storageVolumeFound {
 			return fmt.Errorf("spec.volumeMounts must have at least 1 value OR spec.volumes must have volume.name `data` for spec.storageDataPath=%q", cr.Spec.StorageDataPath)
+		}
+	}
+	scrapeClassNames := sets.New[string]()
+	defaultScrapeClass := false
+	for _, sc := range cr.Spec.ScrapeClasses {
+		if scrapeClassNames.Has(sc.Name) {
+			return fmt.Errorf("duplicated scrapeClass=%q", sc.Name)
+		}
+		scrapeClassNames.Insert(sc.Name)
+		if ptr.Deref(sc.Default, false) {
+			if defaultScrapeClass {
+				return fmt.Errorf("multiple default scrape classes defined")
+			}
+			defaultScrapeClass = true
+		}
+		if sc.TLSConfig != nil {
+			if err := sc.TLSConfig.Validate(); err != nil {
+				return fmt.Errorf("incorrect tlsConfig for scrapeClass=%q: %w", sc.Name, err)
+			}
+		}
+		if err := sc.OAuth2.validate(); err != nil {
+			return fmt.Errorf("incorrect oauth2 for scrapeClass=%q: %w", sc.Name, err)
+		}
+		if err := sc.Authorization.validate(); err != nil {
+			return fmt.Errorf("incorrect authorization for scrapeClass=%q: %w", sc.Name, err)
+		}
+		if err := sc.validate(); err != nil {
+			return fmt.Errorf("incorrect relabeling for scrapeClass=%q: %w", sc.Name, err)
 		}
 	}
 	return nil

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@ aliases:
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): use default stub, when no VMAuth backends are available
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): use volume from spec.volumes as persistent queue volume if its name is `persistent-queue-data`, previously emptyDir was mounted. See [#1677](https://github.com/VictoriaMetrics/operator/issues/1677).
 * BUGFIX: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/): use volume from spec.vmstorage.volumes and spec.vmselect.volumes as data and cache volumes if its name is `vmstorage-db` and `vmselect-cachedir` respectively. See [#784](https://github.com/VictoriaMetrics/operator/issues/784).
+* BUGFIX: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): updated scraping implementation to match vmagent functionality.
 
 ## [v0.68.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.68.1)
 **Release date:** 23 February 2026

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -686,7 +686,16 @@ func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, 
 	}
 
 	owner := cr.AsOwner()
-	for kind, secret := range ac.GetOutput() {
+	secrets := ac.GetOutput()
+	keys := make([]build.ResourceKind, 0, len(secrets))
+	for kind := range secrets {
+		keys = append(keys, kind)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	for _, kind := range keys {
+		secret := secrets[kind]
 		var prevSecretMeta *metav1.ObjectMeta
 		if prevCR != nil {
 			prevSecretMeta = ptr.To(build.ResourceMeta(kind, prevCR))

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -95,7 +95,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.
 		if err := reconcile.ServiceAccount(ctx, rclient, build.ServiceAccount(cr), prevSA, &owner); err != nil {
 			return fmt.Errorf("failed create service account: %w", err)
 		}
-		if !ptr.Deref(cr.Spec.IngestOnlyMode, false) {
+		if !ptr.Deref(cr.Spec.IngestOnlyMode, false) || cr.HasAnyRelabellingConfigs() || cr.HasAnyStreamAggrRule() {
 			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, config.IsClusterWideAccessAllowed()); err != nil {
 				return fmt.Errorf("cannot create vmsingle role and binding for it, err: %w", err)
 			}


### PR DESCRIPTION
* default scrap class verification and tests
* sort secrets when preparing scrape config
* create VMSingle cluster role when relabelling configs or stream aggregation is enabled