### PR TITLE
internal/config: update VM_METRICS_VERSION to v1.141.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ aliases:
 
 ## tip
 
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.141.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.141.0) version
 * FEATURE: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth): previously VMAuth could read configuration only from predefined locations; now VMAuth supports arbitrary filesystem access configuration, allowing users to reference required files directly and reducing configuration workarounds. See [#899](https://github.com/VictoriaMetrics/operator/issues/899).
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,6 +1,6 @@
 | Environment variables |
 | --- |
-| VM_METRICS_VERSION: `v1.140.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
+| VM_METRICS_VERSION: `v1.141.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
 | VM_LOGS_VERSION: `v1.50.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
 | VM_ANOMALY_VERSION: `v1.29.3` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a> |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a> |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ var (
 	initConf sync.Once
 
 	defaultEnvs = map[string]string{
-		"VM_METRICS_VERSION":  "v1.140.0",
+		"VM_METRICS_VERSION":  "v1.141.0",
 		"VM_LOGS_VERSION":     "v1.50.0",
 		"VM_ANOMALY_VERSION":  "v1.29.3",
 		"VM_TRACES_VERSION":   "v0.7.0",


### PR DESCRIPTION
Changelog [v1.141.0](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md#v11410)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped default `VM_METRICS_VERSION` to `v1.141.0` and updated docs to align with the VictoriaMetrics v1.141.0 release. This makes new deployments use the latest metrics version by default.

- **Dependencies**
  - Set `VM_METRICS_VERSION` to `v1.141.0` in `internal/config` and `docs/env.md`.
  - Added changelog note that `vmoperator` defaults are updated to `v1.141.0`.

<sup>Written for commit 6f3932ba53026dae8de02fe34cb7c298431ac670. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2105?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

