### PR TITLE
feat(vmrule): add patchMergeKey to Groups for kubectl/kustomize patches

### DIFF
--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -26,7 +26,11 @@ var initVMAlertTemplatesOnce sync.Once
 // VMRuleSpec defines the desired state of VMRule
 type VMRuleSpec struct {
 	// Groups list of group rules
-	Groups []RuleGroup `json:"groups"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
+	Groups []RuleGroup `json:"groups" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // RuleGroup is a list of sequentially evaluated recording and alerting rules.

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -34036,6 +34036,9 @@ spec:
                   - rules
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
             required:
             - groups
             type: object


### PR DESCRIPTION
The VMRule CRD did not define `patchMergeKey`/`patchStrategy` on `spec.groups`, so `kubectl patch` and `kustomize` had to replace the entire group list to adjust any single group's rules. This made it painful to tweak a single chart-provided rule (e.g. raising an alert's `for:` from 60m to 90m) without redefining every other group in the patch.

This change adds name-based merging to `VMRuleSpec.Groups`:

- Source: 4-line marker block (`+patchMergeKey`, `+patchStrategy`, `+listType=map`, `+listMapKey=name`) + struct tag mirror, matching the existing `Conditions` precedent in `api/operator/v1beta1/vmextra_types.go:1384`.
- Generated: `config/crd/overlay/crd.yaml` and `crd.descriptionless.yaml` now carry `x-kubernetes-list-type: map` and `x-kubernetes-list-map-keys: [name]` on the groups field. Output of `make manifests`; no manual YAML edits.

Scoped to groups for this PR. The inner `Rules []Rule` list has the same pain in principle, but `Rule` carries either `Alert` or `Record` (never both required), so a single `listMapKey` is brittle there - happy to follow up in a separate PR if maintainers want a specific approach (e.g. compound keys via `+listMapKey` twice, or a synthetic merge field).

## Verification

- `make manifests` regenerated both CRD overlays with only the new map markers - no unrelated drift.
- `make api-gen` produced no further diff.
- `make docs` produced no further diff to `docs/api.md`.
- `make lint` clean (0 issues across the `api/...` and main modules).
- `go test ./operator/v1beta1/...` from `./api`: passing.

Closes #657


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable name-based merge for VMRule `spec.groups` so `kubectl patch` and `kustomize` can update a single group without replacing the whole list. This makes small tweaks (like changing an alert’s for: 60m → 90m) safer and easier.

- **New Features**
  - Added `+patchMergeKey=name`, `+patchStrategy=merge`, `+listType=map`, and `+listMapKey=name` to `VMRuleSpec.Groups`.
  - Regenerated CRDs to include `x-kubernetes-list-type: map` and `x-kubernetes-list-map-keys: [name]` for `groups`.

<sup>Written for commit b50f41d2c8c7a8299adbefce5334b4ef85b287fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

