### PR TITLE
e2e: removed validating job

### DIFF
--- a/test/e2e/childobjects/vmalertmanagerconfig_test.go
+++ b/test/e2e/childobjects/vmalertmanagerconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -57,13 +58,12 @@ var _ = Describe("test vmalertmanagerconfig Controller", Label("vm", "child", "a
 			}
 
 			for _, am := range args.ams {
-				Eventually(func() error {
-					return suite.ExpectObjectStatus(ctx,
-						k8sClient,
-						&vmv1beta1.VMAlertmanager{},
-						types.NamespacedName{Name: am.Name, Namespace: am.Namespace},
-						vmv1beta1.UpdateStatusOperational)
-				}, eventualReadyTimeout).ShouldNot(HaveOccurred())
+				Expect(suite.WatchUntilStatusReached(ctx, k8sClient,
+					&vmv1beta1.VMAlertmanagerList{},
+					types.NamespacedName{Name: am.Name, Namespace: am.Namespace},
+					eventualReadyTimeout*time.Second,
+					vmv1beta1.UpdateStatusOperational,
+					vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 			}
 			if step.modify != nil {
 				step.modify()

--- a/test/e2e/childobjects/vmrule_test.go
+++ b/test/e2e/childobjects/vmrule_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -57,13 +58,12 @@ var _ = Describe("test vmrule Controller", Label("vm", "child", "alert"), func()
 			}
 
 			for _, alert := range args.alerts {
-				Eventually(func() error {
-					return suite.ExpectObjectStatus(ctx,
-						k8sClient,
-						&vmv1beta1.VMAlert{},
-						types.NamespacedName{Name: alert.Name, Namespace: alert.Namespace},
-						vmv1beta1.UpdateStatusOperational)
-				}, eventualReadyTimeout).ShouldNot(HaveOccurred())
+				Expect(suite.WatchUntilStatusReached(ctx, k8sClient,
+					&vmv1beta1.VMAlertList{},
+					types.NamespacedName{Name: alert.Name, Namespace: alert.Namespace},
+					eventualReadyTimeout*time.Second,
+					vmv1beta1.UpdateStatusOperational,
+					vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 			}
 			if step.modify != nil {
 				step.modify()

--- a/test/e2e/childobjects/vmuser_test.go
+++ b/test/e2e/childobjects/vmuser_test.go
@@ -3,6 +3,7 @@ package childobjects
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,13 +59,12 @@ var _ = Describe("test vmuser Controller", Label("vm", "child", "auth"), func() 
 			}
 
 			for _, am := range args.vmauths {
-				Eventually(func() error {
-					return suite.ExpectObjectStatus(ctx,
-						k8sClient,
-						&vmv1beta1.VMAuth{},
-						types.NamespacedName{Name: am.Name, Namespace: am.Namespace},
-						vmv1beta1.UpdateStatusOperational)
-				}, eventualReadyTimeout).ShouldNot(HaveOccurred())
+				Expect(suite.WatchUntilStatusReached(ctx, k8sClient,
+					&vmv1beta1.VMAuthList{},
+					types.NamespacedName{Name: am.Name, Namespace: am.Namespace},
+					eventualReadyTimeout*time.Second,
+					vmv1beta1.UpdateStatusOperational,
+					vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 			}
 			if step.modify != nil {
 				step.modify()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/VictoriaMetrics/operator/test/e2e/suite"
@@ -36,11 +37,13 @@ var (
 	eventualDeploymentPodTimeout        = 25 * time.Second
 	eventualExpandingTimeout            = 25 * time.Second
 	eventualDistributedExpandingTimeout = 5 * time.Minute
+	eventualPollingInterval             = 2 * time.Second
 )
 
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyPollingInterval(eventualPollingInterval)
 	fmt.Fprintf(GinkgoWriter, "Starting vm-operator suite\n")
 	suiteConfig, reporterConfig := GinkgoConfiguration()
 	RunSpecs(t, "End2End Suite", suiteConfig, reporterConfig)
@@ -48,11 +51,13 @@ func TestE2E(t *testing.T) {
 
 var (
 	k8sClient client.WithWatch
+	k8sCfg    rest.Config
 
 	_ = SynchronizedBeforeSuite(func() []byte {
 		return suite.InitOperatorProcess()
 	}, func(data []byte) {
 		k8sClient = suite.GetClient(data)
+		k8sCfg = suite.GetRestConfig(data)
 	})
 
 	_ = SynchronizedAfterSuite(func() {}, func() {

--- a/test/e2e/prometheus_converter_test.go
+++ b/test/e2e/prometheus_converter_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -310,16 +309,10 @@ var _ = Describe("test prometheusConverter Controller", func() {
 			Context(fmt.Sprintf("crud %s", testCase.name), func() {
 				AfterEach(func() {
 					k8sClient.Delete(ctx, testCase.source) // nolint:errcheck
-					Eventually(func() error {
-						_, err := getObject(ctx, testCase.source)
-						return err
-					}, eventualDeletionTimeout, 1).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+					waitObjectDeleted(ctx, testCase.source)
 
 					k8sClient.Delete(ctx, testCase.targetTpl) // nolint:errcheck
-					Eventually(func() error {
-						_, err := getObject(ctx, testCase.targetTpl)
-						return err
-					}, 60, 1).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+					waitObjectDeleted(ctx, testCase.targetTpl)
 				})
 
 				It("Should convert the object", func() {
@@ -388,10 +381,7 @@ var _ = Describe("test prometheusConverter Controller", func() {
 						return nil
 					}()).ToNot(HaveOccurred())
 					Expect(k8sClient.Delete(ctx, source)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						_, err := getObject(ctx, testCase.targetTpl)
-						return err
-					}, eventualDeletionTimeout, 1).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+					waitObjectDeleted(ctx, testCase.targetTpl)
 				})
 			})
 		}

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -43,6 +43,13 @@ var (
 	stopped       = make(chan struct{})
 )
 
+func GetRestConfig(data []byte) rest.Config {
+	var cfg rest.Config
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	Expect(dec.Decode(&cfg)).To(Succeed())
+	return cfg
+}
+
 func GetClient(data []byte) client.WithWatch {
 	var cfg rest.Config
 	dec := gob.NewDecoder(bytes.NewReader(data))

--- a/test/e2e/suite/utils.go
+++ b/test/e2e/suite/utils.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint
 	. "github.com/onsi/gomega"    //nolint
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	watchapi "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -52,6 +53,46 @@ func ExpectObjectStatus(ctx context.Context,
 	}
 
 	return nil
+}
+
+// WatchUntilStatusSeen reads events from w until it observes an object with the given name,
+// observedGeneration >= minGen, and target status, or the context deadline is reached.
+// Start the watch before triggering the action, then pass the post-action generation as minGen
+// to avoid matching stale pre-action ADDED events that share the same name and status.
+func WatchUntilStatusSeen(ctx context.Context, w watchapi.Interface, name string, minGen int64, targetStatus vmv1beta1.UpdateStatus) error {
+	for {
+		select {
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch closed before observing status %q for %q", targetStatus, name)
+			}
+			if event.Type == watchapi.Error {
+				return fmt.Errorf("watch error: %v", event.Object)
+			}
+			obj, ok := event.Object.(client.Object)
+			if !ok || obj.GetName() != name {
+				continue
+			}
+			jsD, err := json.Marshal(obj)
+			if err != nil {
+				continue
+			}
+			type statusHolder struct {
+				Status struct {
+					vmv1beta1.StatusMetadata `json:",inline"`
+				} `json:"status"`
+			}
+			var sh statusHolder
+			if err := json.Unmarshal(jsD, &sh); err != nil {
+				continue
+			}
+			if sh.Status.UpdateStatus == targetStatus && sh.Status.ObservedGeneration >= minGen {
+				return nil
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for status %q for object %q: %w", targetStatus, name, ctx.Err())
+		}
+	}
 }
 
 func CollectK8SResources() {

--- a/test/e2e/suite/utils.go
+++ b/test/e2e/suite/utils.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint
 	. "github.com/onsi/gomega"    //nolint
+	"k8s.io/apimachinery/pkg/fields"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	watchapi "k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,6 +50,10 @@ func ExpectObjectStatus(ctx context.Context,
 		for _, cond := range obs.Status.Conditions {
 			conds = append(conds, fmt.Sprintf("type=%s,message=%q,generation=%d,status=%q", cond.Type, cond.Message, cond.ObservedGeneration, cond.Status))
 		}
+		if obs.Status.UpdateStatus == vmv1beta1.UpdateStatusFailed && status != vmv1beta1.UpdateStatusFailed {
+			return StopTrying(fmt.Sprintf("object %q entered %q while waiting for %q: reason=%q,conditions=%s",
+				name.Name, obs.Status.UpdateStatus, status, obs.Status.Reason, strings.Join(conds, ",")))
+		}
 		return fmt.Errorf("not expected object status=%q, reason=%q,conditions=%s", obs.Status.UpdateStatus, obs.Status.Reason, strings.Join(conds, ","))
 	}
 
@@ -59,7 +64,10 @@ func ExpectObjectStatus(ctx context.Context,
 // observedGeneration >= minGen, and target status, or the context deadline is reached.
 // Start the watch before triggering the action, then pass the post-action generation as minGen
 // to avoid matching stale pre-action ADDED events that share the same name and status.
-func WatchUntilStatusSeen(ctx context.Context, w watchapi.Interface, name string, minGen int64, targetStatus vmv1beta1.UpdateStatus) error {
+// If a failStatuses entry is seen (with obsGen >= minGen and status != targetStatus),
+// WatchUntilStatusSeen returns immediately with the failure reason rather than waiting for timeout.
+// All matched events are logged to GinkgoWriter for post-failure diagnostics.
+func WatchUntilStatusSeen(ctx context.Context, w watchapi.Interface, name string, minGen int64, targetStatus vmv1beta1.UpdateStatus, failStatuses ...vmv1beta1.UpdateStatus) error {
 	for {
 		select {
 		case event, ok := <-w.ResultChan():
@@ -86,11 +94,74 @@ func WatchUntilStatusSeen(ctx context.Context, w watchapi.Interface, name string
 			if err := json.Unmarshal(jsD, &sh); err != nil {
 				continue
 			}
-			if sh.Status.UpdateStatus == targetStatus && sh.Status.ObservedGeneration >= minGen {
+			obsGen := sh.Status.ObservedGeneration
+			status := sh.Status.UpdateStatus
+			fmt.Fprintf(GinkgoWriter, "[watch] %s name=%s gen=%d obsGen=%d status=%q",
+				event.Type, name, obj.GetGeneration(), obsGen, status)
+			if status == targetStatus && obsGen >= minGen {
+				fmt.Fprintf(GinkgoWriter, " ✓\n")
 				return nil
+			}
+			if obsGen >= minGen {
+				for _, fs := range failStatuses {
+					if status == fs {
+						var conds []string
+						for _, cond := range sh.Status.Conditions {
+							conds = append(conds, fmt.Sprintf("type=%s,message=%q", cond.Type, cond.Message))
+						}
+						fmt.Fprintf(GinkgoWriter, " (fail-fast)\n")
+						return fmt.Errorf("object %q entered %q while waiting for %q: reason=%q conditions=%s",
+							name, status, targetStatus, sh.Status.Reason, strings.Join(conds, ","))
+					}
+				}
+				fmt.Fprintf(GinkgoWriter, " (skipped: status %q != %q)\n", status, targetStatus)
+			} else {
+				fmt.Fprintf(GinkgoWriter, " (skipped: obsGen %d < minGen %d)\n", obsGen, minGen)
 			}
 		case <-ctx.Done():
 			return fmt.Errorf("timed out waiting for status %q for object %q: %w", targetStatus, name, ctx.Err())
+		}
+	}
+}
+
+// WatchUntilStatusReached starts a watch on the named object and waits until it reaches targetStatus.
+// Uses minGen=0 (matches any generation), suitable when there is no preceding mutation to guard against.
+// Pass failStatuses to return immediately if an unexpected failure state is observed before targetStatus.
+func WatchUntilStatusReached(ctx context.Context, rclient client.WithWatch, list client.ObjectList, nsn k8stypes.NamespacedName, timeout time.Duration, targetStatus vmv1beta1.UpdateStatus, failStatuses ...vmv1beta1.UpdateStatus) error {
+	listOpts := &client.ListOptions{
+		Namespace:     nsn.Namespace,
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", nsn.Name),
+	}
+	watcher, err := rclient.Watch(ctx, list, listOpts)
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+	watchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return WatchUntilStatusSeen(watchCtx, watcher, nsn.Name, 0, targetStatus, failStatuses...)
+}
+
+// WatchUntilDeleted reads events from w until it observes a DELETED event for the named
+// object, or the context deadline is reached.
+func WatchUntilDeleted(ctx context.Context, w watchapi.Interface, name string) error {
+	for {
+		select {
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch closed before observing deletion of %q", name)
+			}
+			if event.Type == watchapi.Error {
+				return fmt.Errorf("watch error: %v", event.Object)
+			}
+			if event.Type == watchapi.Deleted {
+				obj, ok := event.Object.(client.Object)
+				if ok && obj.GetName() == name {
+					return nil
+				}
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for deletion of object %q: %w", name, ctx.Err())
 		}
 	}
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -264,42 +264,67 @@ func mustGetFirstPod(ctx context.Context, rclient client.Client, obj client.Obje
 	return &pods[0]
 }
 
-//nolint:dupl,lll
-func waitResourceDeleted(ctx context.Context, rclient client.Client, nss types.NamespacedName, r client.Object) {
+func waitObjectDeleted(ctx context.Context, obj client.Object) {
 	GinkgoHelper()
+	nsn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	Eventually(func() error {
-		return rclient.Get(ctx, nss, r)
-	}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+		return k8sClient.Get(ctx, nsn, obj.DeepCopyObject().(client.Object))
+	}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "isNotFound"))
+}
+
+//nolint:dupl,lll
+func waitResourceDeleted(ctx context.Context, nss types.NamespacedName, list client.ObjectList) {
+	GinkgoHelper()
+	listOpts := &client.ListOptions{
+		Namespace:     nss.Namespace,
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", nss.Name),
+	}
+	watcher, err := k8sClient.Watch(ctx, list, listOpts)
+	Expect(err).ToNot(HaveOccurred())
+	defer watcher.Stop()
+	// Check after starting the watch to avoid a race: object may have been deleted before watch started.
+	if err := k8sClient.List(ctx, list, listOpts); err == nil {
+		items, _ := k8smeta.ExtractList(list)
+		if len(items) == 0 {
+			return
+		}
+	}
+	watchCtx, cancel := context.WithTimeout(ctx, eventualDeletionTimeout)
+	defer cancel()
+	Expect(suite.WatchUntilDeleted(watchCtx, watcher, nss.Name)).ToNot(HaveOccurred())
 }
 
 // expectStatusAfterAction starts a watch on the named object, runs action, then waits for
-// each status in sequence. Start the watch before the action to capture transient states.
-// After the action, we fetch the current generation so WatchUntilStatusSeen can ignore
-// stale pre-action ADDED events that satisfy the target status but predate the action.
+// each status in sequence. The watch is started before the action to capture transient states.
+//
+// minGen is derived from the pre-action state: minGen = preActionGen + 1. Both Create
+// (K8s sets Gen=1) and Update (always increments by 1) advance the generation by exactly 1,
+// so this reliably filters out stale ADDED events that reflect the pre-action object state.
+// Reading the generation before the action avoids any cache-lag risk from a just-written object.
 func expectStatusAfterAction(ctx context.Context, list client.ObjectList, nsn types.NamespacedName, timeout time.Duration, action func(), statuses ...vmv1beta1.UpdateStatus) {
 	GinkgoHelper()
-	watcher, err := k8sClient.Watch(ctx, list, &client.ListOptions{
+	listOpts := &client.ListOptions{
 		Namespace:     nsn.Namespace,
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", nsn.Name),
-	})
-	Expect(err).ToNot(HaveOccurred())
-	defer watcher.Stop()
-	action()
-	// Fetch the post-action generation to skip stale pre-action watch events.
+	}
+	// Read pre-action generation before the watch starts (stable state, no cache-lag risk).
 	var minGen int64
-	if err := k8sClient.List(ctx, list, &client.ListOptions{
-		Namespace:     nsn.Namespace,
-		FieldSelector: fields.OneTermEqualSelector("metadata.name", nsn.Name),
-	}); err == nil {
+	if err := k8sClient.List(ctx, list, listOpts); err == nil {
 		if items, err := k8smeta.ExtractList(list); err == nil && len(items) > 0 {
 			if obj, ok := items[0].(client.Object); ok {
-				minGen = obj.GetGeneration()
+				minGen = obj.GetGeneration() + 1
 			}
 		}
 	}
+	// minGen stays 0 only if List failed; in that case WatchUntilStatusSeen falls back to
+	// the status-only check, which is no worse than the pre-minGen behavior.
+	watcher, err := k8sClient.Watch(ctx, list, listOpts)
+	Expect(err).ToNot(HaveOccurred())
+	defer watcher.Stop()
+	action()
 	for _, status := range statuses {
 		watchCtx, cancel := context.WithTimeout(ctx, timeout)
-		err := suite.WatchUntilStatusSeen(watchCtx, watcher, nsn.Name, minGen, status)
+		err := suite.WatchUntilStatusSeen(watchCtx, watcher, nsn.Name, minGen, status, vmv1beta1.UpdateStatusFailed)
 		cancel()
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -3,19 +3,24 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -116,34 +121,6 @@ func getRevisionHistoryLimit(ctx context.Context, rclient client.Client, name ty
 	return *app.Spec.RevisionHistoryLimit
 }
 
-func expectObjectStatusExpanding(ctx context.Context,
-	rclient client.Client,
-	object client.Object,
-	name types.NamespacedName) error {
-	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusExpanding)
-}
-
-func expectObjectStatusOperational(ctx context.Context,
-	rclient client.Client,
-	object client.Object,
-	name types.NamespacedName) error {
-	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusOperational)
-}
-
-func expectObjectStatusPaused(ctx context.Context,
-	rclient client.Client,
-	object client.Object,
-	name types.NamespacedName) error {
-	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusPaused)
-}
-
-func expectObjectStatusFailed(ctx context.Context,
-	rclient client.Client,
-	object client.Object,
-	name types.NamespacedName) error {
-	return suite.ExpectObjectStatus(ctx, rclient, object, name, vmv1beta1.UpdateStatusFailed)
-}
-
 type httpRequestOpts struct {
 	dstURL       string
 	method       string
@@ -151,91 +128,65 @@ type httpRequestOpts struct {
 	payload      string
 }
 
-type httpRequestCRDObject interface {
-	GetName() string
-	GetNamespace() string
-}
-
-//nolint:dupl,lll
-func expectHTTPRequestToSucceed(ctx context.Context, object httpRequestCRDObject, opts httpRequestOpts) {
+func expectHTTPRequestToSucceed(ctx context.Context, opts httpRequestOpts) {
 	GinkgoHelper()
 	By("making http request to: " + opts.dstURL)
 	if opts.method == "" {
-		opts.method = "GET"
+		if opts.payload != "" {
+			opts.method = "POST"
+		} else {
+			opts.method = "GET"
+		}
 	}
 	if opts.expectedCode == 0 {
 		opts.expectedCode = 200
 	}
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-http-request-for-" + object.GetName(),
-			Namespace: object.GetNamespace(),
-		},
-		Spec: batchv1.JobSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
-					Containers: []corev1.Container{
-						{
-							Name:    "curl",
-							Image:   "curlimages/curl:7.85.0",
-							Command: []string{"sh", "-c"},
-							Args: []string{
-								fmt.Sprintf(`
-set -e 
-set -o pipefail
-set -x
-response_code=$(curl --write-out %%{http_code} -X %s '%s' -d '%s' -o /tmp/curl_log --connect-timeout 5 --max-time 6 --silent --show-error 2>>/tmp/curl_log)
-if [[ "$response_code" -ne %d ]] ; then
-  echo "unexpected status code: $response_code" | tee >> /tmp/curl_log
-  cat /tmp/curl_log | tr '\n' ' ' | tee > /dev/termination-log
-  exit 1
-else
-  echo "status code: $response_code is ok"
-  cat /tmp/curl_log
-  exit 0
-fi
-`, opts.method, opts.dstURL, opts.payload, opts.expectedCode),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	Expect(k8sClient.Create(ctx, job)).ToNot(HaveOccurred())
-	nss := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
-	defer func() {
-		Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{
-			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
-		})).ToNot(HaveOccurred())
-		waitResourceDeleted(ctx, k8sClient, nss, &batchv1.Job{})
-	}()
+	proxyURL, err := buildServiceProxyURL(&k8sCfg, opts.dstURL)
+	Expect(err).ToNot(HaveOccurred())
+	hc, err := rest.HTTPClientFor(&k8sCfg)
+	Expect(err).ToNot(HaveOccurred())
+	hc.Timeout = 10 * time.Second
 	Eventually(func() error {
-		var jb batchv1.Job
-		if err := k8sClient.Get(ctx, nss, &jb); err != nil {
+		var body io.Reader
+		if opts.payload != "" {
+			body = strings.NewReader(opts.payload)
+		}
+		req, err := http.NewRequestWithContext(ctx, opts.method, proxyURL, body)
+		if err != nil {
 			return err
 		}
-		if jb.Status.Succeeded > 0 {
-			return nil
-		}
-		var pds corev1.PodList
-		if err := k8sClient.List(ctx, &pds, &client.ListOptions{
-			LabelSelector: labels.SelectorFromSet(jb.Spec.Selector.MatchLabels),
-		}); err != nil {
+		resp, err := hc.Do(req)
+		if err != nil {
 			return err
 		}
-		var firstStatus string
-		for _, pd := range pds.Items {
-			for _, ps := range pd.Status.ContainerStatuses {
-				if ps.State.Terminated != nil && firstStatus == "" {
-					firstStatus = fmt.Sprintf("exit_code=%d with message: %s", ps.State.Terminated.ExitCode, ps.State.Terminated.Message)
-					break
-				}
-			}
+		defer resp.Body.Close()
+		if resp.StatusCode != opts.expectedCode {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("unexpected status code: got %d, want %d, body: %s", resp.StatusCode, opts.expectedCode, b)
 		}
-		return fmt.Errorf("unexpected job status, want Succeeded pod > 0 , pod status: %s", firstStatus)
-	}, 60).ShouldNot(HaveOccurred())
+		return nil
+	}, 60*time.Second).ShouldNot(HaveOccurred())
+}
+
+// buildServiceProxyURL converts a cluster-internal service URL to a Kubernetes
+// API server proxy URL so tests can reach in-cluster services without a Job.
+// Input:  "http://svcname.namespace.svc:port/path?query"
+// Output: "{apiserver}/api/v1/namespaces/{namespace}/services/{svcname}:{port}/proxy/{path}?query"
+func buildServiceProxyURL(cfg *rest.Config, svcURL string) (string, error) {
+	u, err := url.Parse(svcURL)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.SplitN(u.Hostname(), ".", 3)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("cannot parse namespace from service URL: %s", svcURL)
+	}
+	proxyPath := u.Path
+	if u.RawQuery != "" {
+		proxyPath += "?" + u.RawQuery
+	}
+	return fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:%s/proxy%s",
+		strings.TrimRight(cfg.Host, "/"), parts[1], parts[0], u.Port(), proxyPath), nil
 }
 
 //nolint:dupl,lll
@@ -319,4 +270,37 @@ func waitResourceDeleted(ctx context.Context, rclient client.Client, nss types.N
 	Eventually(func() error {
 		return rclient.Get(ctx, nss, r)
 	}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+}
+
+// expectStatusAfterAction starts a watch on the named object, runs action, then waits for
+// each status in sequence. Start the watch before the action to capture transient states.
+// After the action, we fetch the current generation so WatchUntilStatusSeen can ignore
+// stale pre-action ADDED events that satisfy the target status but predate the action.
+func expectStatusAfterAction(ctx context.Context, list client.ObjectList, nsn types.NamespacedName, timeout time.Duration, action func(), statuses ...vmv1beta1.UpdateStatus) {
+	GinkgoHelper()
+	watcher, err := k8sClient.Watch(ctx, list, &client.ListOptions{
+		Namespace:     nsn.Namespace,
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", nsn.Name),
+	})
+	Expect(err).ToNot(HaveOccurred())
+	defer watcher.Stop()
+	action()
+	// Fetch the post-action generation to skip stale pre-action watch events.
+	var minGen int64
+	if err := k8sClient.List(ctx, list, &client.ListOptions{
+		Namespace:     nsn.Namespace,
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", nsn.Name),
+	}); err == nil {
+		if items, err := k8smeta.ExtractList(list); err == nil && len(items) > 0 {
+			if obj, ok := items[0].(client.Object); ok {
+				minGen = obj.GetGeneration()
+			}
+		}
+	}
+	for _, status := range statuses {
+		watchCtx, cancel := context.WithTimeout(ctx, timeout)
+		err := suite.WatchUntilStatusSeen(watchCtx, watcher, nsn.Name, minGen, status)
+		cancel()
+		Expect(err).ToNot(HaveOccurred())
+	}
 }

--- a/test/e2e/vlagent_test.go
+++ b/test/e2e/vlagent_test.go
@@ -37,7 +37,7 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VLAgent{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VLAgentList{})
 		})
 
 		DescribeTable("should create vlagent",
@@ -473,8 +473,8 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 					},
 					verify: func(cr *vmv1.VLAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
-						waitResourceDeleted(ctx, k8sClient, nsn, &policyv1.PodDisruptionBudget{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMPodScrape{})
+						waitResourceDeleted(ctx, nsn, &policyv1.PodDisruptionBudgetList{})
+						waitResourceDeleted(ctx, nsn, &vmv1beta1.VMPodScrapeList{})
 					},
 				},
 				testStep{
@@ -507,7 +507,7 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 					verify: func(cr *vmv1.VLAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.DaemonSet{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.StatefulSet{})
+						waitResourceDeleted(ctx, nsn, &appsv1.StatefulSetList{})
 					},
 				},
 				testStep{
@@ -517,7 +517,7 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 					verify: func(cr *vmv1.VLAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.StatefulSet{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.DaemonSet{})
+						waitResourceDeleted(ctx, nsn, &appsv1.DaemonSetList{})
 					},
 				},
 			),

--- a/test/e2e/vlagent_test.go
+++ b/test/e2e/vlagent_test.go
@@ -48,11 +48,9 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 				if setup != nil {
 					setup()
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout,
-				).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				var created vmv1.VLAgent
 				Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -406,22 +404,20 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 				initCR.Name = name
 				initCR.Namespace = namespace
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				for _, step := range steps {
 					if step.setup != nil {
 						step.setup(initCR)
 					}
 					// update and wait ready
 					var toUpdate vmv1.VLAgent
-					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-					}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 					// verify
 					var updated vmv1.VLAgent
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -547,11 +543,9 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -570,30 +564,20 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.LogLevel = "WARN"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("updating the spec to trigger reconcile")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.LogLevel = "WARN"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -612,25 +596,20 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("pausing the VLAgent")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualExpandingTimeout, func() {
+					By("pausing the VLAgent")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -650,25 +629,20 @@ var _ = Describe("test vlagent Controller", Label("vl", "agent", "vlagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
-				By("unpausing the VLAgent")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("unpausing the VLAgent")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -59,10 +59,9 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				cr.Name = name
 				cr.Namespace = namespace
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				if verify != nil {
 					var created vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -146,10 +145,9 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 				initCR.Namespace = namespace
 				nsn.Name = name
 				// setup test
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				for _, step := range steps {
 					if step.setup != nil {
@@ -157,12 +155,11 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 					}
 					// perform update
 					var toUpdate vmv1.VLCluster
-					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-					}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					var updated vmv1.VLCluster
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -247,15 +244,15 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
 						Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)))
 
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:9481/insert/jsonline?_stream_fields=stream&_time_field=date&_msg_field=log.message", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
-							payload: `{\"log\": {\"level\": \"info\", \"message\": \"hello world\" }, \"date\": \"0\", \"stream\": \"stream1\" }
-{ \"log\": { \"level\": \"info\", \"message\": \"hello world\" }, \"date\": \"0\", \"stream\": \"stream2\" }
-              `,
+							payload: `{"log": {"level": "info", "message": "hello world" }, "date": "0", "stream": "stream1" }
+{"log": {"level": "info", "message": "hello world" }, "date": "0", "stream": "stream2" }
+`,
 							expectedCode: 200,
 							method:       "POST",
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:9471/select/logsql/query?query=*", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 							payload:      ``,
 							expectedCode: 200,
@@ -277,15 +274,15 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
 						Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentInsert)))
 
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:9481/insert/jsonline?_stream_fields=stream&_time_field=date&_msg_field=log.message", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
-							payload: `{\"log\": {\"level\": \"info\", \"message\": \"hello world\" }, \"date\": \"0\", \"stream\": \"stream1\" }
-{ \"log\": { \"level\": \"info\", \"message\": \"hello world\" }, \"date\": \"0\", \"stream\": \"stream2\" }
-              `,
+							payload: `{"log": {"level": "info", "message": "hello world" }, "date": "0", "stream": "stream1" }
+{"log": {"level": "info", "message": "hello world" }, "date": "0", "stream": "stream2" }
+`,
 							expectedCode: 200,
 							method:       "POST",
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:9471/select/logsql/query?query=*", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 							payload:      ``,
 							expectedCode: 200,
@@ -459,11 +456,9 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -492,30 +487,20 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.VLStorage.RetentionPeriod = "2"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					By("updating the spec to trigger reconcile")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.VLStorage.RetentionPeriod = "2"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -536,25 +521,20 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("pausing the VLCluster")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualExpandingTimeout, func() {
+					By("pausing the VLCluster")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -576,25 +556,20 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
-				By("unpausing the VLCluster")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					By("unpausing the VLCluster")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vlcluster_test.go
+++ b/test/e2e/vlcluster_test.go
@@ -37,7 +37,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VLCluster{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VLClusterList{})
 		})
 		baseVLCluster := &vmv1.VLCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -264,8 +264,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						cr.Spec.RequestsLoadBalancer.Enabled = false
 					},
 					verify: func(cr *vmv1.VLCluster) {
-						var dep appsv1.Deployment
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer), Namespace: namespace}, &dep)
+						waitResourceDeleted(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer), Namespace: namespace}, &appsv1.DeploymentList{})
 
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
@@ -372,7 +371,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 
 						// vlselect must be removed
 						nsn = types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}
-						waitResourceDeleted(ctx, k8sClient, nsn, dep)
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{
@@ -398,7 +397,7 @@ var _ = Describe("test vlcluster Controller", Label("vl", "cluster", "vlcluster"
 						Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 						// vlinsert must be removed
 						nsn = types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}
-						waitResourceDeleted(ctx, k8sClient, nsn, dep)
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{

--- a/test/e2e/vlsingle_test.go
+++ b/test/e2e/vlsingle_test.go
@@ -38,7 +38,7 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VLSingle{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VLSingleList{})
 		})
 		Context("crud", func() {
 			DescribeTable("should create",

--- a/test/e2e/vlsingle_test.go
+++ b/test/e2e/vlsingle_test.go
@@ -45,11 +45,9 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 				func(name string, cr *vmv1.VLSingle, verify func(*vmv1.VLSingle)) {
 					cr.Name = name
 					nsn.Name = name
-					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout,
-					).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					var created vmv1.VLSingle
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -195,10 +193,9 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 					initCR.Namespace = namespace
 					nsn.Name = name
 					// setup test
-					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					for _, step := range steps {
 						if step.setup != nil {
@@ -206,12 +203,11 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						}
 						// perform update
 						var toUpdate vmv1.VLSingle
-						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-						step.modify(&toUpdate)
-						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-						Eventually(func() error {
-							return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-						}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+						expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+							Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
+							step.modify(&toUpdate)
+							Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+						}, vmv1beta1.UpdateStatusOperational)
 
 						var updated vmv1.VLSingle
 						Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -341,11 +337,9 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -362,30 +356,20 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.RetentionPeriod = "2"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("updating the spec to trigger reconcile")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.RetentionPeriod = "2"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -402,25 +386,20 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("pausing the VLSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualExpandingTimeout, func() {
+					By("pausing the VLSingle")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -438,25 +417,20 @@ var _ = Describe("test vlsingle Controller", Label("vl", "single", "vlsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
-				By("unpausing the VLSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VLSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VLSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("unpausing the VLSingle")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -38,7 +38,7 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 				},
 			},
 			)).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMAgent{})
+			waitResourceDeleted(ctx, nsn, &vmv1beta1.VMAgentList{})
 		})
 
 		It("should be idempotent when calling CreateOrUpdate multiple times", func() {
@@ -578,7 +578,7 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					verify: func(cr *vmv1beta1.VMAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.StatefulSet{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.Deployment{})
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{
@@ -586,7 +586,7 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					verify: func(cr *vmv1beta1.VMAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.Deployment{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.StatefulSet{})
+						waitResourceDeleted(ctx, nsn, &appsv1.StatefulSetList{})
 					},
 				},
 			),
@@ -617,8 +617,8 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					},
 					verify: func(cr *vmv1beta1.VMAgent) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
-						waitResourceDeleted(ctx, k8sClient, nsn, &policyv1.PodDisruptionBudget{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMServiceScrape{})
+						waitResourceDeleted(ctx, nsn, &policyv1.PodDisruptionBudgetList{})
+						waitResourceDeleted(ctx, nsn, &vmv1beta1.VMServiceScrapeList{})
 					},
 				},
 				testStep{
@@ -651,8 +651,8 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.DaemonSet{})).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, nsn, &vmv1beta1.VMPodScrape{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.Deployment{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMServiceScrape{})
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
+						waitResourceDeleted(ctx, nsn, &vmv1beta1.VMServiceScrapeList{})
 					},
 				},
 				testStep{
@@ -664,9 +664,9 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
 						Expect(k8sClient.Get(ctx, nsn, &appsv1.StatefulSet{})).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, nsn, &vmv1beta1.VMServiceScrape{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.DaemonSet{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &appsv1.Deployment{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMPodScrape{})
+						waitResourceDeleted(ctx, nsn, &appsv1.DaemonSetList{})
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
+						waitResourceDeleted(ctx, nsn, &vmv1beta1.VMPodScrapeList{})
 					},
 				},
 			),

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -59,10 +59,9 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-			}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			var agentDep appsv1.Deployment
 			agentDepName := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
@@ -91,11 +90,9 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 				if setup != nil {
 					setup()
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout,
-				).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				var created vmv1beta1.VMAgent
 				Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -458,10 +455,9 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 				initCR.Name = name
 				initCR.Namespace = namespace
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				for _, step := range steps {
 					if step.setup != nil {
 						step.setup(initCR)
@@ -469,11 +465,10 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					// update and wait ready
 					var toUpdate vmv1beta1.VMAgent
 					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-					}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 					// verify
 					var updated vmv1beta1.VMAgent
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -696,11 +691,10 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			deploymentName := types.NamespacedName{Name: cr.PrefixedName(), Namespace: namespace}
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 			By("pausing the VMAgent")
 			Eventually(func() error {
@@ -763,11 +757,9 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -786,30 +778,20 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.LogLevel = "WARN"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.LogLevel = "WARN"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -828,25 +810,20 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("pausing the VMAgent")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualExpandingTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -866,25 +843,20 @@ var _ = Describe("test vmagent Controller", Label("vm", "agent", "vmagent"), fun
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
 				By("unpausing the VMAgent")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAgent{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vmalert_test.go
+++ b/test/e2e/vmalert_test.go
@@ -35,7 +35,7 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 				},
 			},
 			)).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMAlert{})
+			waitResourceDeleted(ctx, nsn, &vmv1beta1.VMAlertList{})
 		})
 		tlsSecretName := "vmalert-remote-tls"
 

--- a/test/e2e/vmalert_test.go
+++ b/test/e2e/vmalert_test.go
@@ -60,10 +60,9 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-			}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			var alertDep appsv1.Deployment
 			alertDepName := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
@@ -92,11 +91,9 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 				if setup != nil {
 					setup()
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout,
-				).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				var created vmv1beta1.VMAlert
 				Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -356,18 +353,16 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 				existObject := existObject.DeepCopy()
 				existObject.Name = name
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, existObject)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, existObject)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				// update and wait ready
 				var toUpdate vmv1beta1.VMAlert
 				Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-				modify(&toUpdate)
-				Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					modify(&toUpdate)
+					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				// verify
 				var updated vmv1beta1.VMAlert
 				Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -430,11 +425,10 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			deploymentName := types.NamespacedName{Name: cr.PrefixedName(), Namespace: namespace}
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
 
 			By("pausing the VMAlert")
 			Eventually(func() error {
@@ -500,11 +494,9 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -526,30 +518,20 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.LogLevel = "WARN"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.LogLevel = "WARN"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -571,25 +553,20 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("pausing the VMAlert")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualExpandingTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -612,25 +589,20 @@ var _ = Describe("test vmalert Controller", Label("vm", "alert"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
 				By("unpausing the VMAlert")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlert{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vmalertmanager_test.go
+++ b/test/e2e/vmalertmanager_test.go
@@ -60,10 +60,9 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 			func(name string, cr *vmv1beta1.VMAlertmanager, verify func(*vmv1beta1.VMAlertmanager)) {
 				nsn.Name = name
 				cr.Name = name
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				var created vmv1beta1.VMAlertmanager
 				Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
 				verify(&created)
@@ -156,21 +155,16 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 				existAlertmanager := existAlertmanager.DeepCopy()
 				existAlertmanager.Name = name
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, existAlertmanager)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, existAlertmanager)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				// update and wait ready
 				var toUpdate vmv1beta1.VMAlertmanager
 				Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-				modify(&toUpdate)
-				Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualExpandingTimeout).ShouldNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					modify(&toUpdate)
+					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 				// verify
 				var updated vmv1beta1.VMAlertmanager
 				Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -261,10 +255,9 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMAlertmanager")
 			Eventually(func() error {
@@ -324,11 +317,9 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -344,30 +335,20 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.LogLevel = "debug"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.LogLevel = "debug"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -383,25 +364,20 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("pausing the VMAlertmanager")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualExpandingTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -418,25 +394,20 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
 				By("unpausing the VMAlertmanager")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAlertmanager{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAlertmanagerList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vmalertmanager_test.go
+++ b/test/e2e/vmalertmanager_test.go
@@ -54,7 +54,7 @@ var _ = Describe("test vmalertmanager Controller", Label("vm", "alertmanager"), 
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMAlertmanager{})
+			waitResourceDeleted(ctx, nsn, &vmv1beta1.VMAlertmanagerList{})
 		})
 		DescribeTable("should create alertmanager",
 			func(name string, cr *vmv1beta1.VMAlertmanager, verify func(*vmv1beta1.VMAlertmanager)) {

--- a/test/e2e/vmanomaly_test.go
+++ b/test/e2e/vmanomaly_test.go
@@ -21,6 +21,7 @@ import (
 	vmv1 "github.com/VictoriaMetrics/operator/api/operator/v1"
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/finalize"
+	"github.com/VictoriaMetrics/operator/test/e2e/suite"
 )
 
 const anomalyConfig = `
@@ -56,7 +57,6 @@ schedulers:
 
 var (
 	anomalyReadyTimeout  = 120 * time.Second
-	anomalyDeleteTimeout = 60 * time.Second
 	anomalyExpandTimeout = 240 * time.Second
 )
 
@@ -86,7 +86,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 	AfterEach(func() {
 		DeleteLicenseSecret(ctx, k8sClient, namespace)
 		Expect(k8sClient.Delete(ctx, &anomalySingle)).ToNot(HaveOccurred())
-		waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: anomalySingle.Name, Namespace: namespace}, &vmv1beta1.VMSingle{})
+		waitResourceDeleted(ctx, types.NamespacedName{Name: anomalySingle.Name, Namespace: namespace}, &vmv1beta1.VMSingleList{})
 	})
 	Context("e2e vmanomaly", func() {
 		namespace := fmt.Sprintf("default-%d", GinkgoParallelProcess())
@@ -103,12 +103,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 					},
 				},
 			)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return k8sClient.Get(context.Background(), types.NamespacedName{
-					Name:      nsn.Name,
-					Namespace: nsn.Namespace,
-				}, &vmv1.VMAnomaly{})
-			}, anomalyDeleteTimeout, 1).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			waitResourceDeleted(ctx, nsn, &vmv1.VMAnomalyList{})
 		})
 		DescribeTable("should create vmanomaly",
 			func(name string, cr *vmv1.VMAnomaly, setup func(), verify func(*vmv1.VMAnomaly)) {
@@ -437,8 +432,8 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 					},
 					verify: func(cr *vmv1.VMAnomaly) {
 						nsn := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
-						waitResourceDeleted(ctx, k8sClient, nsn, &policyv1.PodDisruptionBudget{})
-						waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMPodScrape{})
+						waitResourceDeleted(ctx, nsn, &policyv1.PodDisruptionBudgetList{})
+						waitResourceDeleted(ctx, nsn, &vmv1beta1.VMPodScrapeList{})
 					},
 				},
 				testStep{
@@ -561,9 +556,8 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				Not(ContainSubstring("vm_missed_metric")),
 			))
 			cfgNsn := types.NamespacedName{Name: selectedConfig.Name, Namespace: namespace}
-			expectStatusAfterAction(ctx, &vmv1.VMAnomalyConfigList{}, cfgNsn, anomalyReadyTimeout, func() {
-				// selectedConfig was already created above
-			}, vmv1beta1.UpdateStatusOperational)
+			Expect(suite.WatchUntilStatusReached(ctx, k8sClient, &vmv1.VMAnomalyConfigList{}, cfgNsn, anomalyReadyTimeout,
+				vmv1beta1.UpdateStatusOperational, vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: selectedConfig.Name, Namespace: namespace}, selectedConfig)).ToNot(HaveOccurred())
 			selectedConfig.Spec.Raw = []byte(strings.ReplaceAll(string(selectedConfig.Spec.Raw), "vm_selected_metric", "vm_updated_metric"))
@@ -578,7 +572,7 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 			))
 
 			Expect(k8sClient.Delete(ctx, missedConfig)).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: missedConfig.Name, Namespace: namespace}, &vmv1.VMAnomalyConfig{})
+			waitResourceDeleted(ctx, types.NamespacedName{Name: missedConfig.Name, Namespace: namespace}, &vmv1.VMAnomalyConfigList{})
 		})
 
 		It("should skip reconciliation when VMAnomaly is paused", func() {

--- a/test/e2e/vmanomaly_test.go
+++ b/test/e2e/vmanomaly_test.go
@@ -77,11 +77,10 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 		}
 		CreateLicenseSecret(ctx, k8sClient, namespace)
 
-		Expect(k8sClient.Create(ctx, anomalySingle.DeepCopy())).ToNot(HaveOccurred())
-		Eventually(func() error {
-			return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, types.NamespacedName{Name: anomalySingle.Name, Namespace: namespace})
-		}, eventualDeploymentAppReadyTimeout,
-		).ShouldNot(HaveOccurred())
+		anomalySingleNsn := types.NamespacedName{Name: anomalySingle.Name, Namespace: namespace}
+		expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, anomalySingleNsn, eventualDeploymentAppReadyTimeout, func() {
+			Expect(k8sClient.Create(ctx, anomalySingle.DeepCopy())).ToNot(HaveOccurred())
+		}, vmv1beta1.UpdateStatusOperational)
 
 	})
 	AfterEach(func() {
@@ -118,11 +117,9 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				if setup != nil {
 					setup()
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-				}, anomalyReadyTimeout,
-				).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				var created vmv1.VMAnomaly
 				Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -336,10 +333,9 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				initCR.Name = name
 				initCR.Namespace = namespace
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-				}, anomalyReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				for _, step := range steps {
 					if step.setup != nil {
 						step.setup(initCR)
@@ -347,11 +343,10 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 					// update and wait ready
 					var toUpdate vmv1.VMAnomaly
 					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-					}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 					// verify
 					var updated vmv1.VMAnomaly
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -550,10 +545,9 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				Expect(finalize.SafeDelete(ctx, k8sClient, missedConfig)).ToNot(HaveOccurred())
 			})
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Create(ctx, selectedConfig)).ToNot(HaveOccurred())
 			Expect(k8sClient.Create(ctx, missedConfig)).ToNot(HaveOccurred())
@@ -566,9 +560,10 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 				ContainSubstring(fmt.Sprintf("%s-selected-extra-model", namespace)),
 				Not(ContainSubstring("vm_missed_metric")),
 			))
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomalyConfig{}, types.NamespacedName{Name: selectedConfig.Name, Namespace: namespace})
-			}, anomalyReadyTimeout).ShouldNot(HaveOccurred())
+			cfgNsn := types.NamespacedName{Name: selectedConfig.Name, Namespace: namespace}
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyConfigList{}, cfgNsn, anomalyReadyTimeout, func() {
+				// selectedConfig was already created above
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: selectedConfig.Name, Namespace: namespace}, selectedConfig)).ToNot(HaveOccurred())
 			selectedConfig.Spec.Raw = []byte(strings.ReplaceAll(string(selectedConfig.Spec.Raw), "vm_selected_metric", "vm_updated_metric"))
@@ -618,10 +613,9 @@ var _ = Describe("test vmanomaly Controller", Label("vm", "anomaly", "enterprise
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMAnomaly")
 			Eventually(func() error {

--- a/test/e2e/vmanomalyconfig_test.go
+++ b/test/e2e/vmanomalyconfig_test.go
@@ -35,11 +35,10 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 		}
 		CreateLicenseSecret(ctx, k8sClient, namespace)
 
-		Expect(k8sClient.Create(ctx, anomalyConfigSingle.DeepCopy())).ToNot(HaveOccurred())
-		Eventually(func() error {
-			return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, types.NamespacedName{Name: anomalyConfigSingle.Name, Namespace: namespace})
-		}, eventualDeploymentAppReadyTimeout,
-		).ShouldNot(HaveOccurred())
+		singleNsn := types.NamespacedName{Name: anomalyConfigSingle.Name, Namespace: namespace}
+		expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, singleNsn, eventualDeploymentAppReadyTimeout, func() {
+			Expect(k8sClient.Create(ctx, anomalyConfigSingle.DeepCopy())).ToNot(HaveOccurred())
+		}, vmv1beta1.UpdateStatusOperational)
 	})
 
 	AfterEach(func() {
@@ -131,16 +130,14 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 				waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cfg.Name, Namespace: namespace}, &vmv1.VMAnomalyConfig{})
 			})
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
-			Expect(k8sClient.Create(ctx, cfg)).ToNot(HaveOccurred())
-
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomalyConfig{}, types.NamespacedName{Name: cfg.Name, Namespace: namespace})
-			}, anomalyReadyTimeout).ShouldNot(HaveOccurred())
+			cfgNsn := types.NamespacedName{Name: cfg.Name, Namespace: namespace}
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyConfigList{}, cfgNsn, anomalyReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cfg)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 
 		It("should merge multiple VMAnomalyConfigs into single secret", func() {
@@ -211,10 +208,9 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 				Expect(finalize.SafeDelete(ctx, k8sClient, cfg2)).ToNot(HaveOccurred())
 			})
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Create(ctx, cfg1)).ToNot(HaveOccurred())
 			Expect(k8sClient.Create(ctx, cfg2)).ToNot(HaveOccurred())
@@ -250,10 +246,9 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 }`)},
 			}
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Create(ctx, cfg)).ToNot(HaveOccurred())
 			Eventually(func() string {
@@ -308,10 +303,9 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 				Expect(finalize.SafeDelete(ctx, k8sClient, unselectedCfg)).ToNot(HaveOccurred())
 			})
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Create(ctx, selectedCfg)).ToNot(HaveOccurred())
 			Expect(k8sClient.Create(ctx, unselectedCfg)).ToNot(HaveOccurred())
@@ -388,10 +382,9 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 				Expect(finalize.SafeDelete(ctx, k8sClient, cfg2)).ToNot(HaveOccurred())
 			})
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VMAnomaly{}, nsn)
-			}, anomalyExpandTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			Expect(k8sClient.Create(ctx, cfg1)).ToNot(HaveOccurred())
 			Expect(k8sClient.Create(ctx, cfg2)).ToNot(HaveOccurred())

