### PR TITLE
alertmanagerconfig: properly render negative numbers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 
 * BUGFIX: [converter](https://docs.victoriametrics.com/operator/integrations/prometheus/#objects-conversion): disable all prometheus controllers if CRD group was not found. See [#2838](https://github.com/VictoriaMetrics/helm-charts/issues/2838).
 * BUGFIX: [vmdistributed](https://docs.victoriametrics.com/operator/resources/vmdistributed/): change default load balancing policy for write requests from `first_available` to `least_loaded`. This should allow to evenly distribute write load across all VMAgents.
+* BUGFIX: [vmalertmanagerconfig](https://docs.victoriametrics.com/operator/resources/vmalertmanagerconfig/): fix previously ignored negative values in VMAlertmanagerConfig. See [#2132](https://github.com/VictoriaMetrics/operator/issues/2132).
 
 ## [v0.69.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.69.0)
 **Release date:** 22 April 2026

--- a/internal/controller/operator/factory/vmalertmanager/config.go
+++ b/internal/controller/operator/factory/vmalertmanager/config.go
@@ -246,19 +246,19 @@ func (r *rawValue) set(k string, v any) {
 			r.items = append(r.items, yaml.MapItem{Key: k, Value: item})
 		}
 	case int:
-		if item > 0 {
+		if item != 0 {
 			r.items = append(r.items, yaml.MapItem{Key: k, Value: item})
 		}
 	case int32:
-		if item > 0 {
+		if item != 0 {
 			r.items = append(r.items, yaml.MapItem{Key: k, Value: item})
 		}
 	case int64:
-		if item > 0 {
+		if item != 0 {
 			r.items = append(r.items, yaml.MapItem{Key: k, Value: item})
 		}
 	case float64:
-		if item > 0 {
+		if item != 0 {
 			r.items = append(r.items, yaml.MapItem{Key: k, Value: item})
 		}
 	case bool:

--- a/internal/controller/operator/factory/vmalertmanager/config_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/config_test.go
@@ -940,7 +940,7 @@ templates: []
 							TelegramConfigs: []vmv1beta1.TelegramConfig{
 								{
 									SendResolved: ptr.To(true),
-									ChatID:       125,
+									ChatID:       -1123123123125,
 									BotToken: &corev1.SecretKeySelector{
 										LocalObjectReference: corev1.LocalObjectReference{
 											Name: "tg-secret",
@@ -975,7 +975,7 @@ receivers:
   telegram_configs:
   - bot_token: some-token
     send_resolved: true
-    chat_id: 125
+    chat_id: -1123123123125
     message: some-templated message
 templates: []
 `,


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/2132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ignored negative numbers in `VMAlertmanagerConfig` by rendering any non-zero numeric values. Restores support for fields like negative Telegram `chat_id` (fixes #2132).

- **Bug Fixes**
  - Change config rendering to include ints/floats when value != 0 (was > 0).
  - Add test for negative Telegram `chat_id` to ensure it appears in YAML.
  - Update changelog entry for the bug.

<sup>Written for commit e2554db34970bd9e29ba2a3c9f081130043690d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

