### PR TITLE
chore: move Spec.ParsingError to Status.ParsingSpecError

### DIFF
--- a/api/operator/v1/vlagent_types.go
+++ b/api/operator/v1/vlagent_types.go
@@ -18,8 +18,6 @@ import (
 // VLAgentSpec defines the desired state of VLAgent
 // +k8s:openapi-gen=true
 type VLAgentSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// ComponentVersion defines default images tag for all components.
 	// it can be overwritten with component specific image.tag value.
@@ -188,16 +186,6 @@ func (cr *VLAgent) UseProxyProtocol() bool {
 	return vmv1beta1.UseProxyProtocol(cr.Spec.ExtraArgs)
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VLAgentSpec) UnmarshalJSON(src []byte) error {
-	type pcr VLAgentSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vlagent spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VLAgentRemoteWriteSettings - defines global settings for all remoteWrite urls.
 type VLAgentRemoteWriteSettings struct {
 	// The maximum size of unpacked request to send to remote storage
@@ -276,6 +264,8 @@ type VLAgentStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VLAgentSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -352,6 +342,25 @@ func (cr *VLAgent) DefaultStatusFields(vs *VLAgentStatus) {
 		replicaCount = *cr.Spec.ReplicaCount
 	}
 	vs.Replicas = replicaCount
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VLAgent) UnmarshalJSON(src []byte) error {
+	type pcr VLAgent
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VLAgentSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // FinalAnnotations implements build.builderOpts interface

--- a/api/operator/v1/vlcluster_types.go
+++ b/api/operator/v1/vlcluster_types.go
@@ -34,8 +34,6 @@ import (
 
 // VLClusterSpec defines the desired state of VLCluster
 type VLClusterSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
 	// VLSelect, VLInsert and VLStorage Pods.
@@ -195,22 +193,14 @@ func (cr *VLCluster) FinalLabels(kind vmv1beta1.ClusterComponent) map[string]str
 	return v
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VLClusterSpec) UnmarshalJSON(src []byte) error {
-	type pcr VLClusterSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vlcluster spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VLClusterStatus defines the observed state of VLCluster
 type VLClusterStatus struct {
 	vmv1beta1.StatusMetadata `json:",inline"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VLClusterSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -674,6 +664,25 @@ func (cr *VLCluster) GetStatus() *VLClusterStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VLCluster) DefaultStatusFields(vs *VLClusterStatus) {
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VLCluster) UnmarshalJSON(src []byte) error {
+	type pcr VLCluster
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VLClusterSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // AsOwner returns owner references with current object as owner

--- a/api/operator/v1/vlsingle_types.go
+++ b/api/operator/v1/vlsingle_types.go
@@ -33,8 +33,6 @@ import (
 // VLSingleSpec defines the desired state of VLSingle
 // +k8s:openapi-gen=true
 type VLSingleSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// PodMetadata configures Labels and Annotations which are propagated to the VLSingle pods.
 	// +optional
@@ -116,6 +114,8 @@ type VLSingleStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VLSingleSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -156,7 +156,25 @@ func (cr *VLSingle) UseProxyProtocol() bool {
 }
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
-func (cr *VLSingle) DefaultStatusFields(vs *VLSingleStatus) {
+func (cr *VLSingle) DefaultStatusFields(vs *VLSingleStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VLSingle) UnmarshalJSON(src []byte) error {
+	type pcr VLSingle
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VLSingleSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // +kubebuilder:object:root=true
@@ -188,16 +206,6 @@ func (r *VLSingle) AsOwner() metav1.OwnerReference {
 		Controller:         ptr.To(true),
 		BlockOwnerDeletion: ptr.To(true),
 	}
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VLSingleSpec) UnmarshalJSON(src []byte) error {
-	type pcr VLSingleSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vlsingle spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 func (cr *VLSingle) ProbePath() string {

--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -35,8 +35,6 @@ import (
 // VMAnomalySpec defines the desired state of VMAnomaly.
 // +k8s:openapi-gen=true
 type VMAnomalySpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// ComponentVersion defines default images tag for all components.
 	// it can be overwritten with component specific image.tag value.
@@ -198,6 +196,8 @@ type VMAnomalyStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMAnomalySpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -321,6 +321,25 @@ func (cr *VMAnomaly) DefaultStatusFields(vs *VMAnomalyStatus) {
 		shardCnt = *cr.Spec.ShardCount
 	}
 	vs.Shards = shardCnt
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMAnomaly) UnmarshalJSON(src []byte) error {
+	type pcr VMAnomaly
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAnomalySpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // SelectorLabels returns selector labels for vmanomaly
@@ -488,16 +507,6 @@ func (cr *VMAnomaly) Paused() bool {
 // UseProxyProtocol implements build.probeCRD interface
 func (cr *VMAnomaly) UseProxyProtocol() bool {
 	return false
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMAnomalySpec) UnmarshalJSON(src []byte) error {
-	type pcr VMAnomalySpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmanomaly spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // IsUnmanaged checks if object should manage any config objects

--- a/api/operator/v1/vtcluster_types.go
+++ b/api/operator/v1/vtcluster_types.go
@@ -34,8 +34,6 @@ import (
 
 // VTClusterSpec defines the desired state of VTCluster
 type VTClusterSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run the
 	// VTSelect, VTInsert and VTStorage Pods.
@@ -190,22 +188,14 @@ func (cr *VTCluster) FinalLabels(kind vmv1beta1.ClusterComponent) map[string]str
 	return v
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VTClusterSpec) UnmarshalJSON(src []byte) error {
-	type pcr VTClusterSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vtcluster spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VTClusterStatus defines the observed state of VTCluster
 type VTClusterStatus struct {
 	vmv1beta1.StatusMetadata `json:",inline"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VTClusterSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -584,6 +574,25 @@ func (cr *VTCluster) GetStatus() *VTClusterStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VTCluster) DefaultStatusFields(vs *VTClusterStatus) {
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VTCluster) UnmarshalJSON(src []byte) error {
+	type pcr VTCluster
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VTClusterSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // AsOwner returns owner references with current object as owner

--- a/api/operator/v1/vtsingle_types.go
+++ b/api/operator/v1/vtsingle_types.go
@@ -33,8 +33,6 @@ import (
 // VTSingleSpec defines the desired state of VTSingle
 // +k8s:openapi-gen=true
 type VTSingleSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// PodMetadata configures Labels and Annotations which are propagated to the VTSingle pods.
 	// +optional
@@ -110,6 +108,8 @@ type VTSingleStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VTSingleSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -148,6 +148,25 @@ func (cr *VTSingle) GetStatus() *VTSingleStatus {
 func (cr *VTSingle) DefaultStatusFields(vs *VTSingleStatus) {
 }
 
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VTSingle) UnmarshalJSON(src []byte) error {
+	type pcr VTSingle
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VTSingleSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
+
 // +kubebuilder:object:root=true
 
 // VTSingleList contains a list of VTSingle
@@ -177,16 +196,6 @@ func (r *VTSingle) AsOwner() metav1.OwnerReference {
 		Controller:         ptr.To(true),
 		BlockOwnerDeletion: ptr.To(true),
 	}
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VTSingleSpec) UnmarshalJSON(src []byte) error {
-	type pcr VTSingleSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vtsingle spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // ProbePath implements build.probeCRD interface

--- a/api/operator/v1alpha1/vmdistributed_types.go
+++ b/api/operator/v1alpha1/vmdistributed_types.go
@@ -39,8 +39,6 @@ const (
 // VMDistributedSpec defines configurable parameters for VMDistributed CR
 // +k8s:openapi-gen=true
 type VMDistributedSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// VMAuth is a VMAuth definition (name + optional spec) that acts as a proxy for the VMUsers created by the operator.
 	// Use an inline spec to define a VMAuth object in-place or provide a name to reference an existing VMAuth.
 	// +optional
@@ -156,8 +154,6 @@ type VMDistributedZoneAgent struct {
 // VMDistributedZoneAgentSpec is a customized specification of a new VMAgent.
 // It includes selected options from the original VMAgentSpec.
 type VMDistributedZoneAgentSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// PodMetadata configures Labels and Annotations which are propagated to the vmagent pods.
 	// +optional
 	PodMetadata *vmv1beta1.EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
@@ -317,6 +313,8 @@ type VMDistributedStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMDistributedSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="VMDistributed App"
@@ -424,11 +422,20 @@ func (cr *VMDistributed) SelectorLabels() map[string]string {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMDistributedSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMDistributedSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse VMDistributed spec: %s, err: %s", string(src), err)
-		return nil
+func (cr *VMDistributed) UnmarshalJSON(src []byte) error {
+	type pcr VMDistributed
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMDistributedSpec: %s, err: %s", string(s.Spec), err)
+		}
 	}
 	return nil
 }

--- a/api/operator/v1beta1/vlogs_types.go
+++ b/api/operator/v1beta1/vlogs_types.go
@@ -34,9 +34,6 @@ import (
 // +kubebuilder:validation:Schemaless
 // +kubebuilder:pruning:PreserveUnknownFields
 type VLogsSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
-
 	// PodMetadata configures Labels and Annotations which are propagated to the VLogs pods.
 	// +optional
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
@@ -102,6 +99,8 @@ type VLogsStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VLogsSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -172,11 +171,20 @@ func (r *VLogs) AsOwner() metav1.OwnerReference {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VLogsSpec) UnmarshalJSON(src []byte) error {
-	type pcr VLogsSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vlogs spec: %s, err: %s", string(src), err)
-		return nil
+func (cr *VLogs) UnmarshalJSON(src []byte) error {
+	type pcr VLogs
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VLogsSpec: %s, err: %s", string(s.Spec), err)
+		}
 	}
 	return nil
 }

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -19,8 +19,6 @@ import (
 // VMAgentSpec defines the desired state of VMAgent
 // +k8s:openapi-gen=true
 type VMAgentSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// PodMetadata configures Labels and Annotations which are propagated to the vmagent pods.
 	// +optional
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
@@ -269,11 +267,20 @@ func (cr *VMAgent) AutomountServiceAccountToken() bool {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMAgentSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMAgentSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmagent spec: %s, err: %s", string(src), err)
-		return nil
+func (cr *VMAgent) UnmarshalJSON(src []byte) error {
+	type pcr VMAgent
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAgentSpec: %s, err: %s", string(s.Spec), err)
+		}
 	}
 	return nil
 }
@@ -401,6 +408,8 @@ type VMAgentStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMAgentSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -605,7 +614,7 @@ func (cr *VMAgent) ScrapeSelectors(scrape client.Object) (*metav1.LabelSelector,
 
 // IsUnmanaged checks if object should managed any config objects
 func (cr *VMAgent) IsUnmanaged(scrape client.Object) bool {
-	if !cr.DeletionTimestamp.IsZero() || cr.Spec.ParsingError != "" {
+	if !cr.DeletionTimestamp.IsZero() || cr.Status.ParsingSpecError != "" {
 		return true
 	}
 	if scrape == nil {

--- a/api/operator/v1beta1/vmalert_types.go
+++ b/api/operator/v1beta1/vmalert_types.go
@@ -23,8 +23,6 @@ const (
 // VMAlertSpec defines the desired state of VMAlert
 // +k8s:openapi-gen=true
 type VMAlertSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// PodMetadata configures Labels and Annotations which are propagated to the VMAlert pods.
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
 	// ManagedMetadata defines metadata that will be added to the all objects
@@ -177,11 +175,20 @@ func (cr *VMAlert) AutomountServiceAccountToken() bool {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMAlertSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMAlertSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmalert spec: %s, err: %s", string(src), err)
-		return nil
+func (cr *VMAlert) UnmarshalJSON(src []byte) error {
+	type pcr VMAlert
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAlertSpec: %s, err: %s", string(s.Spec), err)
+		}
 	}
 	return nil
 }
@@ -266,6 +273,8 @@ type VMAlertStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMAlertSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -485,6 +494,9 @@ func (cr *VMAlert) AsURL() string {
 
 // IsUnmanaged checks if object should managed any  config objects
 func (cr *VMAlert) IsUnmanaged() bool {
+	if !cr.DeletionTimestamp.IsZero() || cr.Status.ParsingSpecError != "" {
+		return true
+	}
 	return !cr.Spec.SelectAllByDefault && cr.Spec.RuleSelector == nil && cr.Spec.RuleNamespaceSelector == nil
 }
 

--- a/api/operator/v1beta1/vmalertmanager_types.go
+++ b/api/operator/v1beta1/vmalertmanager_types.go
@@ -47,8 +47,6 @@ type VMAlertmanager struct {
 // https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +k8s:openapi-gen=true
 type VMAlertmanagerSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.
 	// +optional
@@ -246,16 +244,6 @@ func (cr *VMAlertmanager) AutomountServiceAccountToken() bool {
 	return !cr.Spec.DisableAutomountServiceAccountToken
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMAlertmanagerSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMAlertmanagerSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmalertmanager spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VMAlertmanagerList is a list of Alertmanagers.
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -275,6 +263,8 @@ type VMAlertmanagerStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMAlertmanagerSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -288,7 +278,25 @@ func (cr *VMAlertmanager) GetStatus() *VMAlertmanagerStatus {
 }
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
-func (cr *VMAlertmanager) DefaultStatusFields(vs *VMAlertmanagerStatus) {
+func (cr *VMAlertmanager) DefaultStatusFields(vs *VMAlertmanagerStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMAlertmanager) UnmarshalJSON(src []byte) error {
+	type pcr VMAlertmanager
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAlertmanagerSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 // AsOwner returns owner references with current object as owner
@@ -479,6 +487,9 @@ func (*VMAlertmanager) ProbeNeedLiveness() bool {
 
 // IsUnmanaged checks if alertmanager should managed any alertmanager config objects
 func (cr *VMAlertmanager) IsUnmanaged() bool {
+	if !cr.DeletionTimestamp.IsZero() || cr.Status.ParsingSpecError != "" {
+		return true
+	}
 	return !cr.Spec.SelectAllByDefault && cr.Spec.ConfigSelector == nil && cr.Spec.ConfigNamespaceSelector == nil
 }
 

--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -56,8 +56,6 @@ type VMAlertmanagerConfigSpec struct {
 	// See https://prometheus.io/docs/alerting/latest/configuration/#time_interval
 	// +optional
 	TimeIntervals []TimeIntervals `json:"time_intervals,omitempty" yaml:"time_intervals,omitempty"`
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 }
 
 // TimeIntervals for alerts
@@ -269,6 +267,8 @@ type VMAlertmanagerConfigStatus struct {
 	// reconcile
 	StatusMetadata                  `json:",inline"`
 	LastErrorParentAlertmanagerName string `json:"lastErrorParentAlertmanagerName,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // VMAlertmanagerConfig is the Schema for the vmalertmanagerconfigs API
@@ -376,18 +376,26 @@ func parseNestedRoutes(src *Route) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (r *VMAlertmanagerConfig) UnmarshalJSON(src []byte) error {
-	type amcfg VMAlertmanagerConfig
-	if err := json.Unmarshal(src, (*amcfg)(r)); err != nil {
-		r.Spec.ParsingError = fmt.Sprintf("cannot parse alertmanager config: %s, err: %s", string(src), err)
-		return nil
+func (cr *VMAlertmanagerConfig) UnmarshalJSON(src []byte) error {
+	type pcr VMAlertmanagerConfig
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
 	}
-
-	if err := parseNestedRoutes(r.Spec.Route); err != nil {
-		r.Spec.ParsingError = fmt.Sprintf("cannot parse routes for alertmanager config: %s at namespace: %s, err: %s", r.Name, r.Namespace, err)
-		return nil
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
 	}
-
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAlertmanagerConfigSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	if err := parseNestedRoutes(cr.Spec.Route); err != nil {
+		if len(cr.Status.ParsingSpecError) == 0 {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse routes for VMAlertmanagerConfig: %s at namespace: %s, err: %s", cr.Name, cr.Namespace, err)
+		}
+	}
 	return nil
 }
 

--- a/api/operator/v1beta1/vmalertmanagerconfig_types_test.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types_test.go
@@ -13,11 +13,11 @@ func TestValidateVMAlertmanagerConfigFail(t *testing.T) {
 		t.Helper()
 		var amc VMAlertmanagerConfig
 		assert.NoError(t, json.Unmarshal([]byte(src), &amc))
-		if len(amc.Spec.ParsingError) > 0 {
-			if strings.Contains(amc.Spec.ParsingError, expectedReason) {
+		if len(amc.Status.ParsingSpecError) > 0 {
+			if strings.Contains(amc.Status.ParsingSpecError, expectedReason) {
 				return
 			}
-			t.Fatalf("unexpected parsing error: %s", amc.Spec.ParsingError)
+			t.Fatalf("unexpected parsing error: %s", amc.Status.ParsingSpecError)
 		}
 		err := amc.Validate()
 		if assert.Error(t, err, "expect error:\n%s\n got nil", expectedReason) {
@@ -403,7 +403,7 @@ func TestValidateVMAlertmanagerConfigOk(t *testing.T) {
 		t.Helper()
 		var amc VMAlertmanagerConfig
 		assert.NoError(t, json.Unmarshal([]byte(src), &amc))
-		assert.Empty(t, amc.Spec.ParsingError)
+		assert.Empty(t, amc.Status.ParsingSpecError)
 		assert.NoError(t, amc.Validate())
 	}
 	f(`{

--- a/api/operator/v1beta1/vmauth_types.go
+++ b/api/operator/v1beta1/vmauth_types.go
@@ -22,8 +22,6 @@ var labelNameRegexp = regexp.MustCompile("^[a-zA-Z_:.][a-zA-Z0-9_:.]*$")
 
 // VMAuthSpec defines the desired state of VMAuth
 type VMAuthSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 
 	// ComponentVersion defines default images tag for all components.
 	// it can be overwritten with component specific image.tag value.
@@ -485,16 +483,6 @@ func (cr *VMAuth) Validate() error {
 	return nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMAuthSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMAuthSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmauth spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // EmbeddedHTTPRoute describes httproute configuration options.
 //
 // Requires gateway-controller CRD installed and VM_GATEWAY_API_ENABLED=true env var
@@ -550,6 +538,8 @@ type VMAuthStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMAuthSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status
@@ -581,6 +571,25 @@ func (cr *VMAuth) GetStatus() *VMAuthStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMAuth) DefaultStatusFields(vs *VMAuthStatus) {
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMAuth) UnmarshalJSON(src []byte) error {
+	type pcr VMAuth
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMAuthSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
 }
 
 func (cr *VMAuth) ProbePath() string {
@@ -710,6 +719,9 @@ func (cr *VMAuth) IsOwnsServiceAccount() bool {
 
 // IsUnmanaged checks if object should managed any  config objects
 func (cr *VMAuth) IsUnmanaged() bool {
+	if !cr.DeletionTimestamp.IsZero() || cr.Status.ParsingSpecError != "" {
+		return true
+	}
 	return (!cr.Spec.SelectAllByDefault && cr.Spec.UserSelector == nil && cr.Spec.UserNamespaceSelector == nil) ||
 		cr.Spec.SecretRef != nil ||
 		cr.Spec.LocalPath != ""

--- a/api/operator/v1beta1/vmcluster_types.go
+++ b/api/operator/v1beta1/vmcluster_types.go
@@ -17,8 +17,6 @@ import (
 // VMClusterSpec defines the desired state of VMCluster
 // +k8s:openapi-gen=true
 type VMClusterSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// RetentionPeriod defines how long to retain stored metrics, specified as a duration (e.g., "1d", "1w", "1m").
 	// Data with timestamps outside the RetentionPeriod is automatically deleted. The minimum allowed value is 1d, or 24h.
 	// The default value is 1 (one month).
@@ -175,16 +173,6 @@ func (cr *VMCluster) PrefixedInternalName(kind ClusterComponent) string {
 	return ClusterPrefixedName(kind, cr.Name, "vm", true)
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMClusterSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMClusterSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmcluster spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VMCluster is fast, cost-effective and scalable time-series database.
 // Cluster version with
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="VMCluster App"
@@ -220,6 +208,25 @@ func (cr *VMCluster) GetStatus() *VMClusterStatus {
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMCluster) DefaultStatusFields(vs *VMClusterStatus) {}
 
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMCluster) UnmarshalJSON(src []byte) error {
+	type pcr VMCluster
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMClusterSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
+
 // AsOwner returns owner references with current object as owner
 func (cr *VMCluster) AsOwner() metav1.OwnerReference {
 	return metav1.OwnerReference{
@@ -238,6 +245,8 @@ type VMClusterStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMClusterSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata returns metadata for object status

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -1073,6 +1073,8 @@ type TLSClientConfig struct {
 // ScrapeObjectStatus defines the observed state of ScrapeObjects
 type ScrapeObjectStatus struct {
 	StatusMetadata `json:",inline"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // StatefulSetUpdateStrategyBehavior customizes behavior for StatefulSet updates.

--- a/api/operator/v1beta1/vmnodescrape_types.go
+++ b/api/operator/v1beta1/vmnodescrape_types.go
@@ -7,12 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ json.Unmarshaler = (*VMNodeScrapeSpec)(nil)
+var _ json.Unmarshaler = (*VMNodeScrape)(nil)
 
 // VMNodeScrapeSpec defines specification for VMNodeScrape.
 type VMNodeScrapeSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// The label to use to retrieve the job name from.
 	// +optional
 	JobLabel string `json:"jobLabel,omitempty"`
@@ -34,16 +32,6 @@ type VMNodeScrapeSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMNodeScrapeSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMNodeScrapeSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // VMNodeScrape defines discovery for targets placed on kubernetes nodes,
@@ -93,6 +81,25 @@ func (cr *VMNodeScrape) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMNodeScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMNodeScrape) UnmarshalJSON(src []byte) error {
+	type pcr VMNodeScrape
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMNodeScrapeSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
 
 // AsKey returns unique key for object
 func (cr *VMNodeScrape) AsKey(_ bool) string {

--- a/api/operator/v1beta1/vmpodscrape_types.go
+++ b/api/operator/v1beta1/vmpodscrape_types.go
@@ -8,12 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ json.Unmarshaler = (*VMPodScrapeSpec)(nil)
+var _ json.Unmarshaler = (*VMPodScrape)(nil)
 
 // VMPodScrapeSpec defines the desired state of VMPodScrape
 type VMPodScrapeSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// The label to use to retrieve the job name from.
 	// +optional
 	JobLabel string `json:"jobLabel,omitempty"`
@@ -44,16 +42,6 @@ type VMPodScrapeSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMPodScrapeSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMPodScrapeSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // VMPodScrape is scrape configuration for pods,
@@ -158,3 +146,22 @@ func (cr *VMPodScrape) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMPodScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMPodScrape) UnmarshalJSON(src []byte) error {
+	type pcr VMPodScrape
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMPodScrapeSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}

--- a/api/operator/v1beta1/vmprobe_types.go
+++ b/api/operator/v1beta1/vmprobe_types.go
@@ -23,13 +23,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ json.Unmarshaler = (*VMProbeSpec)(nil)
+var _ json.Unmarshaler = (*VMProbe)(nil)
 
 // VMProbeSpec contains specification parameters for a Probe.
 // +k8s:openapi-gen=true
 type VMProbeSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// The job name assigned to scraped metrics by default.
 	JobName string `json:"jobName,omitempty"`
 	// Specification for the prober to use for probing targets.
@@ -49,16 +47,6 @@ type VMProbeSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMProbeSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMProbeSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // VMProbeTargets defines a set of static and dynamically discovered targets for the prober.
@@ -173,6 +161,25 @@ func (cr *VMProbe) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMProbe) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMProbe) UnmarshalJSON(src []byte) error {
+	type pcr VMProbe
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMProbeSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
 
 // AsKey returns unique key for object
 func (cr *VMProbe) AsKey(_ bool) string {

--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -27,8 +27,6 @@ var initVMAlertTemplatesOnce sync.Once
 type VMRuleSpec struct {
 	// Groups list of group rules
 	Groups []RuleGroup `json:"groups"`
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 }
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.
@@ -135,6 +133,8 @@ type Rule struct {
 // VMRuleStatus defines the observed state of VMRule
 type VMRuleStatus struct {
 	StatusMetadata `json:",inline"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // GetStatusMetadata implements reconcile.objectWithStatus interface
@@ -243,11 +243,20 @@ type VMRule struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface
-func (r *VMRule) UnmarshalJSON(src []byte) error {
-	type rcfg VMRule
-	if err := json.Unmarshal(src, (*rcfg)(r)); err != nil {
-		r.Spec.ParsingError = fmt.Sprintf("cannot parse vmrule config: %s, err: %s", string(src), err)
-		return nil
+func (cr *VMRule) UnmarshalJSON(src []byte) error {
+	type pcr VMRule
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMRuleSpec: %s, err: %s", string(s.Spec), err)
+		}
 	}
 	return nil
 }

--- a/api/operator/v1beta1/vmscrapeconfig_types.go
+++ b/api/operator/v1beta1/vmscrapeconfig_types.go
@@ -41,12 +41,10 @@ type VMScrapeConfig struct {
 	Status ScrapeObjectStatus `json:"status,omitempty"`
 }
 
-var _ json.Unmarshaler = (*VMScrapeConfigSpec)(nil)
+var _ json.Unmarshaler = (*VMScrapeConfig)(nil)
 
 // VMScrapeConfigSpec defines the desired state of VMScrapeConfig
 type VMScrapeConfigSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// StaticConfigs defines a list of static targets with a common label set.
 	// +optional
 	StaticConfigs []StaticConfig `json:"staticConfigs,omitempty"`
@@ -106,16 +104,6 @@ type VMScrapeConfigSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMScrapeConfigSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMScrapeConfigSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // StaticConfig defines a static configuration.
@@ -659,3 +647,22 @@ func (cr *VMScrapeConfig) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMScrapeConfig) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMScrapeConfig) UnmarshalJSON(src []byte) error {
+	type pcr VMScrapeConfig
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMScrapeConfigSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}

--- a/api/operator/v1beta1/vmservicescrape_types.go
+++ b/api/operator/v1beta1/vmservicescrape_types.go
@@ -8,12 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ json.Unmarshaler = (*VMServiceScrapeSpec)(nil)
+var _ json.Unmarshaler = (*VMServiceScrape)(nil)
 
 // VMServiceScrapeSpec defines the desired state of VMServiceScrape
 type VMServiceScrapeSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// DiscoveryRole - defines kubernetes_sd role for objects discovery.
 	// by default, its endpoints.
 	// can be changed to service or endpointslices.
@@ -55,16 +53,6 @@ type VMServiceScrapeSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMServiceScrapeSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMServiceScrapeSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // VMServiceScrape is scrape configuration for endpoints associated with
@@ -180,3 +168,22 @@ func (cr *VMServiceScrape) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMServiceScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMServiceScrape) UnmarshalJSON(src []byte) error {
+	type pcr VMServiceScrape
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMServiceScrapeSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -17,8 +17,6 @@ import (
 // VMSingleSpec defines the desired state of VMSingle
 // +k8s:openapi-gen=true
 type VMSingleSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// PodMetadata configures Labels and Annotations which are propagated to the VMSingle pods.
 	// +optional
 	PodMetadata *EmbeddedObjectMetadata `json:"podMetadata,omitempty"`
@@ -118,7 +116,7 @@ func (cr *VMSingle) ScrapeSelectors(scrape client.Object) (*metav1.LabelSelector
 
 // IsUnmanaged checks if object should managed any config objects
 func (cr *VMSingle) IsUnmanaged(scrape client.Object) bool {
-	if !cr.DeletionTimestamp.IsZero() || cr.Spec.ParsingError != "" {
+	if !cr.DeletionTimestamp.IsZero() || cr.Status.ParsingSpecError != "" {
 		return true
 	}
 	if scrape == nil {
@@ -168,16 +166,6 @@ func (cr *VMSingle) AutomountServiceAccountToken() bool {
 	return !cr.Spec.DisableAutomountServiceAccountToken
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMSingleSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMSingleSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmsingle spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // VMSingleStatus defines the observed state of VMSingle
 // +k8s:openapi-gen=true
 type VMSingleStatus struct {
@@ -185,6 +173,8 @@ type VMSingleStatus struct {
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastAppliedSpec *VMSingleSpec `json:"lastAppliedSpec,omitempty"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // VMSingle  is fast, cost-effective and scalable time-series database.
@@ -215,6 +205,25 @@ func (cr *VMSingle) GetStatus() *VMSingleStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMSingle) DefaultStatusFields(_ *VMSingleStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMSingle) UnmarshalJSON(src []byte) error {
+	type pcr VMSingle
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMSingleSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
 
 func (cr *VMSingle) ProbePath() string {
 	return BuildPathWithPrefixFlag(cr.Spec.ExtraArgs, healthPath)

--- a/api/operator/v1beta1/vmstaticscrape_types.go
+++ b/api/operator/v1beta1/vmstaticscrape_types.go
@@ -7,12 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ json.Unmarshaler = (*VMStaticScrapeSpec)(nil)
+var _ json.Unmarshaler = (*VMStaticScrape)(nil)
 
 // VMStaticScrapeSpec defines the desired state of VMStaticScrape.
 type VMStaticScrapeSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// JobName name of job.
 	JobName string `json:"jobName,omitempty"`
 	// A list of target endpoints to scrape metrics from.
@@ -27,16 +25,6 @@ type VMStaticScrapeSpec struct {
 	// ScrapeClass defined scrape class to apply
 	// +optional
 	ScrapeClassName *string `json:"scrapeClass,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMStaticScrapeSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMStaticScrapeSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse spec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
 }
 
 // TargetEndpoint defines single static target endpoint.
@@ -99,6 +87,25 @@ func (cr *VMStaticScrape) GetStatus() *ScrapeObjectStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMStaticScrape) DefaultStatusFields(vs *ScrapeObjectStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMStaticScrape) UnmarshalJSON(src []byte) error {
+	type pcr VMStaticScrape
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMStaticScrapeSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
 
 // AsKey returns unique key for object
 func (cr *VMStaticScrape) AsKey(_ bool) string {

--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -34,8 +34,6 @@ type VMUserJWT struct {
 
 // VMUserSpec defines the desired state of VMUser
 type VMUserSpec struct {
-	// ParsingError contents error with context if operator was failed to parse json object from kubernetes api server
-	ParsingError string `json:"-" yaml:"-"`
 	// Name of the VMUser object.
 	// +optional
 	Name *string `json:"name,omitempty"`
@@ -233,6 +231,8 @@ type TargetRefBasicAuth struct {
 // VMUserStatus defines the observed state of VMUser
 type VMUserStatus struct {
 	StatusMetadata `json:",inline"`
+	// ParsingSpecError contents error with context if operator was failed to parse json object from kubernetes api server
+	ParsingSpecError string `json:"-" yaml:"-"`
 }
 
 // VMUser is the Schema for the vmusers API
@@ -313,16 +313,6 @@ func (cr *VMUser) SelectorLabels() map[string]string {
 	}
 }
 
-// UnmarshalJSON implements json.Unmarshaler interface
-func (cr *VMUserSpec) UnmarshalJSON(src []byte) error {
-	type pcr VMUserSpec
-	if err := json.Unmarshal(src, (*pcr)(cr)); err != nil {
-		cr.ParsingError = fmt.Sprintf("cannot parse vmuserspec: %s, err: %s", string(src), err)
-		return nil
-	}
-	return nil
-}
-
 // FinalLabels returns combination of selector and managed labels
 func (cr *VMUser) FinalLabels() map[string]string {
 	v := cr.SelectorLabels()
@@ -344,6 +334,25 @@ func (cr *VMUser) GetStatus() *VMUserStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMUser) DefaultStatusFields(vs *VMUserStatus) {}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (cr *VMUser) UnmarshalJSON(src []byte) error {
+	type pcr VMUser
+	type shadow struct {
+		*pcr
+		Spec json.RawMessage `json:"spec"`
+	}
+	s := shadow{pcr: (*pcr)(cr)}
+	if err := json.Unmarshal(src, &s); err != nil {
+		return err
+	}
+	if len(s.Spec) > 0 {
+		if err := json.Unmarshal(s.Spec, &cr.Spec); err != nil {
+			cr.Status.ParsingSpecError = fmt.Sprintf("cannot parse VMUserSpec: %s, err: %s", string(s.Spec), err)
+		}
+	}
+	return nil
+}
 
 func (cr *VMUser) AsKey(hide bool) string {
 	var id string

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ aliases:
 * BUGFIX: [vmauth](https://docs.victoriametrics.com/operator/resources/vmauth/): fixed case, when target_path_suffix can be appended multiple times.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): retry reconcile errors, that may lead to expanding state, before resource could hang in expanding state.
 * BUGFIX: [vmcluster](https://docs.victoriametrics.com/operator/resources/vmcluster/), [vlcluster](https://docs.victoriametrics.com/operator/resources/vlcluster/) and [vtcluster](https://docs.victoriametrics.com/operator/resources/vtcluster/): when storage HPA was enabled, generated `-storageNode` flags could become incorrect after scaling, which could break expected routing to storage nodes; now the operator derives storage node count from the current StatefulSet state so generated flags stay correct during HPA-driven scaling. See [#2117](https://github.com/VictoriaMetrics/operator/issues/2117).
+* BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): expose VMClusterSpec parsing error in status, previously it was just swallowed and led to infinite reconciles. See [#2113](https://github.com/VictoriaMetrics/operator/issues/2113).
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -80,8 +80,8 @@ func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return
 	}
 
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vlagent"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vlagent"}
 		return
 	}
 

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -74,8 +74,8 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vlcluster"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vlcluster"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -80,8 +80,8 @@ func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 		err = finalize.OnVLogsDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vlogs"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vlogs"}
 		return
 	}
 	l.Info("VLogs CustomResource transited into read-only state. Please migrate to the VLSingle.")

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -75,8 +75,8 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		err = finalize.OnVLSingleDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vlsingle"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vlsingle"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -105,8 +105,8 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return
 	}
 
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmagent"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmagent"}
 		return
 	}
 

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -91,8 +91,8 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		return
 	}
 
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmalert"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmalert"}
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -92,8 +92,8 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		err = finalize.OnVMAlertManagerDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmalertmanager"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmalertmanager"}
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanagerconfig_controller.go
+++ b/internal/controller/operator/vmalertmanagerconfig_controller.go
@@ -71,8 +71,8 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	RegisterObjectStat(&instance, "vmalertmanagerconfig")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmalertmanagerconfig"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmalertmanagerconfig"}
 		return
 	}
 	if alertmanagerReconcileLimit.Throttle() {
@@ -91,7 +91,7 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 
 	for i := range objects.Items {
 		item := &objects.Items[i]
-		if !item.DeletionTimestamp.IsZero() || item.Spec.ParsingError != "" || item.IsUnmanaged() {
+		if !item.DeletionTimestamp.IsZero() || item.Status.ParsingSpecError != "" || item.IsUnmanaged() {
 			continue
 		}
 

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -92,8 +92,8 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return
 	}
 
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmanomaly"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmanomaly"}
 		return
 	}
 

--- a/internal/controller/operator/vmanomalyconfig_controller.go
+++ b/internal/controller/operator/vmanomalyconfig_controller.go
@@ -91,7 +91,7 @@ func (r *VMAnomalyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	for i := range objects.Items {
 		item := &objects.Items[i]
-		if !item.DeletionTimestamp.IsZero() || item.Spec.ParsingError != "" || item.IsUnmanaged() {
+		if !item.DeletionTimestamp.IsZero() || item.Status.ParsingSpecError != "" || item.IsUnmanaged() {
 			continue
 		}
 		l := l.WithValues("vmanomaly", item.Name, "parent_namespace", item.Namespace)

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -91,8 +91,8 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		}
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmauth"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmauth"}
 		return
 	}
 

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -64,8 +64,8 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmcluster"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmcluster"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -79,8 +79,8 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return
 	}
 	// Check parsing error
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "VMDistributed"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "VMDistributed"}
 		return
 	}
 

--- a/internal/controller/operator/vmnodescrape_controller.go
+++ b/internal/controller/operator/vmnodescrape_controller.go
@@ -71,8 +71,8 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	RegisterObjectStat(&instance, "vmnodescrape")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmnodescrape"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmnodescrape"}
 		return
 	}
 

--- a/internal/controller/operator/vmpodscrape_controller.go
+++ b/internal/controller/operator/vmpodscrape_controller.go
@@ -70,8 +70,8 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	RegisterObjectStat(&instance, "vmpodscrape")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmpodscrape"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmpodscrape"}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmprobe_controller.go
+++ b/internal/controller/operator/vmprobe_controller.go
@@ -70,8 +70,8 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 
 	RegisterObjectStat(&instance, "vmprobescrape")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmprobescrape"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmprobescrape"}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmrule_controller.go
+++ b/internal/controller/operator/vmrule_controller.go
@@ -74,8 +74,8 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}
 
 	RegisterObjectStat(&instance, "vmrule")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmrule"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmrule"}
 		return
 	}
 	if alertReconcileLimit.Throttle() {
@@ -94,7 +94,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	for i := range objects.Items {
 		item := &objects.Items[i]
-		if item.DeletionTimestamp != nil || item.Spec.ParsingError != "" {
+		if item.DeletionTimestamp != nil || item.Status.ParsingSpecError != "" {
 			continue
 		}
 		l := l.WithValues("vmalert", item.Name, "parent_namespace", item.Namespace)

--- a/internal/controller/operator/vmscrapeconfig_controller.go
+++ b/internal/controller/operator/vmscrapeconfig_controller.go
@@ -70,8 +70,8 @@ func (r *VMScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	RegisterObjectStat(&instance, "vmscrapeconfig")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmscrapeconfig"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmscrapeconfig"}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmservicescrape_controller.go
+++ b/internal/controller/operator/vmservicescrape_controller.go
@@ -70,8 +70,8 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	RegisterObjectStat(&instance, "vmservicescrape")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmservicescrape"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmservicescrape"}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -105,8 +105,8 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		err = finalize.OnVMSingleDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmsingle"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmsingle"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmstaticscrape_controller.go
+++ b/internal/controller/operator/vmstaticscrape_controller.go
@@ -49,8 +49,8 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return
 	}
 	RegisterObjectStat(&instance, "vmstaticscrape")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmstaticscrape"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmstaticscrape"}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -80,8 +80,8 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return
 	}
 	RegisterObjectStat(&instance, "vmuser")
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vmuser"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vmuser"}
 		return
 	}
 
@@ -105,7 +105,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	for i := range objects.Items {
 		item := &objects.Items[i]
-		if !item.DeletionTimestamp.IsZero() || item.Spec.ParsingError != "" || item.IsUnmanaged() {
+		if !item.DeletionTimestamp.IsZero() || item.Status.ParsingSpecError != "" || item.IsUnmanaged() {
 			continue
 		}
 		// reconcile users for given vmauth.

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -74,8 +74,8 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vtcluster"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vtcluster"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -75,8 +75,8 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		err = finalize.OnVTSingleDelete(ctx, r.Client, &instance)
 		return
 	}
-	if instance.Spec.ParsingError != "" {
-		err = &parsingError{instance.Spec.ParsingError, "vtsingle"}
+	if instance.Status.ParsingSpecError != "" {
+		err = &parsingError{instance.Status.ParsingSpecError, "vtsingle"}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/webhook/operator/v1/vlagent_webhook.go
+++ b/internal/webhook/operator/v1/vlagent_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VLAgent] = &VLAgentCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VLAgentCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLAgent) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VLAgentCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLAge
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VLAgentCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1.VLAgent) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1/vlcluster_webhook.go
+++ b/internal/webhook/operator/v1/vlcluster_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VLCluster] = &VLClusterCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VLClusterCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLCluster) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VLClusterCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLC
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VLClusterCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1.VLCluster) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1/vlsingle_webhook.go
+++ b/internal/webhook/operator/v1/vlsingle_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VLSingle] = &VLSingleCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VLSingleCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLSingle) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VLSingleCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VLSi
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VLSingleCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1.VLSingle) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1/vmanomaly_webhook.go
+++ b/internal/webhook/operator/v1/vmanomaly_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VMAnomaly] = &VMAnomalyCustomValidator{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type VMAnomaly.
 func (v *VMAnomalyCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1.VMAnomaly) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (v *VMAnomalyCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type VMAnomaly.
 func (v *VMAnomalyCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *vmv1.VMAnomaly) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1/vtcluster_webhook.go
+++ b/internal/webhook/operator/v1/vtcluster_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VTCluster] = (*VTClusterCustomValidator)(nil)
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VTClusterCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VTCluster) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VTClusterCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VTC
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VTClusterCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1.VTCluster) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1/vtsingle_webhook.go
+++ b/internal/webhook/operator/v1/vtsingle_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1.VTSingle] = (*VTSingleCustomValidator)(nil)
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VTSingleCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VTSingle) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VTSingleCustomValidator) ValidateCreate(_ context.Context, obj *vmv1.VTSi
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VTSingleCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1.VTSingle) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1alpha1/vmdistributed_webhook.go
+++ b/internal/webhook/operator/v1alpha1/vmdistributed_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1alpha1.VMDistributed] = &VMDistributedCustomValid
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMDistributedCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1alpha1.VMDistributed) (warnings admission.Warnings, err error) {
-	if obj.Spec.ParsingError != "" {
-		err = errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		err = errors.New(obj.Status.ParsingSpecError)
 		return
 	}
 
@@ -54,8 +54,8 @@ func (*VMDistributedCustomValidator) ValidateCreate(ctx context.Context, obj *vm
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMDistributedCustomValidator) ValidateUpdate(ctx context.Context, _, newObj *vmv1alpha1.VMDistributed) (warnings admission.Warnings, err error) {
-	if newObj.Spec.ParsingError != "" {
-		err = errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		err = errors.New(newObj.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/webhook/operator/v1beta1/vlogs_webhook.go
+++ b/internal/webhook/operator/v1beta1/vlogs_webhook.go
@@ -44,8 +44,8 @@ var vlogsWarning = []string{
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VLogsCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VLogs) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -55,8 +55,8 @@ func (*VLogsCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VL
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VLogsCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VLogs) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmagent_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmagent_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMAgent] = &VMAgentCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMAgentCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMAgent) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMAgentCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMAgentCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMAgent) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmalert_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmalert_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMAlert] = &VMAlertCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMAlert) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMAlertCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMAlert) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmalertmanager_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmalertmanager_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMAlertmanager] = &VMAlertmanagerCustomVali
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertmanagerCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMAlertmanager) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMAlertmanagerCustomValidator) ValidateCreate(_ context.Context, obj *vmv
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertmanagerCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMAlertmanager) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmalertmanagerconfig_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmalertmanagerconfig_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMAlertmanagerConfig] = &VMAlertmanagerConf
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertmanagerConfigCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMAlertmanagerConfig) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMAlertmanagerConfigCustomValidator) ValidateCreate(_ context.Context, ob
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMAlertmanagerConfigCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMAlertmanagerConfig) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 
 	if err := newObj.Validate(); err != nil {

--- a/internal/webhook/operator/v1beta1/vmauth_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmauth_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMAuth] = &VMAuthCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (*VMAuthCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMAuth) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMAuthCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.V
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (*VMAuthCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMAuth) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmcluster_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmcluster_webhook.go
@@ -41,8 +41,8 @@ var _ admission.Validator[*vmv1beta1.VMCluster] = &VMClusterCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMClusterCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1beta1.VMCluster) (warnings admission.Warnings, err error) {
-	if obj.Spec.ParsingError != "" {
-		err = errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		err = errors.New(obj.Status.ParsingSpecError)
 		return
 	}
 	if err = obj.Validate(); err != nil {
@@ -57,8 +57,8 @@ func (*VMClusterCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1be
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMClusterCustomValidator) ValidateUpdate(ctx context.Context, _, newObj *vmv1beta1.VMCluster) (warnings admission.Warnings, err error) {
-	if newObj.Spec.ParsingError != "" {
-		err = errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		err = errors.New(newObj.Status.ParsingSpecError)
 		return
 	}
 	if err = newObj.Validate(); err != nil {

--- a/internal/webhook/operator/v1beta1/vmnodescrape_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmnodescrape_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMNodeScrape] = &VMNodeScrapeCustomValidato
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (*VMNodeScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMNodeScrape) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMNodeScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1b
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (*VMNodeScrapeCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMNodeScrape) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmpodscrape_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmpodscrape_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMPodScrape] = &VMPodScrapeCustomValidator{
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMPodScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMPodScrape) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 
 	if err := obj.Validate(); err != nil {
@@ -52,8 +52,8 @@ func (*VMPodScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1be
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMPodScrapeCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMPodScrape) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 
 	if err := newObj.Validate(); err != nil {

--- a/internal/webhook/operator/v1beta1/vmprobe_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmprobe_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMProbe] = &VMProbeCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMProbeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMProbe) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 
 	if err := obj.Validate(); err != nil {
@@ -52,8 +52,8 @@ func (*VMProbeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMProbeCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMProbe) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmscrapeconfig_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmscrapeconfig_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMScrapeConfig] = &VMScrapeConfigCustomVali
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (*VMScrapeConfigCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMScrapeConfig) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmservicescrape_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmservicescrape_webhook.go
@@ -41,8 +41,8 @@ var _ admission.Validator[*vmv1beta1.VMServiceScrape] = &VMServiceScrapeCustomVa
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMServiceScrapeCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1beta1.VMServiceScrape) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -55,8 +55,8 @@ func (*VMServiceScrapeCustomValidator) ValidateCreate(ctx context.Context, obj *
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMServiceScrapeCustomValidator) ValidateUpdate(ctx context.Context, _, newObj *vmv1beta1.VMServiceScrape) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err

--- a/internal/webhook/operator/v1beta1/vmsingle_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmsingle_webhook.go
@@ -41,8 +41,8 @@ var _ admission.Validator[*vmv1beta1.VMSingle] = &VMSingleCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
 func (*VMSingleCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1beta1.VMSingle) (warnings admission.Warnings, err error) {
-	if obj.Spec.ParsingError != "" {
-		err = errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		err = errors.New(obj.Status.ParsingSpecError)
 		return
 	}
 	if err = obj.Validate(); err != nil {
@@ -57,8 +57,8 @@ func (*VMSingleCustomValidator) ValidateCreate(ctx context.Context, obj *vmv1bet
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
 func (*VMSingleCustomValidator) ValidateUpdate(ctx context.Context, _, newObj *vmv1beta1.VMSingle) (warnings admission.Warnings, err error) {
-	if newObj.Spec.ParsingError != "" {
-		err = errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		err = errors.New(newObj.Status.ParsingSpecError)
 		return
 	}
 	if err = newObj.Validate(); err != nil {

--- a/internal/webhook/operator/v1beta1/vmstaticscrape_webhook.go
+++ b/internal/webhook/operator/v1beta1/vmstaticscrape_webhook.go
@@ -40,8 +40,8 @@ var _ admission.Validator[*vmv1beta1.VMStaticScrape] = &VMStaticScrapeCustomVali
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (*VMStaticScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv1beta1.VMStaticScrape) (admission.Warnings, error) {
-	if obj.Spec.ParsingError != "" {
-		return nil, errors.New(obj.Spec.ParsingError)
+	if obj.Status.ParsingSpecError != "" {
+		return nil, errors.New(obj.Status.ParsingSpecError)
 	}
 	if err := obj.Validate(); err != nil {
 		return nil, err
@@ -51,8 +51,8 @@ func (*VMStaticScrapeCustomValidator) ValidateCreate(_ context.Context, obj *vmv
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (*VMStaticScrapeCustomValidator) ValidateUpdate(_ context.Context, _, newObj *vmv1beta1.VMStaticScrape) (admission.Warnings, error) {
-	if newObj.Spec.ParsingError != "" {
-		return nil, errors.New(newObj.Spec.ParsingError)
+	if newObj.Status.ParsingSpecError != "" {
+		return nil, errors.New(newObj.Status.ParsingSpecError)
 	}
 	if err := newObj.Validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/2113

implemented custom UnmarshalJSON for CR instead of its spec, which allowed to move parsing spec error from Spec to Status. With custom spec unmarshalling spec error is hidden from structs, that may embed it: VMDistributedSpec embeds VMClusterSpec and VMAuthSpec

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved spec parse error handling from Spec to Status across all CRDs by adding root-level UnmarshalJSON that records errors in `Status.ParsingSpecError`. Errors now surface in Status, don’t leak from embedded specs, and prevent infinite reconciles (fixes #2113).

- **Refactors**
  - Replaced `*.Spec.ParsingError` with `*.Status.ParsingSpecError` across v1, v1alpha1, v1beta1; added the field to scrape CRs via `ScrapeObjectStatus`.
  - Implemented root-level `UnmarshalJSON` for each CR to parse `spec` and capture errors in Status; removed spec-level fields/unmarshalers.
  - Updated controllers, admission webhooks, `IsUnmanaged` checks, and tests to use `Status.ParsingSpecError`.

- **Bug Fixes**
  - Parse errors now short-circuit reconcile and webhook validation; nested route/spec errors in `VMAlertmanagerConfig` and embedded specs no longer leak or loop.
  - Changelog: note for `VMDistributed` to expose underlying `VMClusterSpec` parse errors, preventing infinite reconciles (#2113).

<sup>Written for commit 21c257ca256d48d6a36bbc31a873aa048e534074. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

