### PR TITLE
vmdistributed: support trafficMode

### DIFF
--- a/api/operator/v1alpha1/vmdistributed_types.go
+++ b/api/operator/v1alpha1/vmdistributed_types.go
@@ -82,11 +82,23 @@ type VMDistributedZoneCommon struct {
 	UpdatePause *metav1.Duration `json:"updatePause,omitempty"`
 }
 
+type VMDistributedTrafficMode string
+
+const (
+	VMDistributedTrafficModeReadWrite   VMDistributedTrafficMode = "read-write"
+	VMDistributedTrafficModeReadOnly    VMDistributedTrafficMode = "read-only"
+	VMDistributedTrafficModeWriteOnly   VMDistributedTrafficMode = "write-only"
+	VMDistributedTrafficModeMaintenance VMDistributedTrafficMode = "maintenance"
+)
+
 // +k8s:openapi-gen=true
 // VMDistributedZone defines items within a single zone to update.
 type VMDistributedZone struct {
 	// Name defines a name of zone, which can be used in zoneCommon spec as %ZONE%
 	Name string `json:"name"`
+	// TrafficMode defines allowed traffic mode for a zone: read-only, write-only, read-write, maintenance
+	// +kubebuilder:validation:Enum=read-only;write-only;read-write;maintenance
+	TrafficMode VMDistributedTrafficMode `json:"trafficMode,omitempty"`
 	// VMCluster defines a new inline or referencing existing one VMCluster
 	// +optional
 	VMCluster VMDistributedZoneCluster `json:"vmcluster,omitempty"`

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -27514,6 +27514,13 @@ spec:
                       type: string
                     remoteWrite:
                       x-kubernetes-preserve-unknown-fields: true
+                    trafficMode:
+                      enum:
+                      - read-only
+                      - write-only
+                      - read-write
+                      - maintenance
+                      type: string
                     vmagent:
                       properties:
                         name:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ aliases:
 
 * FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth/): previously VMAuth could read configuration only from predefined locations; now VMAuth supports arbitrary filesystem access configuration, allowing users to reference required files directly and reducing configuration workarounds. See [#899](https://github.com/VictoriaMetrics/operator/issues/899).
 * FEATURE: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): support VMAnomaly CRD in VMUser targetRefs. See [#2141](https://github.com/VictoriaMetrics/operator/issues/2141).
+* FEATURE: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed): introduce `spec.zones[*].trafficMode` property, which allows disable read, write or whole traffic to a zone. See [#1995](https://github.com/VictoriaMetrics/operator/issues/1995).
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): change default load balancing policy for write requests from `first_available` to `least_loaded`. This should allow to evenly distribute write load across all VMAgents.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1145,6 +1145,12 @@ Appears in: [VMDistributed](#vmdistributed)
 | zoneCommon<a href="#vmdistributedspec-zonecommon" id="vmdistributedspec-zonecommon">#</a><br/>_[VMDistributedZoneCommon](#vmdistributedzonecommon)_ | _(Optional)_<br/>ZoneCommon defines common properties for all zones |
 | zones<a href="#vmdistributedspec-zones" id="vmdistributedspec-zones">#</a><br/>_[VMDistributedZone](#vmdistributedzone) array_ | _(Required)_<br/>Zones is a list of zones to update. Each item in the list represents a "zone" within the distributed setup. |
 
+#### VMDistributedTrafficMode
+
+_Underlying type:_ _string_
+
+Appears in: [VMDistributedZone](#vmdistributedzone)
+
 #### VMDistributedZone
 
 VMDistributedZone defines items within a single zone to update.
@@ -1155,6 +1161,7 @@ Appears in: [VMDistributedSpec](#vmdistributedspec)
 | --- | --- |
 | name<a href="#vmdistributedzone-name" id="vmdistributedzone-name">#</a><br/>_string_ | _(Required)_<br/>Name defines a name of zone, which can be used in zoneCommon spec as %ZONE% |
 | remoteWrite<a href="#vmdistributedzone-remotewrite" id="vmdistributedzone-remotewrite">#</a><br/>_[VMDistributedZoneRemoteWriteSpec](#vmdistributedzoneremotewritespec)_ | _(Optional)_<br/>RemoteWrite defines VMAgent remote write settings for given zone |
+| trafficMode<a href="#vmdistributedzone-trafficmode" id="vmdistributedzone-trafficmode">#</a><br/>_[VMDistributedTrafficMode](#vmdistributedtrafficmode)_ | _(Required)_<br/>TrafficMode defines allowed traffic mode for a zone: read-only, write-only, read-write, maintenance |
 | vmagent<a href="#vmdistributedzone-vmagent" id="vmdistributedzone-vmagent">#</a><br/>_[VMDistributedZoneAgent](#vmdistributedzoneagent)_ | _(Optional)_<br/>VMAgent defines VMAgent to balance incoming traffic between VMClusters. |
 | vmcluster<a href="#vmdistributedzone-vmcluster" id="vmdistributedzone-vmcluster">#</a><br/>_[VMDistributedZoneCluster](#vmdistributedzonecluster)_ | _(Optional)_<br/>VMCluster defines a new inline or referencing existing one VMCluster |
 

--- a/internal/controller/operator/factory/build/defaults.go
+++ b/internal/controller/operator/factory/build/defaults.go
@@ -52,7 +52,6 @@ func AddDefaults(scheme *runtime.Scheme) {
 
 func addVMDistributedDefaults(objI any) {
 	cr := objI.(*vmv1alpha1.VMDistributed)
-
 	if cr.Spec.ZoneCommon.ReadyTimeout == nil {
 		cr.Spec.ZoneCommon.ReadyTimeout = &metav1.Duration{
 			Duration: 5 * time.Minute,
@@ -61,6 +60,12 @@ func addVMDistributedDefaults(objI any) {
 	if cr.Spec.ZoneCommon.UpdatePause == nil {
 		cr.Spec.ZoneCommon.UpdatePause = &metav1.Duration{
 			Duration: 1 * time.Minute,
+		}
+	}
+	for i := range cr.Spec.Zones {
+		z := &cr.Spec.Zones[i]
+		if len(z.TrafficMode) == 0 {
+			z.TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadWrite
 		}
 	}
 	if cr.Spec.License.IsProvided() {

--- a/internal/controller/operator/factory/vmdistributed/vmauth.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth.go
@@ -96,7 +96,7 @@ func vmAgentTargetRef(vmAgents []*vmv1beta1.VMAgent, owner *metav1.OwnerReferenc
 	return ref
 }
 
-func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, vmClusters []*vmv1beta1.VMCluster, excludeIds ...int) *vmv1beta1.VMAuth {
+func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, vmClusters []*vmv1beta1.VMCluster, trafficModes []vmv1alpha1.VMDistributedTrafficMode, excludeIds ...int) *vmv1beta1.VMAuth {
 	if !ptr.Deref(cr.Spec.VMAuth.Enabled, true) || build.IsControllerDisabled("VMAuth") {
 		return nil
 	}
@@ -108,10 +108,23 @@ func buildVMAuthLB(cr *vmv1alpha1.VMDistributed, vmAgents []*vmv1beta1.VMAgent, 
 		},
 		Spec: *cr.Spec.VMAuth.Spec.DeepCopy(),
 	}
+	writeExcludeIds := slices.Clone(excludeIds)
+	readExcludeIds := slices.Clone(excludeIds)
+	for i, mode := range trafficModes {
+		switch mode {
+		case vmv1alpha1.VMDistributedTrafficModeReadOnly:
+			writeExcludeIds = append(writeExcludeIds, i)
+		case vmv1alpha1.VMDistributedTrafficModeWriteOnly:
+			readExcludeIds = append(readExcludeIds, i)
+		case vmv1alpha1.VMDistributedTrafficModeMaintenance:
+			writeExcludeIds = append(writeExcludeIds, i)
+			readExcludeIds = append(readExcludeIds, i)
+		}
+	}
 	var targetRefs []vmv1beta1.TargetRef
 	owner := cr.AsOwner()
-	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, &owner, excludeIds...))
-	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, &owner, excludeIds...))
+	targetRefs = append(targetRefs, vmAgentTargetRef(vmAgents, &owner, writeExcludeIds...))
+	targetRefs = append(targetRefs, vmClusterTargetRef(vmClusters, &owner, readExcludeIds...))
 	vmAuth.Spec.DefaultTargetRefs = targetRefs
 	return &vmAuth
 }

--- a/internal/controller/operator/factory/vmdistributed/vmauth_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmauth_test.go
@@ -160,7 +160,7 @@ func TestBuildVMAuthLBZoneOrder(t *testing.T) {
 
 	f := func(o opts) {
 		t.Helper()
-		vmAuth := buildVMAuthLB(cr, o.agents, o.clusters, o.excludeIds...)
+		vmAuth := buildVMAuthLB(cr, o.agents, o.clusters, nil, o.excludeIds...)
 		assert.NotNil(t, vmAuth)
 		assert.Len(t, vmAuth.Spec.DefaultTargetRefs, 2)
 

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_reconcile_test.go
@@ -399,6 +399,177 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
 		},
 	})
+
+	zoneSpec := vmv1alpha1.VMDistributedZoneCluster{
+		Spec: vmv1beta1.VMClusterSpec{
+			RetentionPeriod: "1",
+			VMStorage: &vmv1beta1.VMStorage{
+				CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To(int32(1))},
+			},
+			VMSelect: &vmv1beta1.VMSelect{
+				CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To(int32(1))},
+			},
+			VMInsert: &vmv1beta1.VMInsert{
+				CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To(int32(1))},
+			},
+		},
+	}
+	vmAuthSpec := vmv1alpha1.VMDistributedAuth{
+		Spec: vmv1beta1.VMAuthSpec{
+			CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To(int32(1))},
+		},
+	}
+
+	// switching from read-write to read-only: pre-reconcile PQ drain, no post-reconcile drain
+	f(args{
+		cr: &vmv1alpha1.VMDistributed{
+			ObjectMeta: objectMeta,
+			Spec: vmv1alpha1.VMDistributedSpec{
+				Zones: []vmv1alpha1.VMDistributedZone{
+					{
+						Name:        zoneName,
+						TrafficMode: vmv1alpha1.VMDistributedTrafficModeReadOnly,
+						VMCluster:   zoneSpec,
+						VMAgent: vmv1alpha1.VMDistributedZoneAgent{
+							Spec: vmv1alpha1.VMDistributedZoneAgentSpec{
+								PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{},
+							},
+						},
+					},
+				},
+				VMAuth: vmAuthSpec,
+			},
+		},
+		preRun: func(ctx context.Context, c *k8stools.ClientWithActions, cr *vmv1alpha1.VMDistributed) {
+			crCopy := cr.DeepCopy()
+			crCopy.Spec.Zones[0].TrafficMode = ""
+			assert.NoError(t, CreateOrUpdate(ctx, crCopy, c))
+			c.Actions = nil
+		},
+	}, want{
+		actions: []k8stools.ClientAction{
+			// getZones
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// prevAcceptsWrites=true: drain PQ (no k8s actions), then exclude zone from LB
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+
+			// reconcile VMCluster: VMInsert.ReplicaCount 1 → 0
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Update", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+
+			// reconcile VMAgent: no changes
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// newAcceptsWrites=false: no PQ drain; restore LB with read-only config
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+		},
+	})
+
+	// switching from read-only to read-write: no pre-reconcile drain, post-reconcile PQ drain
+	f(args{
+		cr: &vmv1alpha1.VMDistributed{
+			ObjectMeta: objectMeta,
+			Spec: vmv1alpha1.VMDistributedSpec{
+				Zones: []vmv1alpha1.VMDistributedZone{
+					{
+						Name:        zoneName,
+						TrafficMode: vmv1alpha1.VMDistributedTrafficModeReadWrite,
+						VMCluster:   zoneSpec,
+						VMAgent: vmv1alpha1.VMDistributedZoneAgent{
+							Spec: vmv1alpha1.VMDistributedZoneAgentSpec{
+								PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{},
+							},
+						},
+					},
+				},
+				VMAuth: vmAuthSpec,
+			},
+		},
+		preRun: func(ctx context.Context, c *k8stools.ClientWithActions, cr *vmv1alpha1.VMDistributed) {
+			crCopy := cr.DeepCopy()
+			crCopy.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadOnly
+			assert.NoError(t, CreateOrUpdate(ctx, crCopy, c))
+			c.Actions = nil
+		},
+	}, want{
+		actions: []k8stools.ClientAction{
+			// getZones
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// prevAcceptsWrites=false: no pre-reconcile drain; exclude zone from LB
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+
+			// reconcile VMCluster: VMInsert.ReplicaCount 0 → 1
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Update", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+
+			// reconcile VMAgent: no changes
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// newAcceptsWrites=true: drain PQ (no k8s actions), then restore LB
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Update", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+		},
+	})
+
+	// read-only mode with no spec changes: no reconcile, no PQ drains
+	f(args{
+		cr: &vmv1alpha1.VMDistributed{
+			ObjectMeta: objectMeta,
+			Spec: vmv1alpha1.VMDistributedSpec{
+				Zones: []vmv1alpha1.VMDistributedZone{
+					{
+						Name:        zoneName,
+						TrafficMode: vmv1alpha1.VMDistributedTrafficModeReadOnly,
+						VMCluster:   zoneSpec,
+						VMAgent: vmv1alpha1.VMDistributedZoneAgent{
+							Spec: vmv1alpha1.VMDistributedZoneAgentSpec{
+								PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{},
+							},
+						},
+					},
+				},
+				VMAuth: vmAuthSpec,
+			},
+		},
+		preRun: func(ctx context.Context, c *k8stools.ClientWithActions, cr *vmv1alpha1.VMDistributed) {
+			assert.NoError(t, CreateOrUpdate(ctx, cr.DeepCopy(), c))
+			c.Actions = nil
+		},
+	}, want{
+		actions: []k8stools.ClientAction{
+			// getZones
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// no spec changes: no LB exclude, no PQ drains
+			// reconcile VMCluster: no changes
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+			{Verb: "Get", Kind: "VMCluster", Resource: vmClusterName},
+
+			// reconcile VMAgent: no changes
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+			{Verb: "Get", Kind: "VMAgent", Resource: vmAgentName},
+
+			// restore LB: no changes
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+			{Verb: "Get", Kind: "VMAuth", Resource: vmAuthLBName},
+		},
+	})
 }
 
 func Test_CreateOrUpdate_Paused(t *testing.T) {

--- a/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
+++ b/internal/controller/operator/factory/vmdistributed/vmdistributed_test.go
@@ -276,7 +276,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters, d.zones.trafficModes)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 		},
@@ -291,7 +291,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		preRun: func(c client.Client, d *testData) {
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			c.Scheme().Default(lb)
 			assert.NoError(t, c.Create(context.TODO(), lb))
 		},