--- a/test/e2e/vmanomalyconfig_test.go
+++ b/test/e2e/vmanomalyconfig_test.go
@@ -44,7 +44,7 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 	AfterEach(func() {
 		DeleteLicenseSecret(ctx, k8sClient, namespace)
 		Expect(k8sClient.Delete(ctx, &anomalyConfigSingle)).ToNot(HaveOccurred())
-		waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: anomalyConfigSingle.Name, Namespace: namespace}, &vmv1beta1.VMSingle{})
+		waitResourceDeleted(ctx, types.NamespacedName{Name: anomalyConfigSingle.Name, Namespace: namespace}, &vmv1beta1.VMSingleList{})
 	})
 
 	// baseVMAnomaly returns a VMAnomaly with configSelector set, ready for config-injection tests.
@@ -88,7 +88,7 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 			Expect(finalize.SafeDelete(ctx, k8sClient, &vmv1.VMAnomaly{
 				ObjectMeta: metav1.ObjectMeta{Name: nsn.Name, Namespace: nsn.Namespace},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VMAnomaly{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VMAnomalyList{})
 			nsn.Name = ""
 		})
 
@@ -127,7 +127,7 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 			}
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cfg)).ToNot(HaveOccurred())
-				waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cfg.Name, Namespace: namespace}, &vmv1.VMAnomalyConfig{})
+				waitResourceDeleted(ctx, types.NamespacedName{Name: cfg.Name, Namespace: namespace}, &vmv1.VMAnomalyConfigList{})
 			})
 
 			expectStatusAfterAction(ctx, &vmv1.VMAnomalyList{}, nsn, anomalyExpandTimeout, func() {
@@ -258,7 +258,7 @@ var _ = Describe("test VMAnomalyConfig Controller", Serial, Label("vm", "anomaly
 			}, anomalyReadyTimeout).Should(ContainSubstring("vm_delete_metric"))
 
 			Expect(k8sClient.Delete(ctx, cfg)).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cfg.Name, Namespace: namespace}, &vmv1.VMAnomalyConfig{})
