### PR TITLE
fix: fixed scrape class validation

### DIFF
--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -390,6 +390,20 @@ func (cr *VMSingle) Validate() error {
 			}
 			defaultScrapeClass = true
 		}
+		if sc.TLSConfig != nil {
+			if err := sc.TLSConfig.Validate(); err != nil {
+				return fmt.Errorf("incorrect tlsConfig for scrapeClass=%q: %w", sc.Name, err)
+			}
+		}
+		if err := sc.OAuth2.validate(); err != nil {
+			return fmt.Errorf("incorrect oauth2 for scrapeClass=%q: %w", sc.Name, err)
+		}
+		if err := sc.Authorization.validate(); err != nil {
+			return fmt.Errorf("incorrect authorization for scrapeClass=%q: %w", sc.Name, err)
+		}
+		if err := sc.validate(); err != nil {
+			return fmt.Errorf("incorrect relabeling for scrapeClass=%q: %w", sc.Name, err)
+		}
 	}
 	if cr.Spec.StorageDataPath != "" {
 		if len(cr.Spec.Volumes) == 0 {
@@ -410,34 +424,6 @@ func (cr *VMSingle) Validate() error {
 		}
 		if len(cr.Spec.VolumeMounts) == 0 && !storageVolumeFound {
 			return fmt.Errorf("spec.volumeMounts must have at least 1 value OR spec.volumes must have volume.name `data` for spec.storageDataPath=%q", cr.Spec.StorageDataPath)
-		}
-	}
-	scrapeClassNames := sets.New[string]()
-	defaultScrapeClass := false
-	for _, sc := range cr.Spec.ScrapeClasses {
-		if scrapeClassNames.Has(sc.Name) {
-			return fmt.Errorf("duplicated scrapeClass=%q", sc.Name)
-		}
-		scrapeClassNames.Insert(sc.Name)
-		if ptr.Deref(sc.Default, false) {
-			if defaultScrapeClass {
-				return fmt.Errorf("multiple default scrape classes defined")
-			}
-			defaultScrapeClass = true
-		}
-		if sc.TLSConfig != nil {
-			if err := sc.TLSConfig.Validate(); err != nil {
-				return fmt.Errorf("incorrect tlsConfig for scrapeClass=%q: %w", sc.Name, err)
-			}
-		}
-		if err := sc.OAuth2.validate(); err != nil {
-			return fmt.Errorf("incorrect oauth2 for scrapeClass=%q: %w", sc.Name, err)
-		}
-		if err := sc.Authorization.validate(); err != nil {
-			return fmt.Errorf("incorrect authorization for scrapeClass=%q: %w", sc.Name, err)
-		}
-		if err := sc.validate(); err != nil {
-			return fmt.Errorf("incorrect relabeling for scrapeClass=%q: %w", sc.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
fixed build issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed scrape class validation in `VMSingle.Validate()` by consolidating checks into a single loop and validating TLS, OAuth2, authorization, and relabeling per class. This removes duplicate code and fixes the build.

- **Bug Fixes**
  - Single pass over `Spec.ScrapeClasses` with duplicate/default checks preserved.
  - Run `TLSConfig.Validate()`, `OAuth2.validate()`, `Authorization.validate()`, and `sc.validate()` for each class.

<sup>Written for commit 49cf3c9accab8e282903a51cf0636abab0caab8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

