### PR TITLE
vmdistributed: change default write requests load balancing policy from first_available to least_loaded

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ aliases:
 * FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): previously VMAuth could read configuration only from predefined locations; now VMAuth supports arbitrary filesystem access configuration, allowing users to reference required files directly and reducing configuration workarounds. See [#899](https://github.com/VictoriaMetrics/operator/issues/899).
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): change default load balancing policy for write requests from `first_available` to `least_loaded`. This should allow to evenly distribute write load across all VMAgents.
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026

--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -78,7 +78,7 @@ func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, owner *metav1.OwnerReferenc
 	ref := vmv1beta1.TargetRef{
 		Name: "write",
 		URLMapCommon: vmv1beta1.URLMapCommon{
-			LoadBalancingPolicy: ptr.To("first_available"),
+			LoadBalancingPolicy: ptr.To("least_loaded"),
 			RetryStatusCodes:    []int{500, 502, 503},
 		},
 		Paths: []string{"/insert/.+", "/api/v1/write"},

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
@@ -415,6 +415,9 @@ func TestCreateOrUpdate(t *testing.T) {
 						Kind:    "VMAgent",
 						Objects: vmAgentObjs,
 					},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("least_loaded"),
+					},
 				},
 				{
 					Name:  "read",
@@ -423,11 +426,13 @@ func TestCreateOrUpdate(t *testing.T) {
 						Kind:    "VMCluster/vmselect",
 						Objects: vmClusterObjs,
 					},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("first_available"),
+					},
 				},
 			}
 			for i := range targetRefs {
 				targetRef := &targetRefs[i]
-				targetRef.LoadBalancingPolicy = ptr.To("first_available")
 				targetRef.RetryStatusCodes = []int{500, 502, 503}
 			}
 			var got vmv1beta1.VMAuth
@@ -550,6 +555,9 @@ func TestCreateOrUpdate(t *testing.T) {
 						Kind:    "VMAgent",
 						Objects: vmAgentObjs,
 					},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("least_loaded"),
+					},
 				},
 				{
 					Name:  "read",
@@ -558,11 +566,13 @@ func TestCreateOrUpdate(t *testing.T) {
 						Kind:    "VMCluster/vmselect",
 						Objects: vmClusterObjs,
 					},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("first_available"),
+					},
 				},
 			}
 			for i := range targetRefs {
 				targetRef := &targetRefs[i]
-				targetRef.LoadBalancingPolicy = ptr.To("first_available")
 				targetRef.RetryStatusCodes = []int{500, 502, 503}
 			}
 			var got vmv1beta1.VMAuth
@@ -623,14 +633,19 @@ func TestCreateOrUpdate(t *testing.T) {
 				{
 					Name:  "write",
 					Paths: []string{"/insert/.+", "/api/v1/write"},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("least_loaded"),
+					},
 				},
 				{
 					Name:  "read",
 					Paths: []string{"/select/.+", "/admin/tenants"},
+					URLMapCommon: vmv1beta1.URLMapCommon{
+						LoadBalancingPolicy: ptr.To("first_available"),
+					},
 				},
 			}
 			for i := range expectedTargetRefs {
-				expectedTargetRefs[i].LoadBalancingPolicy = ptr.To("first_available")
 				expectedTargetRefs[i].RetryStatusCodes = []int{500, 502, 503}
 				expectedTargetRefs[i].Static = &vmv1beta1.StaticRef{URL: defaultStubAddr}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the default load balancing policy for write requests in `vmdistributed` from `first_available` to `least_loaded` to spread write load evenly across VMAgents. Read requests remain on `first_available`.

- **Bug Fixes**
  - Update `vmauth` "write" target to use `least_loaded`; retry codes unchanged.
  - Adjust tests to expect the new default and add explicit policies for write/read.
  - Add changelog entry.

<sup>Written for commit 6a9d422f3fbdf8598e73349c99c56b293b143e19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

