### PR TITLE
ci: sign images with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
       packages: write
       contents: write
       pages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -27,6 +28,13 @@ jobs:
           check-latest: true
           cache: true
         id: go
+      - name: Extract Cosign version
+        id: cosign-version
+        run: echo "version=$(grep 'COSIGN_VERSION ?=' Makefile | awk '{print $3}')" >> $GITHUB_OUTPUT
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: ${{ steps.cosign-version.outputs.version }}
       - name: lint, test and build
         env:
           TAG: ${{ github.event.release.tag_name }}
@@ -38,6 +46,7 @@ jobs:
           echo ${{secrets.REPO_KEY}} | docker login --username ${{secrets.REPO_USER}} --password-stdin
           echo ${{secrets.QUAY_ACCESSKEY}} | docker login quay.io --username '${{secrets.QUAY_USER}}' --password-stdin
           TAG=${TAG} make publish
+          TAG=${TAG} make sign
           TAG=${TAG} REGISTRY=quay.io make olm
           gh release upload ${{github.event.release.tag_name}} ./dist/install-no-webhook.yaml#install-no-webhook.yaml --clobber || echo "fix me NOT enough security permissions"
           gh release upload ${{github.event.release.tag_name}} ./dist/install-with-webhook.yaml#install-with-webhook.yaml --clobber || echo "fix me NOT enough security permissions"

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,23 @@ publish:
 	TAG=config-reloader-$(TAG) COMPONENT=config-reloader ROOT=./cmd/config-reloader $(MAKE) docker-buildx
 	TAG=config-reloader-$(TAG)-fips COMPONENT=config-reloader GODEBUG_BUILD_ARGS=fips140=only FIPS_BUILD_VERSION=$(FIPS_VERSION) ROOT=./cmd/config-reloader $(MAKE) docker-buildx
 
+COSIGN ?= $(shell which cosign 2>/dev/null || echo $(COSIGN_BIN))
+
+.PHONY: cosign
+cosign: $(COSIGN_BIN)
+$(COSIGN_BIN): $(LOCALBIN)
+	$(call download-github-release,$(COSIGN_BIN),sigstore/cosign,$(COSIGN_VERSION),cosign-$(OS)-$(ARCH),cosign-$(OS)-$(ARCH))
+
+.PHONY: sign
+sign: $(COSIGN)
+	for registry in $(PUBLISH_REGISTRIES); do \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-ubi && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-fips && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/config-reloader:config-reloader-$(TAG) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/config-reloader:config-reloader-$(TAG)-fips ; \
+	done
+
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist && rm -rf dist/*
@@ -358,6 +375,7 @@ CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs-$(CRD_REF_DOCS_VERSION)
 GINKGO_BIN ?= $(LOCALBIN)/ginkgo-$(GINKGO_VERSION)
 CRUST_GATHER_BIN ?= $(LOCALBIN)/crust-gather-$(CRUST_GATHER_VERSION)
 MIRRORD_BIN ?= $(LOCALBIN)/mirrord-$(MIRRORD_VERSION)
+COSIGN_BIN ?= $(LOCALBIN)/cosign-$(COSIGN_VERSION)
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.1
@@ -374,6 +392,7 @@ YQ_VERSION ?= v4.53.2
 GINKGO_VERSION ?= v2.28.3
 CRUST_GATHER_VERSION ?= v0.15.0
 MIRRORD_VERSION ?= 3.209.2
+COSIGN_VERSION ?= v3.0.6
 
 CRD_REF_DOCS_VERSION ?= 4deb8b1eb0169ac22ac5d777feaeb26a00e38a33
 

--- a/Makefile
+++ b/Makefile
@@ -279,8 +279,8 @@ sign: $(COSIGN)
 		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG) && \
 		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-ubi && \
 		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-fips && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/config-reloader:config-reloader-$(TAG) && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/config-reloader:config-reloader-$(TAG)-fips ; \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):config-reloader-$(TAG) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):config-reloader-$(TAG)-fips ; \
 	done
 
 .PHONY: build-installer

--- a/renovate.json
+++ b/renovate.json
@@ -178,6 +178,17 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "metalbear-co/mirrord"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Makefile$/"
+      ],
+      "matchStrings": [
+        "COSIGN_VERSION \\?= (?<currentValue>v.*)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "sigstore/cosign"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sign container images with `cosign` in the release workflow to enable verification and provenance. Uses GitHub OIDC for keyless signing and signs all published tags across registries.

- **New Features**
  - Grant `id-token: write` in the release workflow for keyless signing.
  - Install `cosign` via `sigstore/cosign-installer` (version read from `COSIGN_VERSION` in the `Makefile`) and run `make sign` after `make publish`.
  - Add Makefile targets: `sign` for main, `-ubi`, `-fips`, and `config-reloader` (incl. `-fips`) across `$(PUBLISH_REGISTRIES)`, and `cosign` to bootstrap the binary via `COSIGN_BIN`.
  - Resolve `COSIGN` from PATH when available, falling back to the bootstrapped binary.

- **Dependencies**
  - Add `sigstore/cosign-installer@v4.1.1`; default `COSIGN_VERSION` is `v3.0.6`.
  - Teach Renovate to track `COSIGN_VERSION` in the `Makefile`.

<sup>Written for commit 1437fa0406fca5663d74e5e2849df58edb007ddb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

