### PR TITLE
promconverter: disable controllers when CRDs are absent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
+
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ var (
 		"VM_LOGS_VERSION":     "v1.50.0",
 		"VM_ANOMALY_VERSION":  "v1.29.3",
 		"VM_TRACES_VERSION":   "v0.7.0",
-		"VM_OPERATOR_VERSION": getVersion("v0.68.3"),
+		"VM_OPERATOR_VERSION": getVersion("v0.69.0"),
 	}
 )
 

--- a/internal/controller/operator/factory/vmauth/vmauth_test.go
+++ b/internal/controller/operator/factory/vmauth/vmauth_test.go
@@ -557,6 +557,9 @@ serviceaccountname: vmauth-auth
 				},
 				Port: "8429",
 			},
+			CommonConfigReloaderParams: vmv1beta1.CommonConfigReloaderParams{
+				ConfigReloaderImage: "victoriametrics/operator:config-reloader-v0.68.3",
+			},
 		},
 	}, `
 volumes:

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -525,11 +525,11 @@ func initControllers(mgr ctrl.Manager, l logr.Logger, baseClient *kubernetes.Cli
 			if !k8serrors.IsNotFound(err) {
 				return fmt.Errorf("cannot get server resource for API=%s: %w", groupVersion, err)
 			}
-			continue
-		}
-		for _, r := range api.APIResources {
-			if _, ok := controllersByName[r.Kind]; ok && kinds.Has(r.Kind) {
-				kinds.Delete(r.Kind)
+		} else {
+			for _, r := range api.APIResources {
+				if _, ok := controllersByName[r.Kind]; ok && kinds.Has(r.Kind) {
+					kinds.Delete(r.Kind)
+				}
 			}
 		}
 		disabledControllerNames.Insert(kinds.UnsortedList()...)


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/helm-charts/issues/2838

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Prometheus converter controllers when the Prometheus CRD group is missing so they don’t start on clusters without those CRDs. Also bumps `VM_OPERATOR_VERSION` to v0.69.0; fixes victoriaMetrics/helm-charts#2838.

- **Bug Fixes**
  - On API discovery NotFound for the Prometheus group, disable all Prometheus controllers and only enumerate API resources when the group exists. Updated CHANGELOG.

<sup>Written for commit a1e5cf2f7d88ffd23c0fb63193f843a96376d4c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