@@ -316,7 +316,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				LogLevel: "INFO",
 			}
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 		},
@@ -333,7 +333,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		preRun: func(c client.Client, d *testData) {
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			c.Scheme().Default(lb)
 			assert.NoError(t, c.Create(context.TODO(), lb))
 		},
@@ -351,7 +351,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 		},
@@ -389,7 +389,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters, d.zones.trafficModes)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 			var vmClusterObjs, vmAgentObjs []vmv1beta1.NamespacedName
@@ -456,7 +456,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		preRun: func(c client.Client, d *testData) {
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			lb := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			c.Scheme().Default(lb)
 			lb.OwnerReferences = nil
 			assert.NoError(t, c.Create(context.TODO(), lb))
@@ -483,7 +483,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
 			clusters := []*vmv1beta1.VMCluster{d.zones.vmclusters[0]}
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, clusters, nil)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 			var got vmv1beta1.VMAuth
@@ -529,7 +529,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			}
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
-			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
+			vmAuth := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters, d.zones.trafficModes)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 			var vmClusterObjs, vmAgentObjs []vmv1beta1.NamespacedName
@@ -592,7 +592,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		preRun: func(c client.Client, d *testData) {
 			// Create initial VMAuth backed by CRD targets
-			lb := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters)
+			lb := buildVMAuthLB(d.cr, d.zones.vmagents, d.zones.vmclusters, d.zones.trafficModes)
 			c.Scheme().Default(lb)
 			assert.NoError(t, c.Create(context.TODO(), lb))
 		},
