### PR TITLE
Docs/vmsingle API version not specified in example

### DIFF
--- a/docs/resources/vmsingle.md
+++ b/docs/resources/vmsingle.md
@@ -398,6 +398,7 @@ Advantages of using `VMBackupmanager` include:
 ## Examples
 
 ```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMSingle
 metadata:
   name: example


### PR DESCRIPTION
This adds the API version to the example CR for vmsingle.