+			waitResourceDeleted(ctx, types.NamespacedName{Name: cfg.Name, Namespace: namespace}, &vmv1.VMAnomalyConfigList{})
 
 			Eventually(func() string {
 				var secret corev1.Secret

--- a/test/e2e/vmauth_test.go
+++ b/test/e2e/vmauth_test.go
@@ -44,7 +44,7 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						Namespace: nsn.Namespace,
 					},
 				})).ToNot(HaveOccurred())
-				waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMAuth{})
+				waitResourceDeleted(ctx, nsn, &vmv1beta1.VMAuthList{})
 			})
 			DescribeTable("should create vmauth", func(name string, cr *vmv1beta1.VMAuth, verify func(cr *vmv1beta1.VMAuth)) {
 				cr.Name = name
@@ -514,7 +514,7 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 							}, eventualDeploymentPodTimeout).ShouldNot(HaveOccurred())
 							nsn := types.NamespacedName{Namespace: cr.Namespace, Name: cr.PrefixedName()}
 							Expect(k8sClient.Get(ctx, nsn, &networkingv1.Ingress{})).ToNot(HaveOccurred())
-							waitResourceDeleted(ctx, k8sClient, nsn, &policyv1.PodDisruptionBudget{})
+							waitResourceDeleted(ctx, nsn, &policyv1.PodDisruptionBudgetList{})
 						},
 					},
 					testStep{

--- a/test/e2e/vmauth_test.go
+++ b/test/e2e/vmauth_test.go
@@ -50,10 +50,9 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 				cr.Name = name
 				cr.Namespace = namespace
 				nsn.Name = name
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				verify(cr)
 			},
 				Entry("with 1 replica", "replica-1", &vmv1beta1.VMAuth{
@@ -264,10 +263,9 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 					initCR.Namespace = namespace
 					nsn.Name = name
 					// setup test
-					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 					for _, step := range steps {
 						if step.setup != nil {
 							step.setup(initCR)
@@ -275,11 +273,10 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						// perform update
 						var toUpdate vmv1beta1.VMAuth
 						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-						step.modify(&toUpdate)
-						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-						Eventually(func() error {
-							return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-						}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+						expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+							step.modify(&toUpdate)
+							Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+						}, vmv1beta1.UpdateStatusOperational)
 						var updated vmv1beta1.VMAuth
 						Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
 						// verify results
@@ -741,10 +738,9 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMAuth")
 			Eventually(func() error {
@@ -804,11 +800,9 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -824,30 +818,20 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.UseProxyProtocol = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.UseProxyProtocol = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -863,25 +847,20 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("pausing the VMAuth")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualExpandingTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -898,25 +877,20 @@ var _ = Describe("test vmauth Controller", Label("vm", "auth"), func() {
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
 				By("unpausing the VMAuth")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMAuth{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMAuthList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -76,10 +76,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			var vmStorageSTS appsv1.StatefulSet
 			storageSTSName := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentStorage)}
@@ -121,10 +120,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 		DescribeTable("should create vmcluster", func(name string, cr *vmv1beta1.VMCluster, verify func(cr *vmv1beta1.VMCluster)) {
 			nsn.Name = name
 			cr.Name = name
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			if verify != nil {
 				var createdCluster vmv1beta1.VMCluster
 				Expect(k8sClient.Get(ctx, nsn, &createdCluster)).ToNot(HaveOccurred())
@@ -451,10 +449,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMCluster")
 			Eventually(func() error {
@@ -539,10 +536,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 				nsn.Name = name
 				initCR.Namespace = namespace
 				initCR.Name = name
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, initCR, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				for _, step := range steps {
 					if step.setup != nil {
 						step.setup(initCR)
@@ -551,13 +547,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 					var toUpdate vmv1beta1.VMCluster
 					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
 					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusExpanding(ctx, k8sClient, initCR, nsn)
-					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, initCR, nsn)
-					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 					var updated vmv1beta1.VMCluster
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
 					step.verify(&updated)
@@ -1099,14 +1091,14 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 				},
 				testStep{
 					setup: func(cr *vmv1beta1.VMCluster) {
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 					},
@@ -1136,14 +1128,14 @@ up{baz="bar"} 123
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentInsert),
 							Namespace: namespace,
 						}, &vmv1beta1.VMServiceScrape{})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 					},
@@ -1174,14 +1166,14 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 					},
@@ -1217,14 +1209,14 @@ up{baz="bar"} 123
 						cr.Spec.RequestsLoadBalancer.DisableInsertBalancing = true
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 						var lbDep appsv1.Deployment
@@ -1268,14 +1260,14 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 					},
@@ -1305,14 +1297,14 @@ up{baz="bar"} 123
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
 						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 					},
@@ -1362,14 +1354,14 @@ up{baz="bar"} 123
 						}
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 						var lbDep appsv1.Deployment
@@ -1410,14 +1402,14 @@ up{baz="bar"} 123
 						cr.Spec.RequestsLoadBalancer.Spec.Port = ""
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
 up{baz="bar"} 123
               `,
 							expectedCode: 204,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8481/select/0/prometheus/api/v1/query?query=up", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 						})
 						var lbDep appsv1.Deployment
@@ -1598,10 +1590,9 @@ up{baz="bar"} 123
 				initCR.Namespace = namespace
 				initCR.Name = name
 				ctx = context.Background()
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, initCR, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 				for _, step := range steps {
 					if step.setup != nil {
 						step.setup(initCR)
@@ -1609,14 +1600,13 @@ up{baz="bar"} 123
 					// update and verify immediately
 					var toUpdate vmv1beta1.VMCluster
 					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					var updated vmv1beta1.VMCluster
-					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
-					step.verify(&updated)
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, initCR, nsn)
-					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+						var updated vmv1beta1.VMCluster
+						Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
+						step.verify(&updated)
+					}, vmv1beta1.UpdateStatusOperational)
 				}
 			},
 			Entry("configures vmstorage with MaxUnavailable 2", "maxunavailable-2-integer",
@@ -1846,11 +1836,9 @@ up{baz="bar"} 123
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			By("waiting for operational status after creation")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 
 		It("should transition operational→expanding→operational on spec update", func() {
@@ -1879,30 +1867,20 @@ up{baz="bar"} 123
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			By("waiting for operational status before update")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("updating the spec to trigger reconcile")
-			Eventually(func() error {
-				if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-					return err
-				}
-				cr.Spec.RetentionPeriod = "2"
-				return k8sClient.Update(ctx, cr)
-			}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-			By("waiting for expanding status")
-			Eventually(func() error {
-				return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-			By("waiting for operational status after update")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Eventually(func() error {
+					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+						return err
+					}
+					cr.Spec.RetentionPeriod = "2"
+					return k8sClient.Update(ctx, cr)
+				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 		})
 
 		It("should transition operational→paused when paused", func() {
@@ -1925,25 +1903,20 @@ up{baz="bar"} 123
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			By("waiting for operational status before pause")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMCluster")
-			Eventually(func() error {
-				if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-					return err
-				}
-				cr.Spec.Paused = true
-				return k8sClient.Update(ctx, cr)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-			By("waiting for paused status")
-			Eventually(func() error {
-				return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualExpandingTimeout, func() {
+				Eventually(func() error {
+					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+						return err
+					}
+					cr.Spec.Paused = true
+					return k8sClient.Update(ctx, cr)
+				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusPaused)
 		})
 
 		It("should transition paused→operational when unpaused", func() {
@@ -1967,25 +1940,20 @@ up{baz="bar"} 123
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			By("waiting for paused status after creation")
-			Eventually(func() error {
-				return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusPaused)
 
 			By("unpausing the VMCluster")
-			Eventually(func() error {
-				if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-					return err
-				}
-				cr.Spec.Paused = false
-				return k8sClient.Update(ctx, cr)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-			By("waiting for operational status after unpause")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMCluster{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Eventually(func() error {
+					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+						return err
+					}
+					cr.Spec.Paused = false
+					return k8sClient.Update(ctx, cr)
+				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 	})
 })

--- a/test/e2e/vmcluster_test.go
+++ b/test/e2e/vmcluster_test.go
@@ -42,10 +42,10 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 					Name:      nsn.Name,
 				},
 			})).ToNot(HaveOccurred(), "must delete vmcluster after test")
-			waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+			waitResourceDeleted(ctx, types.NamespacedName{
 				Name:      nsn.Name,
 				Namespace: namespace,
-			}, &vmv1beta1.VMCluster{})
+			}, &vmv1beta1.VMClusterList{})
 		})
 
 		It("should be idempotent when calling CreateOrUpdate multiple times", func() {
@@ -500,10 +500,10 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 					Name:      nsn.Name,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+			waitResourceDeleted(ctx, types.NamespacedName{
 				Name:      nsn.Name,
 				Namespace: namespace,
-			}, &vmv1beta1.VMCluster{})
+			}, &vmv1beta1.VMClusterList{})
 			DeleteLicenseSecret(ctx, k8sClient, namespace)
 		})
 
@@ -824,9 +824,9 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentSelect),
 							Namespace: namespace,
 						}
-						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.StatefulSet{})
-						waitResourceDeleted(ctx, k8sClient, nss, &corev1.Service{})
-						waitResourceDeleted(ctx, k8sClient, nss, &vmv1beta1.VMServiceScrape{})
+						waitResourceDeleted(ctx, nss, &appsv1.StatefulSetList{})
+						waitResourceDeleted(ctx, nss, &corev1.ServiceList{})
+						waitResourceDeleted(ctx, nss, &vmv1beta1.VMServiceScrapeList{})
 					},
 				},
 				testStep{
@@ -887,12 +887,12 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 							Namespace: namespace,
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentStorage),
 						}
-						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.StatefulSet{})
-						waitResourceDeleted(ctx, k8sClient, nss, &corev1.Service{})
-						waitResourceDeleted(ctx, k8sClient, nss, &vmv1beta1.VMServiceScrape{})
+						waitResourceDeleted(ctx, nss, &appsv1.StatefulSetList{})
+						waitResourceDeleted(ctx, nss, &corev1.ServiceList{})
+						waitResourceDeleted(ctx, nss, &vmv1beta1.VMServiceScrapeList{})
 
 						nss.Name = cr.PrefixedName(vmv1beta1.ClusterComponentInsert)
-						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.Deployment{})
+						waitResourceDeleted(ctx, nss, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{
@@ -977,12 +977,12 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 							Namespace: namespace,
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentSelect) + "-additional-service",
 						}
-						waitResourceDeleted(ctx, k8sClient, nss, &corev1.Service{})
+						waitResourceDeleted(ctx, nss, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name + "-additional-service"}, &corev1.Service{})).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Namespace: namespace,
 							Name:      "my-service-name",
-						}, &corev1.Service{})
+						}, &corev1.ServiceList{})
 					},
 				},
 				testStep{
@@ -1005,10 +1005,10 @@ var _ = Describe("e2e vmcluster", Label("vm", "cluster", "vmcluster"), func() {
 						}
 					},
 					verify: func(cr *vmv1beta1.VMCluster) {
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Namespace: namespace,
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentStorage) + "-additional-service",
-						}, &corev1.Service{})
+						}, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "my-service-name-v2"}, &corev1.Service{})).ToNot(HaveOccurred())
 						var stSvc corev1.Service
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "vmstorage-" + cr.Name}, &stSvc)).ToNot(HaveOccurred())
@@ -1120,14 +1120,14 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentSelect),
 							Namespace: namespace,
-						}, &vmv1beta1.VMServiceScrape{})
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						}, &vmv1beta1.VMServiceScrapeList{})
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Name:      cr.PrefixedName(vmv1beta1.ClusterComponentInsert),
 							Namespace: namespace,
-						}, &vmv1beta1.VMServiceScrape{})
+						}, &vmv1beta1.VMServiceScrapeList{})
 						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
@@ -1147,25 +1147,25 @@ up{baz="bar"} 123
 					verify: func(cr *vmv1beta1.VMCluster) {
 						By("disabling loadbalancer")
 						nss := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer)}
-						waitResourceDeleted(ctx, k8sClient, nss, &appsv1.Deployment{})
+						waitResourceDeleted(ctx, nss, &appsv1.DeploymentList{})
 						var svc corev1.Service
-						waitResourceDeleted(ctx, k8sClient, nss, &svc)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						waitResourceDeleted(ctx, nss, &corev1.ServiceList{})
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Namespace: namespace,
 							Name:      cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert),
-						}, &svc)
+						}, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{
+						waitResourceDeleted(ctx, types.NamespacedName{
 							Namespace: namespace,
 							Name:      cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect),
-						}, &svc)
+						}, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
 						var vss vmv1beta1.VMServiceScrape
-						waitResourceDeleted(ctx, k8sClient, nss, &vss)
+						waitResourceDeleted(ctx, nss, &vmv1beta1.VMServiceScrapeList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vmv1beta1.VMServiceScrapeList{})
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vmv1beta1.VMServiceScrapeList{})
 						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
@@ -1224,15 +1224,15 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &lbDep)).ToNot(HaveOccurred())
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, nss, &svc)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &svc)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vmv1beta1.VMServiceScrapeList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vmv1beta1.VMServiceScrapeList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)).ToNot(HaveOccurred())
 
 					},
@@ -1258,8 +1258,8 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vmv1beta1.VMServiceScrapeList{})
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vmv1beta1.VMServiceScrapeList{})
 						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
@@ -1289,14 +1289,14 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &svc)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &svc)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &svc)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &corev1.ServiceList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &svc)).ToNot(HaveOccurred())
 						var vss vmv1beta1.VMServiceScrape
 						Expect(k8sClient.Get(ctx, nss, &vss)).ToNot(HaveOccurred())
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentInsert)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect)}, &vmv1beta1.VMServiceScrapeList{})
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vmv1beta1.VMServiceScrapeList{})
 						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL: fmt.Sprintf("http://%s.%s.svc:8480/insert/0/prometheus/api/v1/import/prometheus", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							payload: `up{bar="baz"} 123
@@ -1387,8 +1387,8 @@ up{baz="bar"} 123
 							Namespace: namespace,
 							Name:      cr.PrefixedInternalName(vmv1beta1.ClusterComponentSelect),
 						}, &vss)).ToNot(HaveOccurred())
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vss)
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vss)
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}, &vmv1beta1.VMServiceScrapeList{})
+						waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}, &vmv1beta1.VMServiceScrapeList{})
 						var pdb policyv1.PodDisruptionBudget
 						Expect(k8sClient.Get(ctx, nss, &pdb)).ToNot(HaveOccurred())
 					},
