### PR TITLE
reconcile: apply predicate.TypedGenerationChangedPredicate filter in all controllers to fix frequent reconciles

### DIFF
--- a/api/operator/v1/vlagent_types.go
+++ b/api/operator/v1/vlagent_types.go
@@ -7,7 +7,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -478,7 +477,7 @@ func (*VLAgent) ProbeNeedLiveness() bool {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VLAgent) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1/vlcluster_types.go
+++ b/api/operator/v1/vlcluster_types.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -797,7 +796,7 @@ func (cr *VLCluster) AvailableStorageNodeIDs(requestsType string) []int32 {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VLCluster) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1/vlsingle_types.go
+++ b/api/operator/v1/vlsingle_types.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -318,7 +317,7 @@ func (cr *VLSingle) AsURL() string {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VLSingle) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -24,7 +24,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -462,7 +461,7 @@ func (cr *VMAnomaly) GetShardCount() int32 {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMAnomaly) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1/vtcluster_types.go
+++ b/api/operator/v1/vtcluster_types.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -708,7 +707,7 @@ func (cr *VTCluster) AvailableStorageNodeIDs(requestsType string) []int32 {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VTCluster) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1/vtsingle_types.go
+++ b/api/operator/v1/vtsingle_types.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -314,7 +313,7 @@ func (cr *VTSingle) AsURL() string {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VTSingle) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1alpha1/vmdistributed_types.go
+++ b/api/operator/v1alpha1/vmdistributed_types.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -412,7 +411,7 @@ func (cr *VMDistributed) GetStatusMetadata() *vmv1beta1.StatusMetadata {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMDistributed) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !vmv1beta1.SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vlogs_types.go
+++ b/api/operator/v1beta1/vlogs_types.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -297,7 +296,7 @@ func (cr *VLogs) AsURL() string {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VLogs) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -632,7 +631,7 @@ func (cr *VMAgent) IsUnmanaged(scrape client.Object) bool {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMAgent) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmalert_types.go
+++ b/api/operator/v1beta1/vmalert_types.go
@@ -8,7 +8,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -490,7 +489,7 @@ func (cr *VMAlert) IsUnmanaged() bool {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMAlert) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -10,7 +10,6 @@ import (
 	amparse "github.com/prometheus/alertmanager/matcher/parse"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -484,7 +483,7 @@ func (cr *VMAlertmanager) IsUnmanaged() bool {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMAlertmanager) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -9,7 +9,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -748,7 +747,7 @@ func (cr *VMAuth) AutomountServiceAccountToken() bool {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMAuth) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -7,7 +7,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -754,7 +753,7 @@ func (cr *VMCluster) FinalAnnotations() map[string]string {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMCluster) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -1360,6 +1360,16 @@ type ExternalConfig struct {
 	LocalPath string `json:"localPath,omitempty" yaml:"localPath,omitempty"`
 }
 
+// SpecEqualJSON compares two specs of the same type by JSON marshaling.
+// This treats nil and empty maps/slices identically since both are omitted
+// with omitempty, avoiding false positives from in-memory defaulting that
+// converts nil maps to empty ones.
+func SpecEqualJSON[T any](a, b *T) bool {
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return bytes.Equal(ab, bb)
+}
+
 // StatusMetadata holds metadata of application update status
 // +k8s:openapi-gen=true
 type StatusMetadata struct {

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -355,7 +354,7 @@ func (cr *VMSingle) AsURL() string {
 
 // LastSpecUpdated compares spec with last applied spec stored, replaces old spec and returns true if it's updated
 func (cr *VMSingle) LastSpecUpdated() bool {
-	updated := cr.Status.LastAppliedSpec == nil || !equality.Semantic.DeepEqual(&cr.Spec, cr.Status.LastAppliedSpec)
+	updated := cr.Status.LastAppliedSpec == nil || !SpecEqualJSON(&cr.Spec, cr.Status.LastAppliedSpec)
 	cr.Status.LastAppliedSpec = cr.Spec.DeepCopy()
 	return updated
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): change default load balancing policy for write requests from `first_available` to `least_loaded`. This should allow to evenly distribute write load across all VMAgents.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): replace DeepEqual with marshalled JSON specs compare. See [#2113](https://github.com/VictoriaMetrics/operator/issues/2113).
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ aliases:
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): change default load balancing policy for write requests from `first_available` to `least_loaded`. This should allow to evenly distribute write load across all VMAgents.
-* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): replace DeepEqual with marshalled JSON specs compare. See [#2113](https://github.com/VictoriaMetrics/operator/issues/2113).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): added TypedGenerationChangedPredicate filter to all controllers to prevent from frequent reconciles and compare JSONs instead of using DeepEqual. See [#2113](https://github.com/VictoriaMetrics/operator/issues/2113).
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -113,6 +114,7 @@ func (r *VLAgentReconciler) Scheme() *runtime.Scheme {
 func (r *VLAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VLAgent{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -101,6 +102,7 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *VLClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VLCluster{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -92,6 +93,7 @@ func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 func (r *VLogsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VLogs{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -102,6 +103,7 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 func (r *VLSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VLSingle{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -138,6 +139,7 @@ func (r *VMAgentReconciler) Scheme() *runtime.Scheme {
 func (r *VMAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAgent{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -123,6 +124,7 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 func (r *VMAlertReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAlert{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -123,6 +124,7 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *VMAlertmanagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAlertmanager{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -120,6 +121,7 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *VMAnomalyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VMAnomaly{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -119,6 +120,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 func (r *VMAuthReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMAuth{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -91,6 +92,7 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 func (r *VMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMCluster{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1alpha1 "github.com/VictoriaMetrics/operator/api/operator/v1alpha1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -106,6 +107,7 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *VMDistributedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1alpha1.VMDistributed{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		WithOptions(getDefaultOptions()).
 		Complete(r)
 }

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -132,6 +133,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 func (r *VMSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1beta1.VMSingle{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		WithOptions(getDefaultOptions()).

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -101,6 +102,7 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *VTClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VTCluster{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -102,6 +103,7 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 func (r *VTSingleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VTSingle{}).
+		WithEventFilter(predicate.TypedGenerationChangedPredicate[client.Object]{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(getDefaultOptions()).


### PR DESCRIPTION
fixes #2113


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `predicate.TypedGenerationChangedPredicate` in all controllers to reconcile on generation changes. Compare specs via JSON instead of DeepEqual to avoid nil/empty differences; status/labels/annotations no longer trigger reconcile.

<sup>Written for commit bb3ec36338de38f9848ca0363adcaa772533aaa4. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2115?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



