### PR TITLE
vmauth: introduce arbitrary fs access

### DIFF
--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -49,6 +49,11 @@ type VMAuthSpec struct {
 	// with selectAllByDefault: false - selects nothing
 	// +optional
 	SelectAllByDefault bool `json:"selectAllByDefault,omitempty" yaml:"selectAllByDefault,omitempty"`
+	// ArbitraryFSAccessThroughSMs configures whether configuration
+	// can contain paths to arbitrary files on the file system
+	// e.g bearer token files, basic auth password files, tls certs file paths
+	// +optional
+	ArbitraryFSAccessThroughSMs ArbitraryFSAccessThroughSMsConfig `json:"arbitraryFSAccessThroughSMs,omitempty"`
 	// UserSelector defines VMUser to be selected for config file generation.
 	// Works in combination with NamespaceSelector.
 	// NamespaceSelector nil - only objects at VMAuth namespace.

--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -266,7 +266,7 @@ func (cr *VMUser) PrefixedName() string {
 
 func (cr *VMUser) ValidateArbitraryFSAccess() error {
 	var props []string
-	props = cr.Spec.VMUserConfigOptions.TLSConfig.appendForbiddenProperties(props)
+	props = cr.Spec.TLSConfig.appendForbiddenProperties(props)
 	if len(props) > 0 {
 		return fmt.Errorf("%s are prohibited", strings.Join(props, ", "))
 	}

--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -264,6 +264,15 @@ func (cr *VMUser) PrefixedName() string {
 	return fmt.Sprintf("vmuser-%s", cr.Name)
 }
 
+func (cr *VMUser) ValidateArbitraryFSAccess() error {
+	var props []string
+	props = cr.Spec.VMUserConfigOptions.TLSConfig.appendForbiddenProperties(props)
+	if len(props) > 0 {
+		return fmt.Errorf("%s are prohibited", strings.Join(props, ", "))
+	}
+	return nil
+}
+
 // PasswordRefAsKey - builds key for passwordRef cache
 func (cr *VMUser) PasswordRefAsKey() string {
 	return fmt.Sprintf("%s/%s/%s", cr.Namespace, cr.Spec.PasswordRef.Name, cr.Spec.PasswordRef.Key)

--- a/api/operator/v1beta1/zz_generated.deepcopy.go
+++ b/api/operator/v1beta1/zz_generated.deepcopy.go
@@ -5493,6 +5493,7 @@ func (in *VMAuthSpec) DeepCopyInto(out *VMAuthSpec) {
 		*out = new(ManagedObjectsMetadata)
 		(*in).DeepCopyInto(*out)
 	}
+	out.ArbitraryFSAccessThroughSMs = in.ArbitraryFSAccessThroughSMs
 	if in.UserSelector != nil {
 		in, out := &in.UserSelector, &out.UserSelector
 		*out = new(metav1.LabelSelector)

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -13671,6 +13671,11 @@ spec:
               affinity:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              arbitraryFSAccessThroughSMs:
+                properties:
+                  deny:
+                    type: boolean
+                type: object
               componentVersion:
                 type: string
               configMaps:
@@ -18294,6 +18299,11 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
+                        type: object
+                      arbitraryFSAccessThroughSMs:
+                        properties:
+                          deny:
+                            type: boolean
                         type: object
                       componentVersion:
                         type: string

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): introduce arbitrary fs access feature for VMAuth. See [#899](https://github.com/VictoriaMetrics/operator/issues/899)
+
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ aliases:
 
 ## tip
 
-* FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): introduce arbitrary fs access feature for VMAuth. See [#899](https://github.com/VictoriaMetrics/operator/issues/899)
+* FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): previously VMAuth could read configuration only from predefined locations; now VMAuth supports arbitrary filesystem access configuration, allowing users to reference required files directly and reducing configuration workarounds. See [#899](https://github.com/VictoriaMetrics/operator/issues/899).
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1359,7 +1359,7 @@ in the vmagent container. Those secrets would then be sent with a scrape
 request by vmagent to a malicious target. Denying the above would prevent the
 attack, users can instead use the BearerTokenSecret field.
 
-Appears in: [CommonScrapeParams](#commonscrapeparams), [CommonScrapeSecurityEnforcements](#commonscrapesecurityenforcements), [VMAgentSpec](#vmagentspec), [VMAlertmanagerSpec](#vmalertmanagerspec), [VMSingleSpec](#vmsinglespec)
+Appears in: [CommonScrapeParams](#commonscrapeparams), [CommonScrapeSecurityEnforcements](#commonscrapesecurityenforcements), [VMAgentSpec](#vmagentspec), [VMAlertmanagerSpec](#vmalertmanagerspec), [VMAuthSpec](#vmauthspec), [VMSingleSpec](#vmsinglespec)
 
 | Field | Description |
 | --- | --- |
@@ -3998,6 +3998,7 @@ Appears in: [VMAuth](#vmauth), [VMDistributedAuth](#vmdistributedauth)
 | Field | Description |
 | --- | --- |
 | affinity<a href="#vmauthspec-affinity" id="vmauthspec-affinity">#</a><br/>_[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#affinity-v1-core)_ | _(Optional)_<br/>Affinity If specified, the pod's scheduling constraints. |
+| arbitraryFSAccessThroughSMs<a href="#vmauthspec-arbitraryfsaccessthroughsms" id="vmauthspec-arbitraryfsaccessthroughsms">#</a><br/>_[ArbitraryFSAccessThroughSMsConfig](#arbitraryfsaccessthroughsmsconfig)_ | _(Optional)_<br/>ArbitraryFSAccessThroughSMs configures whether configuration<br />can contain paths to arbitrary files on the file system<br />e.g bearer token files, basic auth password files, tls certs file paths |
 | componentVersion<a href="#vmauthspec-componentversion" id="vmauthspec-componentversion">#</a><br/>_string_ | _(Optional)_<br/>ComponentVersion defines default images tag for all components.<br />it can be overwritten with component specific image.tag value. |
 | configMaps<a href="#vmauthspec-configmaps" id="vmauthspec-configmaps">#</a><br/>_string array_ | _(Optional)_<br/>ConfigMaps is a list of ConfigMaps in the same namespace as the Application<br />object, which shall be mounted into the Application container<br />at /etc/vm/configs/CONFIGMAP_NAME folder |
 | configReloadAuthKeySecret<a href="#vmauthspec-configreloadauthkeysecret" id="vmauthspec-configreloadauthkeysecret">#</a><br/>_[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#secretkeyselector-v1-core)_ | _(Optional)_<br/>ConfigReloadAuthKeySecret defines optional secret reference authKey for /-/reload API requests.<br />Given secret reference will be added to the application and vm-config-reloader as volume<br />available since v0.57.0 version |

--- a/docs/env.md
+++ b/docs/env.md
@@ -4,7 +4,7 @@
 | VM_LOGS_VERSION: `v1.50.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
 | VM_ANOMALY_VERSION: `v1.29.3` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a> |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a> |
-| VM_OPERATOR_VERSION: `v0.68.3` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a> |
+| VM_OPERATOR_VERSION: `v0.69.0` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a> |
 | VM_GATEWAY_API_ENABLED: `false` <a href="#variables-vm-gateway-api-enabled" id="variables-vm-gateway-api-enabled">#</a> |
 | VM_VPA_API_ENABLED: `false` <a href="#variables-vm-vpa-api-enabled" id="variables-vm-vpa-api-enabled">#</a> |
 | WATCH_NAMESPACE: `-` <a href="#variables-watch-namespace" id="variables-watch-namespace">#</a><br>Defines a list of namespaces to be watched by operator. Operator don't perform any cluster wide API calls if namespaces not empty. In case of empty list it performs only clusterwide api calls. |

--- a/docs/env.md
+++ b/docs/env.md
@@ -4,7 +4,7 @@
 | VM_LOGS_VERSION: `v1.50.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
 | VM_ANOMALY_VERSION: `v1.29.3` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a> |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a> |
-| VM_OPERATOR_VERSION: `v0.69.0` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a> |
+| VM_OPERATOR_VERSION: `v0.68.3` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a> |
 | VM_GATEWAY_API_ENABLED: `false` <a href="#variables-vm-gateway-api-enabled" id="variables-vm-gateway-api-enabled">#</a> |
 | VM_VPA_API_ENABLED: `false` <a href="#variables-vm-vpa-api-enabled" id="variables-vm-vpa-api-enabled">#</a> |
 | WATCH_NAMESPACE: `-` <a href="#variables-watch-namespace" id="variables-watch-namespace">#</a><br>Defines a list of namespaces to be watched by operator. Operator don't perform any cluster wide API calls if namespaces not empty. In case of empty list it performs only clusterwide api calls. |

--- a/internal/controller/operator/factory/vmauth/vmusers_config.go
+++ b/internal/controller/operator/factory/vmauth/vmusers_config.go
@@ -123,6 +123,11 @@ func (pos *parsedObjects) buildConfig(ctx context.Context, rclient client.Client
 				return err
 			}
 		}
+		if cr.Spec.ArbitraryFSAccessThroughSMs.Deny {
+			if err := user.ValidateArbitraryFSAccess(); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 	toCreateSecrets, toUpdate, err := pos.addAuthCredentialsBuildSecrets(ac)


### PR DESCRIPTION
fixes #899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `arbitraryFSAccessThroughSMs` to `VMAuth` to allow or block file-path references in `VMUser` configs. When denied, VMAuth rejects users that reference node files (e.g., bearer tokens, basic auth, TLS files).

- **New Features**
  - Added `arbitraryFSAccessThroughSMs.deny` to `VMAuthSpec`; when true, `VMUser.ValidateArbitraryFSAccess()` blocks configs with file-path refs (e.g., TLS cert/key/CA).
  - Updated CRDs, deepcopy, and docs (API includes `VMAuthSpec`; CHANGELOG entry added).

<sup>Written for commit 363c0bea9b92355b727875bfd0ebcfe9ebd80e5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