@@ -1422,7 +1422,7 @@ up{baz="bar"} 123
 						Expect(k8sClient.Get(ctx, nss, &svc)).ToNot(HaveOccurred())
 						Expect(svc.Spec.ClusterIP).NotTo(Equal(corev1.ClusterIPNone))
 						Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.Parse("8427")))
-						waitResourceDeleted(ctx, k8sClient, nss, &policyv1.PodDisruptionBudget{})
+						waitResourceDeleted(ctx, nss, &policyv1.PodDisruptionBudgetList{})
 					},
 				},
 			),
@@ -1575,7 +1575,7 @@ up{baz="bar"} 123
 					Name:      nsn.Name,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Namespace: namespace, Name: nsn.Name}, &vmv1beta1.VMCluster{})
+			waitResourceDeleted(ctx, types.NamespacedName{Namespace: namespace, Name: nsn.Name}, &vmv1beta1.VMClusterList{})
 		})
 
 		type testStep struct {

--- a/test/e2e/vmdistributed_test.go
+++ b/test/e2e/vmdistributed_test.go
@@ -57,10 +57,10 @@ func createVMClusters(ctx context.Context, wg *sync.WaitGroup, k8sClient client.
 					return k8sClient.Get(ctx, types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace}, &vmv1beta1.VMCluster{})
 				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 			})
