### PR TITLE
fix(backup): stop passing deprecated -eula flag to vmbackupmanager

### DIFF
--- a/internal/controller/operator/factory/build/backup.go
+++ b/internal/controller/operator/factory/build/backup.go
@@ -55,9 +55,7 @@ func VMBackupManager(
 		fmt.Sprintf("-snapshot.createURL=%s", snapshotCreateURL),
 		fmt.Sprintf("-snapshot.deleteURL=%s", snapshotDeleteURL),
 	}
-	if cr.AcceptEULA {
-		args = append(args, "-eula")
-	}
+	// -eula flag was deprecated and removed from VictoriaMetrics; no longer passed.
 	if cr.LogLevel != nil {
 		args = append(args, fmt.Sprintf("-loggerLevel=%s", *cr.LogLevel))
 	}
@@ -179,9 +177,7 @@ func VMRestore(
 	args := []string{
 		fmt.Sprintf("-storageDataPath=%s", storagePath),
 	}
-	if cr.AcceptEULA {
-		args = append(args, "-eula")
-	}
+	// -eula flag was deprecated and removed from VictoriaMetrics; no longer passed.
 	if cr.LogLevel != nil {
 		args = append(args, fmt.Sprintf("-loggerLevel=%s", *cr.LogLevel))
 	}


### PR DESCRIPTION
The `-eula` flag was deprecated in VictoriaMetrics and will be removed, causing a startup error in `vmbackupmanager` once that happens. Remove the two places in `build/backup.go` where the operator appends `-eula` to the container args.

The `AcceptEULA` field on the CR is intentionally left in place so existing configurations that set it don't require a breaking change.

Fixes #1319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop passing the deprecated `-eula` flag to `vmbackupmanager` in backup and restore args so it starts cleanly on current and future VictoriaMetrics versions. The `AcceptEULA` CR field stays for backward compatibility but no longer changes container args.

<sup>Written for commit 1cd828d047d0d6d0f8afff9cfa7cb7bb8e76e852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

