### PR TITLE
Fix logging for sharded deployments

### DIFF
--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -190,13 +190,14 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 	shardCount := cr.GetShardCount()
 	prevShardCount := prevCR.GetShardCount()
 
-	isUpscaling := false
+	isUpscaling := prevShardCount < shardCount
 	if prevCR.IsSharded() {
-		if prevShardCount < shardCount {
-			logger.WithContext(ctx).Info(fmt.Sprintf("VMAgent shard upscaling from=%d to=%d", prevShardCount, shardCount))
-			isUpscaling = true
-		} else {
-			logger.WithContext(ctx).Info(fmt.Sprintf("VMAgent shard downscaling from=%d to=%d", prevShardCount, shardCount))
+		if prevShardCount != shardCount {
+			action := "downscaling"
+			if isUpscaling {
+				action = "upscaling"
+			}
+			logger.WithContext(ctx).Info(fmt.Sprintf("VMAgent shard %s from=%d to=%d", action, prevShardCount, shardCount))
 		}
 	}
 

--- a/internal/controller/operator/factory/vmanomaly/statefulset.go
+++ b/internal/controller/operator/factory/vmanomaly/statefulset.go
@@ -176,13 +176,14 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 	shardCount := cr.GetShardCount()
 	prevShardCount := prevCR.GetShardCount()
 
-	isUpscaling := false
+	isUpscaling := prevShardCount < shardCount
 	if prevCR.IsSharded() {
-		if prevShardCount < shardCount {
-			logger.WithContext(ctx).Info(fmt.Sprintf("%T shard upscaling from=%d to=%d", cr, prevShardCount, shardCount))
-			isUpscaling = true
-		} else {
-			logger.WithContext(ctx).Info(fmt.Sprintf("%T shard downscaling from=%d to=%d", cr, prevShardCount, shardCount))
+		if prevShardCount != shardCount {
+			action := "downscaling"
+			if isUpscaling {
+				action = "upscaling"
+			}
+			logger.WithContext(ctx).Info(fmt.Sprintf("VMAnomaly shard %s from=%d to=%d", action, prevShardCount, shardCount))
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/2134


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect scaling logs for sharded `vmagent` and `vmanomaly`. Logs now only emit when the shard count changes and correctly label upscaling vs downscaling.

- **Bug Fixes**
  - Sharded deployments: emit logs only on shard count changes; compute action from previous vs current counts; use explicit `VMAgent`/`VMAnomaly` names; avoid false downscale messages. Fixes #2134.

<sup>Written for commit e167c0ec83c9f6f1824f4d3149db2fad52205861. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