-			Expect(k8sClient.Create(ctx, vmCluster.DeepCopy())).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, vmCluster, types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace})
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			clusterNsn := types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace}
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, clusterNsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, vmCluster.DeepCopy())).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 	}
 }
@@ -86,10 +86,10 @@ func createVMAgents(ctx context.Context, wg *sync.WaitGroup, k8sClient client.Cl
 					return k8sClient.Get(ctx, types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace}, &vmv1beta1.VMAgent{})
 				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 			})
-			Expect(k8sClient.Create(ctx, vmAgent)).NotTo(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, vmAgent, types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace})
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			agentNsn := types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace}
+			expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, agentNsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, vmAgent)).NotTo(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 	}
 }
@@ -205,10 +205,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			for i := range zs {
 				z := &zs[i]
@@ -289,7 +288,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			var inlineVMClusters []*vmv1beta1.VMCluster
 			owner := cr.AsOwner()
@@ -302,30 +303,23 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 					},
 				})
 			}
-
-			By("waiting for VMDistributed to become operational")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
 			verifyOwnerReferences(ctx, cr, inlineVMClusters, namespace)
 
 			By("verifying that the inline VMClusters are created and operational")
 			nsn := types.NamespacedName{Name: vmClusters[0].Name, Namespace: namespace}
 			vmCluster1 := &vmv1beta1.VMCluster{}
