### PR TITLE
Halt emitting config-reloader signals when delay-interval is customized

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -275,15 +275,14 @@ func (c *cfgWatcher) close() {
 }
 
 func (c *cfgWatcher) waitDelay(ctx context.Context) bool {
-	if *delayInterval <= 0 {
-		return true
-	}
-	t := time.NewTimer(*delayInterval)
-	defer t.Stop()
-	select {
-	case <-t.C:
-	case <-ctx.Done():
-		return false
+	if *delayInterval > 0 {
+		t := time.NewTimer(*delayInterval)
+		defer t.Stop()
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			return false
+		}
 	}
 	for {
 		select {

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -251,26 +251,34 @@ func (c *cfgWatcher) start(ctx context.Context) {
 		for {
 			select {
 			case <-c.updates:
-				go func() {
-					if *delayInterval > 0 {
-						t := time.NewTimer(*delayInterval)
-						defer t.Stop()
-						select {
-						case <-t.C:
-						case <-ctx.Done():
-							return
-						}
-					}
-					if err := c.reloader(ctx); err != nil {
-						logger.Errorf("cannot trigger api reload: %s", err.Error())
-						configLastReloadSuccess.Set(0)
-						configReloadErrorsTotal.Inc()
+				if *delayInterval > 0 {
+					t := time.NewTimer(*delayInterval)
+					select {
+					case <-t.C:
+						t.Stop()
+					case <-ctx.Done():
+						t.Stop()
 						return
 					}
-					configLastReloadSuccess.Set(1)
-					configLastOkReloadTime.Set(uint64(time.Now().UnixMilli()))
-					logger.Infof("reload config ok.")
-				}()
+				}
+				// drain any updates that accumulated during the delay
+				for {
+					select {
+					case <-c.updates:
+					default:
+						goto doReload
+					}
+				}
+			doReload:
+				if err := c.reloader(ctx); err != nil {
+					logger.Errorf("cannot trigger api reload: %s", err.Error())
+					configLastReloadSuccess.Set(0)
+					configReloadErrorsTotal.Inc()
+					continue
+				}
+				configLastReloadSuccess.Set(1)
+				configLastOkReloadTime.Set(uint64(time.Now().UnixMilli()))
+				logger.Infof("reload config ok.")
 
 			case <-ctx.Done():
 				return

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -251,44 +251,47 @@ func (c *cfgWatcher) start(ctx context.Context) {
 		for {
 			select {
 			case <-c.updates:
-				if *delayInterval > 0 {
-					t := time.NewTimer(*delayInterval)
-					select {
-					case <-t.C:
-						t.Stop()
-					case <-ctx.Done():
-						t.Stop()
-						return
-					}
-				}
-				// drain any updates that accumulated during the delay
-				for {
-					select {
-					case <-c.updates:
-					default:
-						goto doReload
-					}
-				}
-			doReload:
-				if err := c.reloader(ctx); err != nil {
-					logger.Errorf("cannot trigger api reload: %s", err.Error())
-					configLastReloadSuccess.Set(0)
-					configReloadErrorsTotal.Inc()
-					continue
-				}
-				configLastReloadSuccess.Set(1)
-				configLastOkReloadTime.Set(uint64(time.Now().UnixMilli()))
-				logger.Infof("reload config ok.")
-
 			case <-ctx.Done():
 				return
 			}
+			if !c.waitDelay(ctx) {
+				return
+			}
+			if err := c.reloader(ctx); err != nil {
+				logger.Errorf("cannot trigger api reload: %s", err.Error())
+				configLastReloadSuccess.Set(0)
+				configReloadErrorsTotal.Inc()
+				continue
+			}
+			configLastReloadSuccess.Set(1)
+			configLastOkReloadTime.Set(uint64(time.Now().UnixMilli()))
+			logger.Infof("reload config ok.")
 		}
 	}()
 }
 
 func (c *cfgWatcher) close() {
 	c.wg.Wait()
+}
+
+func (c *cfgWatcher) waitDelay(ctx context.Context) bool {
+	if *delayInterval <= 0 {
+		return true
+	}
+	t := time.NewTimer(*delayInterval)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+		return false
+	}
+	for {
+		select {
+		case <-c.updates:
+		default:
+			return true
+		}
+	}
 }
 
 type watcher interface {

--- a/cmd/config-reloader/main_test.go
+++ b/cmd/config-reloader/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestLogFormatAlias(t *testing.T) {
@@ -30,4 +33,153 @@ func TestLogFormatAlias(t *testing.T) {
 
 	// log-format is empty
 	f("", "json", "json")
+}
+
+// TestCfgWatcherSignalSentOnce verifies that a burst of updates results in
+// exactly one reloader call (channel drained before reload).
+func TestCfgWatcherSignalSentOnce(t *testing.T) {
+	origDelay := *delayInterval
+	*delayInterval = 0
+	defer func() { *delayInterval = origDelay }()
+
+	var reloadCount atomic.Int64
+	updates := make(chan struct{}, 10)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			reloadCount.Add(1)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.start(ctx)
+
+	for range 5 {
+		select {
+		case updates <- struct{}{}:
+		default:
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	w.close()
+
+	if got := reloadCount.Load(); got != 1 {
+		t.Fatalf("expected 1 reload call, got %d", got)
+	}
+}
+
+// TestCfgWatcherDelayIntervalHonoured verifies that the reloader is not called
+// before delayInterval elapses after an update signal.
+func TestCfgWatcherDelayIntervalHonoured(t *testing.T) {
+	delay := 150 * time.Millisecond
+	origDelay := *delayInterval
+	*delayInterval = delay
+	defer func() { *delayInterval = origDelay }()
+
+	var reloadCount atomic.Int64
+	updates := make(chan struct{}, 10)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			reloadCount.Add(1)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.start(ctx)
+
+	updates <- struct{}{}
+
+	// before delay elapses - no reload yet
+	time.Sleep(50 * time.Millisecond)
+	if got := reloadCount.Load(); got != 0 {
+		t.Fatalf("expected 0 reload calls before delay, got %d", got)
+	}
+
+	// after delay elapses - exactly one reload
+	time.Sleep(200 * time.Millisecond)
+	if got := reloadCount.Load(); got != 1 {
+		t.Fatalf("expected 1 reload call after delay, got %d", got)
+	}
+}
+
+// TestCfgWatcherDelayIntervalDebouncesUpdates verifies that multiple updates
+// arriving within the delay window are coalesced into a single reload call.
+func TestCfgWatcherDelayIntervalDebouncesUpdates(t *testing.T) {
+	delay := 150 * time.Millisecond
+	origDelay := *delayInterval
+	*delayInterval = delay
+	defer func() { *delayInterval = origDelay }()
+
+	var reloadCount atomic.Int64
+	updates := make(chan struct{}, 10)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			reloadCount.Add(1)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.start(ctx)
+
+	// send first signal then more signals before delay elapses
+	updates <- struct{}{}
+	time.Sleep(20 * time.Millisecond)
+	for range 4 {
+		select {
+		case updates <- struct{}{}:
+		default:
+		}
+	}
+
+	// wait for delay + processing
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	w.close()
+
+	if got := reloadCount.Load(); got != 1 {
+		t.Fatalf("expected 1 reload call for burst within delay window, got %d", got)
+	}
+}
+
+// TestCfgWatcherDelayIntervalCancelledContext verifies that cancelling context
+// during delay window prevents reloader from being called.
+func TestCfgWatcherDelayIntervalCancelledContext(t *testing.T) {
+	delay := 500 * time.Millisecond
+	origDelay := *delayInterval
+	*delayInterval = delay
+	defer func() { *delayInterval = origDelay }()
+
+	var reloadCount atomic.Int64
+	updates := make(chan struct{}, 10)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			reloadCount.Add(1)
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.start(ctx)
+
+	updates <- struct{}{}
+
+	// cancel before delay elapses
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	w.close()
+
+	if got := reloadCount.Load(); got != 0 {
+		t.Fatalf("expected 0 reload calls after context cancel, got %d", got)
+	}
 }


### PR DESCRIPTION
Each reload called a separate goroutine, instead we should use delay-interval to prevent other goroutines from running.

Fixes #2171
