### PR TITLE
chore: use k8s apimachinery aggregate errors

### DIFF
--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -39,7 +40,7 @@ func StatusForChildObjects[T any, PT interface {
 	*T
 	objectWithStatus
 }](ctx context.Context, rclient client.Client, parentObjectName string, childObjects []PT) error {
-	var errors []string
+	var errs []error
 
 	n := strings.Split(parentObjectName, ".")
 	if len(n) != 3 {
@@ -63,14 +64,14 @@ func StatusForChildObjects[T any, PT interface {
 		} else {
 			currCound.Status = "False"
 			currCound.Message = st.CurrentSyncError
-			errors = append(errors, fmt.Sprintf("parent=%s config=namespace/name=%s/%s error text: %s", parentObjectName, childObject.GetNamespace(), childObject.GetName(), st.CurrentSyncError))
+			errs = append(errs, fmt.Errorf("parent=%s config=namespace/name=%s/%s error text: %s", parentObjectName, childObject.GetNamespace(), childObject.GetName(), st.CurrentSyncError))
 		}
 		if err := updateChildStatusConditions[T](ctx, rclient, childObject, currCound); err != nil {
 			return err
 		}
 	}
-	if len(errors) > 0 {
-		logger.WithContext(ctx).Error(fmt.Errorf("%s have errors", parentObjectName), fmt.Sprintf("skip config generation for resources: %s", strings.Join(errors, ",")))
+	if aggErr := utilerrors.NewAggregate(errs); aggErr != nil {
+		logger.WithContext(ctx).Error(aggErr, fmt.Sprintf("%s skip config generation for resources", parentObjectName))
 	}
 	return nil
 }

--- a/internal/controller/operator/factory/vmanomaly/statefulset.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset.go
@@ -2,7 +2,6 @@ package vmanomaly
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -253,8 +253,8 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 			}
 		}
 	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+	if err := utilerrors.NewAggregate(errs); err != nil {
+		return err
 	}
 	if err := finalize.RemoveOrphanedPDBs(ctx, rclient, cr, pdbToKeep, true); err != nil {
 		return err


### PR DESCRIPTION
Instead of storing errors as strings and joining them use k8s apimachinery's `errors.NewAggregate`