-			Expect(k8sClient.Get(ctx, nsn, vmCluster1)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, vmCluster1, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Get(ctx, nsn, vmCluster1)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			Expect(*vmCluster1.Spec.VMSelect.ReplicaCount).To(Equal(int32(1)))
 			Expect(*vmCluster1.Spec.VMInsert.ReplicaCount).To(Equal(int32(0)))
 			Expect(*vmCluster1.Spec.VMStorage.ReplicaCount).To(Equal(int32(1)))
 
 			nsn = types.NamespacedName{Name: vmClusters[1].Name, Namespace: namespace}
 			vmCluster2 := &vmv1beta1.VMCluster{}
-			Expect(k8sClient.Get(ctx, nsn, vmCluster2)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, vmCluster2, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Get(ctx, nsn, vmCluster2)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			Expect(*vmCluster2.Spec.VMSelect.ReplicaCount).To(Equal(int32(2)))
 			Expect(*vmCluster2.Spec.VMInsert.ReplicaCount).To(Equal(int32(0)))
 			Expect(*vmCluster2.Spec.VMStorage.ReplicaCount).To(Equal(int32(1)))
@@ -387,12 +381,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-
-			By("waiting for VMDistributed to become operational")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("verifying that the inline VMAuth is created and operational")
 			var createdVMAuth vmv1beta1.VMAuth
@@ -465,12 +456,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-
-			By("waiting for VMDistributed to become operational")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			verifyOwnerReferences(ctx, cr, vmClusters, namespace)
 
 			By("verifying that the referenced VMClusters have the override applied")
@@ -550,12 +538,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-
-			By("waiting for VMDistributed to become operational")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			verifyOwnerReferences(ctx, cr, vmClusters, namespace)
 
 			By("verifying that both VMClusters have the global override applied")
@@ -621,29 +606,27 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			verifyOwnerReferences(ctx, cr, vmClusters, namespace)
 
 			// Update VMAgent
-			Eventually(func() error {
-				var obj vmv1alpha1.VMDistributed
-				if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
-					return err
-				}
-				for i := range obj.Spec.Zones {
-					z := &obj.Spec.Zones[i]
-					z.VMAgent = vmv1alpha1.VMDistributedZoneAgent{Name: z.Name}
-				}
-				return k8sClient.Update(ctx, &obj)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Eventually(func() error {
+					var obj vmv1alpha1.VMDistributed
+					if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
+						return err
+					}
+					for i := range obj.Spec.Zones {
+						z := &obj.Spec.Zones[i]
+						z.VMAgent = vmv1alpha1.VMDistributedZoneAgent{Name: z.Name}
+					}
+					return k8sClient.Update(ctx, &obj)
+				}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
 
-			// Wait for VMDistributed to become operational after update
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				// Wait for VMDistributed to become operational after update
+			}, vmv1beta1.UpdateStatusOperational)
 		})
 
 		It("should wait for VMCluster upgrade completion", func() {
@@ -701,26 +684,18 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			verifyOwnerReferences(ctx, cr, vmClusters, namespace)
 
-			// Apply spec update
-			Expect(k8sClient.Get(ctx, nsn, cr)).ToNot(HaveOccurred())
-			cr.Spec.Zones[0].VMCluster.Spec.ClusterVersion = updateVersion
-			cr.Spec.Zones[1].VMCluster.Spec.ClusterVersion = updateVersion
-			Expect(k8sClient.Update(ctx, cr)).ToNot(HaveOccurred())
-			// Wait for VMDistributed to start expanding after its own upgrade
-			Eventually(func() error {
-				return expectObjectStatusExpanding(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-			// Wait for VMDistributed to become operational after its own upgrade
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			// Apply spec update and wait for expanding then operational
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Get(ctx, nsn, cr)).ToNot(HaveOccurred())
+				cr.Spec.Zones[0].VMCluster.Spec.ClusterVersion = updateVersion
+				cr.Spec.Zones[1].VMCluster.Spec.ClusterVersion = updateVersion
+				Expect(k8sClient.Update(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 
 			// Verify VMDistributed status reflects both clusters are upgraded/operational
 			var newVMCluster1, newVMCluster2 vmv1beta1.VMCluster
@@ -787,25 +762,23 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 			verifyOwnerReferences(ctx, cr, vmClusters, namespace)
 
 			By("pausing the VMDistributed")
 			// Re-fetch the latest VMDistributed object to avoid conflict errors
-			Eventually(func() error {
-				err := k8sClient.Get(ctx, nsn, cr)
-				if err != nil {
-					return err
-				}
-				cr.Spec.Paused = true
-				return k8sClient.Update(ctx, cr)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusPaused(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Eventually(func() error {
+					err := k8sClient.Get(ctx, nsn, cr)
+					if err != nil {
+						return err
+					}
+					cr.Spec.Paused = true
+					return k8sClient.Update(ctx, cr)
+				}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusPaused)
 
 			By("attempting to scale the VMCluster while paused")
 			var vmCluster1 vmv1beta1.VMCluster
@@ -837,22 +810,17 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 
 			By("unpausing the VMDistributed")
 			// Re-fetch the latest VMDistributed object to avoid conflict errors
-			Eventually(func() error {
-				err := k8sClient.Get(ctx, nsn, cr)
-				if err != nil {
-					return err
-				}
-				cr.Spec.Paused = false
-				return k8sClient.Update(ctx, cr)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Eventually(func() error {
+					err := k8sClient.Get(ctx, nsn, cr)
+					if err != nil {
+						return err
+					}
+					cr.Spec.Paused = false
+					return k8sClient.Update(ctx, cr)
+				}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
 
-			Eventually(func() error {
-				return expectObjectStatusExpanding(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
-
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 
 			By("verifying reconciliation resumes after unpausing")
 			Eventually(func() int32 {
@@ -917,10 +885,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			// Capture resource versions of key child resources
 			var beforeCluster vmv1beta1.VMCluster
@@ -1078,10 +1045,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			zone0NSN := types.NamespacedName{Name: vmClusters[0].Name, Namespace: namespace}
 			zone1NSN := types.NamespacedName{Name: vmClusters[1].Name, Namespace: namespace}
@@ -1101,38 +1067,32 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			Expect(getInsertReplicas(zone1NSN)).To(BeEquivalentTo(1))
 
 			By("switching zone 0 to read-only mode")
-			Eventually(func() error {
-				var obj vmv1alpha1.VMDistributed
-				if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
-					return err
-				}
-				obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadOnly
-				return k8sClient.Update(ctx, &obj)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
-
-			By("waiting for VMDistributed to complete read-only transition")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Eventually(func() error {
+					var obj vmv1alpha1.VMDistributed
+					if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
+						return err
+					}
+					obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadOnly
+					return k8sClient.Update(ctx, &obj)
+				}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("verifying zone 0 VMInsert is disabled and zone 1 is unchanged")
 			Expect(getInsertReplicas(zone0NSN)).To(BeEquivalentTo(0))
 			Expect(getInsertReplicas(zone1NSN)).To(BeEquivalentTo(1))
 
 			By("switching zone 0 back to read-write mode")
-			Eventually(func() error {
-				var obj vmv1alpha1.VMDistributed
-				if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
-					return err
-				}
-				obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadWrite
-				return k8sClient.Update(ctx, &obj)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
-
-			By("waiting for VMDistributed to complete read-write transition")
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn)
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Eventually(func() error {
+					var obj vmv1alpha1.VMDistributed
+					if err := k8sClient.Get(ctx, nsn, &obj); err != nil {
+						return err
+					}
+					obj.Spec.Zones[0].TrafficMode = vmv1alpha1.VMDistributedTrafficModeReadWrite
+					return k8sClient.Update(ctx, &obj)
+				}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("verifying zone 0 VMInsert is re-enabled")
 			Expect(getInsertReplicas(zone0NSN)).To(BeEquivalentTo(1))
@@ -1236,10 +1196,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, types.NamespacedName{Name: nsn.Name, Namespace: namespace})
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("ensuring VMAuth was created")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nsn.Name, Namespace: cr.Namespace}, &vmv1beta1.VMAuth{})).ToNot(HaveOccurred())
@@ -1327,10 +1286,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, types.NamespacedName{Name: nsn.Name, Namespace: namespace})
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("ensuring VMAgent was created")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vmAgents[0].Name, Namespace: cr.Namespace}, &vmv1beta1.VMAgent{})).ToNot(HaveOccurred())
@@ -1414,10 +1372,9 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, types.NamespacedName{Name: nsn.Name, Namespace: namespace})
-			}, eventualDistributedExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1alpha1.VMDistributedList{}, nsn, eventualDistributedExpandingTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("ensuring VMAuth was not created")
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: nsn.Name, Namespace: cr.Namespace}, &vmv1beta1.VMAuth{})

--- a/test/e2e/vmdistributed_test.go
+++ b/test/e2e/vmdistributed_test.go
@@ -53,9 +53,7 @@ func createVMClusters(ctx context.Context, wg *sync.WaitGroup, k8sClient client.
 		wg.Go(func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, vmCluster)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return k8sClient.Get(ctx, types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace}, &vmv1beta1.VMCluster{})
-				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+				waitResourceDeleted(ctx, types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace}, &vmv1beta1.VMClusterList{})
 			})
 			clusterNsn := types.NamespacedName{Name: vmCluster.Name, Namespace: vmCluster.Namespace}
 			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, clusterNsn, eventualDistributedExpandingTimeout, func() {
@@ -82,9 +80,7 @@ func createVMAgents(ctx context.Context, wg *sync.WaitGroup, k8sClient client.Cl
 		wg.Go(func() {
 			DeferCleanup(func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, vmAgent)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return k8sClient.Get(ctx, types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace}, &vmv1beta1.VMAgent{})
-				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+				waitResourceDeleted(ctx, types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace}, &vmv1beta1.VMAgentList{})
 			})
 			agentNsn := types.NamespacedName{Name: vmAgent.Name, Namespace: vmAgent.Namespace}
 			expectStatusAfterAction(ctx, &vmv1beta1.VMAgentList{}, agentNsn, eventualDistributedExpandingTimeout, func() {
@@ -118,14 +114,9 @@ func createVMAuth(ctx context.Context, wg *sync.WaitGroup, k8sClient client.Clie
 		}
 		DeferCleanup(func() {
 			Expect(finalize.SafeDelete(ctx, k8sClient, vmAuth)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: vmAuth.Name, Namespace: ns}, &vmv1beta1.VMAuth{})
-			}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			waitResourceDeleted(ctx, types.NamespacedName{Name: vmAuth.Name, Namespace: ns}, &vmv1beta1.VMAuthList{})
 		})
 		Expect(k8sClient.Create(ctx, vmAuth)).NotTo(HaveOccurred())
-		Eventually(func() error {
-			return k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, vmAuth)
-		}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
 	})
 }
 
@@ -307,19 +298,19 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 
 			By("verifying that the inline VMClusters are created and operational")
 			nsn := types.NamespacedName{Name: vmClusters[0].Name, Namespace: namespace}
+			Expect(suite.WatchUntilStatusReached(ctx, k8sClient, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout,
+				vmv1beta1.UpdateStatusOperational, vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 			vmCluster1 := &vmv1beta1.VMCluster{}
-			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout, func() {
-				Expect(k8sClient.Get(ctx, nsn, vmCluster1)).ToNot(HaveOccurred())
-			}, vmv1beta1.UpdateStatusOperational)
+			Expect(k8sClient.Get(ctx, nsn, vmCluster1)).ToNot(HaveOccurred())
 			Expect(*vmCluster1.Spec.VMSelect.ReplicaCount).To(Equal(int32(1)))
 			Expect(*vmCluster1.Spec.VMInsert.ReplicaCount).To(Equal(int32(0)))
 			Expect(*vmCluster1.Spec.VMStorage.ReplicaCount).To(Equal(int32(1)))
 
 			nsn = types.NamespacedName{Name: vmClusters[1].Name, Namespace: namespace}
+			Expect(suite.WatchUntilStatusReached(ctx, k8sClient, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout,
+				vmv1beta1.UpdateStatusOperational, vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 			vmCluster2 := &vmv1beta1.VMCluster{}
-			expectStatusAfterAction(ctx, &vmv1beta1.VMClusterList{}, nsn, eventualDistributedExpandingTimeout, func() {
-				Expect(k8sClient.Get(ctx, nsn, vmCluster2)).ToNot(HaveOccurred())
-			}, vmv1beta1.UpdateStatusOperational)
+			Expect(k8sClient.Get(ctx, nsn, vmCluster2)).ToNot(HaveOccurred())
 			Expect(*vmCluster2.Spec.VMSelect.ReplicaCount).To(Equal(int32(2)))
 			Expect(*vmCluster2.Spec.VMInsert.ReplicaCount).To(Equal(int32(0)))
 			Expect(*vmCluster2.Spec.VMStorage.ReplicaCount).To(Equal(int32(1)))
@@ -572,7 +563,6 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 				zs[i].Name = objMeta.Name
 				zs[i].VMCluster.Spec = genVMClusterSpec()
 				zs[i].VMCluster.Name = objMeta.Name
-				zs[i].VMAgent.Name = objMeta.Name
 				vmClusters[i] = &vmv1beta1.VMCluster{
 					ObjectMeta: objMeta,
 					Spec:       genVMClusterSpec(),
@@ -1107,9 +1097,8 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 				Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 			})
 			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return suite.ExpectObjectStatus(ctx, k8sClient, &vmv1alpha1.VMDistributed{}, nsn, vmv1beta1.UpdateStatusFailed)
-			}, eventualDistributedExpandingTimeout).ShouldNot(HaveOccurred())
+			Expect(suite.WatchUntilStatusReached(ctx, k8sClient, &vmv1alpha1.VMDistributedList{}, nsn,
+				eventualDistributedExpandingTimeout, vmv1beta1.UpdateStatusFailed)).ToNot(HaveOccurred())
 		},
 			Entry("with invalid VMCluster", &vmv1alpha1.VMDistributed{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1213,23 +1202,15 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			Expect(finalize.SafeDelete(ctx, k8sClient, cr)).ToNot(HaveOccurred())
 
 			By("ensuring VMAuth is eventually removed")
-			Eventually(func() error {
-				return k8sClient.Get(ctx, types.NamespacedName{Name: nsn.Name, Namespace: cr.Namespace}, &vmv1beta1.VMAuth{})
-			}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			waitResourceDeleted(ctx, types.NamespacedName{Name: nsn.Name, Namespace: cr.Namespace}, &vmv1beta1.VMAuthList{})
 
 			By("ensuring VMDistributed is eventually removed")
-			Eventually(func() error {
-				return k8sClient.Get(ctx, nsn, &vmv1alpha1.VMDistributed{})
-			}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			waitResourceDeleted(ctx, nsn, &vmv1alpha1.VMDistributedList{})
 
 			By("ensuring VMClusters and VMAgents are eventually removed")
 			for _, zone := range cr.Spec.Zones {
-				Eventually(func() error {
-					return k8sClient.Get(ctx, types.NamespacedName{Name: zone.VMAgent.Name, Namespace: namespace}, &vmv1beta1.VMAgent{})
-				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
-				Eventually(func() error {
-					return k8sClient.Get(ctx, types.NamespacedName{Name: zone.VMCluster.Name, Namespace: namespace}, &vmv1beta1.VMCluster{})
-				}, eventualDeletionTimeout).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+				waitResourceDeleted(ctx, types.NamespacedName{Name: zone.VMAgent.Name, Namespace: namespace}, &vmv1beta1.VMAgentList{})
+				waitResourceDeleted(ctx, types.NamespacedName{Name: zone.VMCluster.Name, Namespace: namespace}, &vmv1beta1.VMClusterList{})
 			}
 		})
 
@@ -1314,9 +1295,7 @@ var _ = Describe("e2e VMDistributed", Label("vm", "vmdistributed"), func() {
 			}, eventualDeletionTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
 
 			By("ensuring VMDistributed is eventually removed")
-			Eventually(func() error {
-				return k8sClient.Get(ctx, nsn, &vmv1alpha1.VMDistributed{})
-			}, eventualDeletionTimeout).WithContext(ctx).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			waitResourceDeleted(ctx, nsn, &vmv1alpha1.VMDistributedList{})
 
 			By("ensuring VMCluster is not removed")
 			Consistently(func() error {

--- a/test/e2e/vmsingle_test.go
+++ b/test/e2e/vmsingle_test.go
@@ -40,7 +40,7 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1beta1.VMSingle{})
+			waitResourceDeleted(ctx, nsn, &vmv1beta1.VMSingleList{})
 			DeleteLicenseSecret(ctx, k8sClient, namespace)
 		})
 		Context("crud", func() {

--- a/test/e2e/vmsingle_test.go
+++ b/test/e2e/vmsingle_test.go
@@ -60,10 +60,9 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 					},
 				}
 
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				var singleDep appsv1.Deployment
 				singleDepName := types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName()}
@@ -103,11 +102,9 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 					}
 					cr.Name = name
 					nsn.Name = name
-					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout,
-					).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					var created vmv1beta1.VMSingle
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -387,10 +384,9 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 					initCR.Namespace = namespace
 					nsn.Name = name
 					// setup test
-					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					for _, step := range steps {
 						if step.setup != nil {
@@ -399,14 +395,10 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						// perform update
 						var toUpdate vmv1beta1.VMSingle
 						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-						step.modify(&toUpdate)
-						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-						Eventually(func() error {
-							return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-						}, eventualExpandingTimeout).ShouldNot(HaveOccurred())
-						Eventually(func() error {
-							return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-						}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+						expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+							step.modify(&toUpdate)
+							Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+						}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 
 						var updated vmv1beta1.VMSingle
 						Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -501,10 +493,9 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 					RetentionPeriod: "1",
 				},
 			}
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-			}, eventualStatefulsetAppReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			By("pausing the VMSingle")
 			Eventually(func() error {
@@ -565,11 +556,9 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -586,30 +575,20 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.RetentionPeriod = "2"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.RetentionPeriod = "2"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -626,25 +605,20 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("pausing the VMSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualExpandingTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -662,25 +636,20 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
 				By("unpausing the VMSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→failed→operational on non-retryable error", func() {
@@ -697,35 +666,27 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating with invalid spec to trigger failure (non-retryable error)")
-				Expect(k8sClient.Get(ctx, nsn, cr)).ToNot(HaveOccurred())
-				cr.Spec.ServiceAccountName = "invalid_name!"
-				Expect(k8sClient.Update(ctx, cr)).ToNot(HaveOccurred())
-
-				By("waiting for failed status")
-				Eventually(func() error {
-					return expectObjectStatusFailed(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Get(ctx, nsn, cr)).ToNot(HaveOccurred())
+					cr.Spec.ServiceAccountName = "invalid_name!"
+					Expect(k8sClient.Update(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusFailed)
 
 				By("fixing the spec to recover")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.ServiceAccountName = ""
-					return k8sClient.Update(ctx, cr)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after recovery")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.ServiceAccountName = ""
+						return k8sClient.Update(ctx, cr)
+					}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on retryable error", func() {
@@ -742,40 +703,32 @@ var _ = Describe("test vmsingle Controller", Label("vm", "single"), func() {
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				By("updating with unsatisfiable nodeSelector to trigger timeout (retryable wait.Interrupted error)")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					// Change both spec and node selector to force a reconcile
-					cr.Spec.NodeSelector = map[string]string{"non-existent-node-label": "true"}
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status due to Pending pods")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						// Change both spec and node selector to force a reconcile
+						cr.Spec.NodeSelector = map[string]string{"non-existent-node-label": "true"}
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding)
 
 				By("fixing the spec to recover")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.NodeSelector = nil
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after recovery")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1beta1.VMSingle{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1beta1.VMSingleList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.NodeSelector = nil
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vtcluster_test.go
+++ b/test/e2e/vtcluster_test.go
@@ -37,7 +37,7 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VTCluster{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VTClusterList{})
 		})
 
 		DescribeTable("should create", func(name string, cr *vmv1.VTCluster, verify func(cr *vmv1.VTCluster)) {
@@ -231,8 +231,7 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						cr.Spec.RequestsLoadBalancer.Enabled = false
 					},
 					verify: func(cr *vmv1.VTCluster) {
-						var dep appsv1.Deployment
-						waitResourceDeleted(ctx, k8sClient, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer), Namespace: namespace}, &dep)
+						waitResourceDeleted(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentBalancer), Namespace: namespace}, &appsv1.DeploymentList{})
 
 						var svc corev1.Service
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
@@ -276,7 +275,7 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 
 						// vtselect must be removed
 						nsn = types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentSelect)}
-						waitResourceDeleted(ctx, k8sClient, nsn, dep)
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{
@@ -302,7 +301,7 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 						// vtinsert must be removed
 						nsn = types.NamespacedName{Namespace: namespace, Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert)}
-						waitResourceDeleted(ctx, k8sClient, nsn, dep)
+						waitResourceDeleted(ctx, nsn, &appsv1.DeploymentList{})
 					},
 				},
 				testStep{

--- a/test/e2e/vtcluster_test.go
+++ b/test/e2e/vtcluster_test.go
@@ -43,10 +43,9 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 		DescribeTable("should create", func(name string, cr *vmv1.VTCluster, verify func(cr *vmv1.VTCluster)) {
 			nsn.Name = name
 			cr.Name = name
-			Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-			Eventually(func() error {
-				return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-			}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+			expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+			}, vmv1beta1.UpdateStatusOperational)
 
 			var created vmv1.VTCluster
 			Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -117,10 +116,9 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 				initCR.Namespace = namespace
 				nsn.Name = name
 				// setup test
-				Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
 				for _, step := range steps {
 					if step.setup != nil {
@@ -128,12 +126,11 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 					}
 					// perform update
 					var toUpdate vmv1.VTCluster
-					Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-					step.modify(&toUpdate)
-					Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
+						step.modify(&toUpdate)
+						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					var updated vmv1.VTCluster
 					Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -218,11 +215,11 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
 						Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentBalancer)))
 
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							expectedCode: 200,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 							payload:      ``,
 							expectedCode: 200,