@@ -618,7 +618,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		},
 		validate: func(ctx context.Context, rclient client.Client, d *testData) {
 			// Simulate removing both backends by passing empty slices
-			vmAuth := buildVMAuthLB(d.cr, nil, nil)
+			vmAuth := buildVMAuthLB(d.cr, nil, nil, nil)
 			owner := d.cr.AsOwner()
 			assert.NoError(t, reconcile.VMAuth(ctx, rclient, vmAuth, nil, &owner))
 

--- a/internal/controller/operator/factory/vmdistributed/zone.go
+++ b/internal/controller/operator/factory/vmdistributed/zone.go
@@ -30,10 +30,12 @@ import (
 )
 
 type zones struct {
-	httpClient *http.Client
-	vmagents   []*vmv1beta1.VMAgent
-	vmclusters []*vmv1beta1.VMCluster
-	hasChanges []bool
+	httpClient        *http.Client
+	vmagents          []*vmv1beta1.VMAgent
+	vmclusters        []*vmv1beta1.VMCluster
+	hasChanges        []bool
+	trafficModes      []vmv1alpha1.VMDistributedTrafficMode
+	prevAcceptsWrites []bool
 }
 
 func (zs *zones) Len() int {
@@ -66,6 +68,8 @@ func (zs *zones) Swap(i, j int) {
 	zs.vmagents[i], zs.vmagents[j] = zs.vmagents[j], zs.vmagents[i]
 	zs.vmclusters[i], zs.vmclusters[j] = zs.vmclusters[j], zs.vmclusters[i]
 	zs.hasChanges[i], zs.hasChanges[j] = zs.hasChanges[j], zs.hasChanges[i]
+	zs.trafficModes[i], zs.trafficModes[j] = zs.trafficModes[j], zs.trafficModes[i]
+	zs.prevAcceptsWrites[i], zs.prevAcceptsWrites[j] = zs.prevAcceptsWrites[j], zs.prevAcceptsWrites[i]
 }
 
 // getZones builds desired zones
@@ -74,9 +78,11 @@ func getZones(ctx context.Context, rclient client.Client, cr *vmv1alpha1.VMDistr
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
 		},
-		vmagents:   make([]*vmv1beta1.VMAgent, len(cr.Spec.Zones)),
-		vmclusters: make([]*vmv1beta1.VMCluster, len(cr.Spec.Zones)),
-		hasChanges: make([]bool, len(cr.Spec.Zones)),
+		vmagents:          make([]*vmv1beta1.VMAgent, len(cr.Spec.Zones)),
+		vmclusters:        make([]*vmv1beta1.VMCluster, len(cr.Spec.Zones)),
+		hasChanges:        make([]bool, len(cr.Spec.Zones)),
+		trafficModes:      make([]vmv1alpha1.VMDistributedTrafficMode, len(cr.Spec.Zones)),
+		prevAcceptsWrites: make([]bool, len(cr.Spec.Zones)),
 	}
 	for i := range cr.Spec.Zones {
 		z := &cr.Spec.Zones[i]
@@ -102,8 +108,15 @@ func getZones(ctx context.Context, rclient client.Client, cr *vmv1alpha1.VMDistr
 		prevClusterSpec := vmCluster.Spec
 		vmCluster.Spec = *vmClusterSpec
 		rclient.Scheme().Default(&vmCluster)
+
+		// for maintenance and read-only modes setting VMInsert replicas down to 0 to enable VMAgent buffering
+		if (z.TrafficMode == vmv1alpha1.VMDistributedTrafficModeReadOnly || z.TrafficMode == vmv1alpha1.VMDistributedTrafficModeMaintenance) && vmCluster.Spec.VMInsert != nil {
+			vmCluster.Spec.VMInsert.ReplicaCount = ptr.To(int32(0))
+		}
 		zs.hasChanges[i] = !equality.Semantic.DeepEqual(&vmCluster.Spec, &prevClusterSpec)
 		zs.vmclusters[i] = &vmCluster
+		zs.trafficModes[i] = z.TrafficMode
+		zs.prevAcceptsWrites[i] = prevClusterSpec.VMInsert != nil && ptr.Deref(prevClusterSpec.VMInsert.ReplicaCount, 1) > 0
 	}
 
 	for i := range cr.Spec.Zones {
@@ -195,11 +208,15 @@ func (zs *zones) upgrade(ctx context.Context, rclient client.Client, cr *vmv1alp
 	if !zs.hasChanges[i] {
 		needsLBUpdate = false
 	}
+	newAcceptsWrites := vmCluster.Spec.VMInsert != nil && ptr.Deref(vmCluster.Spec.VMInsert.ReplicaCount, 1) > 0
+
 	if needsLBUpdate {
-		// wait for empty persistent queue
-		zs.waitForEmptyPQ(ctx, rclient, defaultMetricsCheckInterval, i)
-		if ctx.Err() != nil {
-			return fmt.Errorf("zone=%s: failed to wait till VMCluster=%s queue is empty", item, nsnCluster.String())
+		if zs.prevAcceptsWrites[i] {
+			// wait for empty persistent queue before excluding from LB
+			zs.waitForEmptyPQ(ctx, rclient, defaultMetricsCheckInterval, i)
+			if ctx.Err() != nil {
+				return fmt.Errorf("zone=%s: failed to wait till VMCluster=%s queue is empty", item, nsnCluster.String())
+			}
 		}
 
 		// excluding zone from VMAuth LB
@@ -219,10 +236,12 @@ func (zs *zones) upgrade(ctx context.Context, rclient client.Client, cr *vmv1alp
 		return fmt.Errorf("zone=%s: failed to reconcile VMAgent=%s: %w", item, nsnAgent.String(), err)
 	}
 
-	// wait for empty persistent queue
-	zs.waitForEmptyPQ(ctx, rclient, defaultMetricsCheckInterval, i)
-	if ctx.Err() != nil {
-		return fmt.Errorf("zone=%s: failed to wait till VMAgent queue for VMCluster=%s is drained", item, nsnCluster.String())
+	if newAcceptsWrites {
+		// wait for empty persistent queue before restoring in LB
+		zs.waitForEmptyPQ(ctx, rclient, defaultMetricsCheckInterval, i)
+		if ctx.Err() != nil {
+			return fmt.Errorf("zone=%s: failed to wait till VMAgent queue for VMCluster=%s is drained", item, nsnCluster.String())
+		}
 	}
 
 	// restore zone in VMAuth LB
@@ -238,7 +257,7 @@ func (zs *zones) updateLB(ctx context.Context, rclient client.Client, cr *vmv1al
 	if !ptr.Deref(cr.Spec.VMAuth.Enabled, true) {
 		return nil
 	}
-	vmAuth := buildVMAuthLB(cr, zs.vmagents, zs.vmclusters, excludeIds...)
+	vmAuth := buildVMAuthLB(cr, zs.vmagents, zs.vmclusters, zs.trafficModes, excludeIds...)
 	if vmAuth == nil {
 		return nil
 	}

--- a/internal/controller/operator/factory/vmdistributed/zone_test.go
+++ b/internal/controller/operator/factory/vmdistributed/zone_test.go
@@ -260,9 +260,11 @@ func TestZonesSorting(t *testing.T) {
 	f := func(o opts) {
 		t.Helper()
 		zs := &zones{
-			vmclusters: o.clusters,
-			vmagents:   make([]*vmv1beta1.VMAgent, len(o.clusters)),
-			hasChanges: make([]bool, len(o.clusters)),
+			vmclusters:        o.clusters,
+			vmagents:          make([]*vmv1beta1.VMAgent, len(o.clusters)),
+			hasChanges:        make([]bool, len(o.clusters)),
+			trafficModes:      make([]vmv1alpha1.VMDistributedTrafficMode, len(o.clusters)),
+			prevAcceptsWrites: make([]bool, len(o.clusters)),
 		}
 		for i := range o.clusters {
 			zs.vmagents[i] = &vmv1beta1.VMAgent{

--- a/test/e2e/vmdistributed_test.go
+++ b/test/e2e/vmdistributed_test.go
@@ -1030,6 +1030,113 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 				return nil
 			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
 		})
+
+		It("should correctly migrate zones between traffic modes", func() {
+			nsn.Name = "vmd-traffic-mode"
+
+			zonesCount := 2
+			clusterSpec := vmv1beta1.VMClusterSpec{
+				VMSelect:  &vmv1beta1.VMSelect{CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To[int32](1)}},
+				VMInsert:  &vmv1beta1.VMInsert{CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To[int32](1)}},
+				VMStorage: &vmv1beta1.VMStorage{CommonAppsParams: vmv1beta1.CommonAppsParams{ReplicaCount: ptr.To[int32](1)}},
+			}
+
+			zs := make([]vmv1alpha1.VMDistributedZone, zonesCount)
+			vmClusters := make([]*vmv1beta1.VMCluster, zonesCount)
+			vmAgents := make([]*vmv1beta1.VMAgent, zonesCount)
+			for i := range zs {
+				objMeta := metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      fmt.Sprintf("%s-%d", nsn.Name, i+1),
+				}
+				zs[i].Name = objMeta.Name
+				zs[i].VMCluster.Name = objMeta.Name
+				zs[i].VMCluster.Spec = clusterSpec
+				zs[i].VMAgent.Name = objMeta.Name
+				vmClusters[i] = &vmv1beta1.VMCluster{ObjectMeta: objMeta, Spec: clusterSpec}
+				vmAgents[i] = &vmv1beta1.VMAgent{ObjectMeta: objMeta, Spec: genVMAgentSpec()}
+			}
+
+			var wg sync.WaitGroup
+			createVMClusters(ctx, &wg, k8sClient, vmClusters...)
+			createVMAgents(ctx, &wg, k8sClient, vmAgents...)
+			createVMAuth(ctx, &wg, k8sClient, nsn.Name, namespace)
+			wg.Wait()
+
+			By("creating VMDistributed with both zones in read-write mode")
+			cr := &vmv1alpha1.VMDistributed{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: nsn.Name},
+				Spec: vmv1alpha1.VMDistributedSpec{
+					ZoneCommon: vmv1alpha1.VMDistributedZoneCommon{
+						ReadyTimeout: &metav1.Duration{Duration: 2 * time.Minute},
+						UpdatePause:  &metav1.Duration{Duration: 1 * time.Second},
+					},
+					VMAuth: vmv1alpha1.VMDistributedAuth{Name: nsn.Name},
+					Zones:  zs,
+				},
+			}
+			DeferCleanup(func() {
+				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
+			})
+			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			Eventually(func() error {
+				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
+			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+
+			zone0NSN := types.NamespacedName{Name: vmClusters[0].Name, Namespace: namespace}
+			zone1NSN := types.NamespacedName{Name: vmClusters[1].Name, Namespace: namespace}
+
+			getInsertReplicas := func(name types.NamespacedName) int32 {
+				GinkgoHelper()
+				var c vmv1beta1.VMCluster
+				Expect(k8sClient.Get(ctx, name, &c)).ToNot(HaveOccurred())
+				if c.Spec.VMInsert == nil {
+					return -1
+				}
+				return ptr.Deref(c.Spec.VMInsert.ReplicaCount, -1)
+			}
+
+			By("verifying both zones start with VMInsert enabled")
+			Expect(getInsertReplicas(zone0NSN)).To(BeEquivalentTo(1))
+			Expect(getInsertReplicas(zone1NSN)).To(BeEquivalentTo(1))
+
+			By("switching zone 0 to read-only mode")
+			Eventually(func() error {
+				var obj vmv1alpha1.VMDistributed
+				if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
+					return err
+				}
+				obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadOnly
+				return k8sClient.Update(ctx, &obj)
+			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+
+			By("waiting for VMDistributed to complete read-only transition")
+			Eventually(func() error {
+				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
+			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+
+			By("verifying zone 0 VMInsert is disabled and zone 1 is unchanged")
+			Expect(getInsertReplicas(zone0NSN)).To(BeEquivalentTo(0))
+			Expect(getInsertReplicas(zone1NSN)).To(BeEquivalentTo(1))
+
+			By("switching zone 0 back to read-write mode")
+			Eventually(func() error {
+				var obj vmv1alpha1.VMDistributed
+				if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
+					return err
+				}
+				obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadWrite
+				return k8sClient.Update(ctx, &obj)
+			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+
+			By("waiting for VMDistributed to complete read-write transition")
+			Eventually(func() error {
+				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
+			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+
+			By("verifying zone 0 VMInsert is re-enabled")
+			Expect(getInsertReplicas(zone0NSN)).To(BeEquivalentTo(1))
+		})
 	})
 
 	Context("fail", func() {


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1995

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-zone traffic modes to `vmdistributed` to control read and write routing without removing a zone. `vmauth` now builds separate read and write targets and applies each zone’s mode during updates.

- **New Features**
  - Added `spec.zones[*].trafficMode` with `read-write` (default), `read-only`, `write-only`, `maintenance` (CRDs, defaults, docs updated).
  - `vmauth` LB: `read-only` zones are excluded from write targets (VMAgent); `write-only` from read targets (VMCluster); `maintenance` from both.
  - In `read-only` or `maintenance`, the zone’s VMInsert scales to 0 replicas to block writes.
  - Drains VMAgent queues only when a zone stops or starts accepting writes to avoid unnecessary waits around LB updates.

<sup>Written for commit a761f933bb8919e5f43be2a25686f82ba3c2b37d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