@@ -244,11 +241,11 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(vmv1beta1.ClusterComponentInsert), Namespace: namespace}, &svc)).ToNot(HaveOccurred())
 						Expect(svc.Spec.Selector).To(Equal(cr.SelectorLabels(vmv1beta1.ClusterComponentInsert)))
 
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:10481/insert/ready", cr.PrefixedName(vmv1beta1.ClusterComponentInsert), namespace),
 							expectedCode: 200,
 						})
-						expectHTTPRequestToSucceed(ctx, cr, httpRequestOpts{
+						expectHTTPRequestToSucceed(ctx, httpRequestOpts{
 							dstURL:       fmt.Sprintf("http://%s.%s.svc:10471/select/logsql/query?query=*", cr.PrefixedName(vmv1beta1.ClusterComponentSelect), namespace),
 							payload:      ``,
 							expectedCode: 200,
@@ -363,11 +360,9 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -396,30 +391,20 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Storage.RetentionPeriod = "2"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					By("updating the spec to trigger reconcile")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Storage.RetentionPeriod = "2"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -440,25 +425,20 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("pausing the VTCluster")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualExpandingTimeout, func() {
+					By("pausing the VTCluster")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -480,25 +460,20 @@ var _ = Describe("test vtcluster Controller", Label("vt", "cluster", "vtcluster"
 						},
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
-				By("unpausing the VTCluster")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTCluster{}, nsn)
-				}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTClusterList{}, nsn, eventualStatefulsetAppReadyTimeout, func() {
+					By("unpausing the VTCluster")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualStatefulsetAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vtsingle_test.go
+++ b/test/e2e/vtsingle_test.go
@@ -45,11 +45,9 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 				func(name string, cr *vmv1.VTSingle, verify func(*vmv1.VTSingle)) {
 					cr.Name = name
 					nsn.Name = name
-					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout,
-					).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					var created vmv1.VTSingle
 					Expect(k8sClient.Get(ctx, nsn, &created)).ToNot(HaveOccurred())
@@ -195,22 +193,20 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 					initCR.Namespace = namespace
 					nsn.Name = name
 					// setup test
-					Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
-					Eventually(func() error {
-						return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-					}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+					expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+						Expect(k8sClient.Create(ctx, initCR)).ToNot(HaveOccurred())
+					}, vmv1beta1.UpdateStatusOperational)
 
 					for _, step := range steps {
 						if step.setup != nil {
 							step.setup(initCR)
 						}
 						var toUpdate vmv1.VTSingle
-						Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
-						step.modify(&toUpdate)
-						Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
-						Eventually(func() error {
-							return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-						}, eventualDeploymentAppReadyTimeout).ShouldNot(HaveOccurred())
+						expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+							Expect(k8sClient.Get(ctx, nsn, &toUpdate)).ToNot(HaveOccurred())
+							step.modify(&toUpdate)
+							Expect(k8sClient.Update(ctx, &toUpdate)).ToNot(HaveOccurred())
+						}, vmv1beta1.UpdateStatusOperational)
 
 						var updated vmv1.VTSingle
 						Expect(k8sClient.Get(ctx, nsn, &updated)).ToNot(HaveOccurred())
@@ -274,11 +270,9 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status after creation")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→expanding→operational on spec update", func() {
@@ -295,30 +289,20 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("updating the spec to trigger reconcile")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.RetentionPeriod = "2"
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for expanding status")
-				Eventually(func() error {
-					return expectObjectStatusExpanding(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after update")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("updating the spec to trigger reconcile")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.RetentionPeriod = "2"
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusExpanding, vmv1beta1.UpdateStatusOperational)
 			})
 
 			It("should transition operational→paused when paused", func() {
@@ -335,25 +319,20 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for operational status before pause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 
-				By("pausing the VTSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = true
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for paused status")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualExpandingTimeout, func() {
+					By("pausing the VTSingle")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = true
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 			})
 
 			It("should transition paused→operational when unpaused", func() {
@@ -371,25 +350,20 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 						RetentionPeriod: "1",
 					},
 				}
-				Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
-				By("waiting for paused status after creation")
-				Eventually(func() error {
-					return expectObjectStatusPaused(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualExpandingTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualExpandingTimeout, func() {
+					Expect(k8sClient.Create(ctx, cr)).ToNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusPaused)
 
-				By("unpausing the VTSingle")
-				Eventually(func() error {
-					if err := k8sClient.Get(ctx, nsn, cr); err != nil {
-						return err
-					}
-					cr.Spec.Paused = false
-					return k8sClient.Update(ctx, cr)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
-
-				By("waiting for operational status after unpause")
-				Eventually(func() error {
-					return expectObjectStatusOperational(ctx, k8sClient, &vmv1.VTSingle{}, nsn)
-				}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				expectStatusAfterAction(ctx, &vmv1.VTSingleList{}, nsn, eventualDeploymentAppReadyTimeout, func() {
+					By("unpausing the VTSingle")
+					Eventually(func() error {
+						if err := k8sClient.Get(ctx, nsn, cr); err != nil {
+							return err
+						}
+						cr.Spec.Paused = false
+						return k8sClient.Update(ctx, cr)
+					}, eventualDeploymentAppReadyTimeout).WithContext(ctx).ShouldNot(HaveOccurred())
+				}, vmv1beta1.UpdateStatusOperational)
 			})
 		})
 	})

--- a/test/e2e/vtsingle_test.go
+++ b/test/e2e/vtsingle_test.go
@@ -38,7 +38,7 @@ var _ = Describe("test vtsingle Controller", Label("vt", "single", "vtsingle"), 
 					Namespace: nsn.Namespace,
 				},
 			})).ToNot(HaveOccurred())
-			waitResourceDeleted(ctx, k8sClient, nsn, &vmv1.VTSingle{})
+			waitResourceDeleted(ctx, nsn, &vmv1.VTSingleList{})
 		})
 		Context("crud", func() {
 			DescribeTable("should create",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the in-cluster Job used for HTTP validation in e2e tests. We now call services via the API server proxy and use watch-based status/deletion waits that fail fast on errors to reduce flakiness and speed up runs.

- **Refactors**
  - Dropped `batch/v1` Job + `curl`; HTTP checks now use `rest.HTTPClientFor` (10s timeout) via the API server proxy, auto-POSTing when a payload is provided.
  - Added `GetRestConfig` and plumbed `rest.Config` (`k8sCfg`) into tests.
  - Implemented `buildServiceProxyURL` to reach in-cluster services without Pods.
  - Replaced polling `Eventually` with watch-based waits and deletion helpers (`expectStatusAfterAction`, `WatchUntilStatusReached/Seen`, `waitResourceDeleted`/`waitObjectDeleted`) with generation guards; watchers/status checks now fail fast on `UpdateStatusFailed`; set default polling interval to 2s.

<sup>Written for commit ad2d5e7f0cad50b068152627a57a2b3e239d1e6a. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2174?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

