### PR TITLE
vmalertmanager: remove prefix from empty subroute receiver

### DIFF
--- a/api/operator/v1beta1/vmalertmanagerconfig_types.go
+++ b/api/operator/v1beta1/vmalertmanagerconfig_types.go
@@ -222,7 +222,7 @@ func (r *VMAlertmanagerConfig) Validate() error {
 			return fmt.Errorf("notification config name %q is not unique", recv.Name)
 		}
 		receivers.Insert(recv.Name)
-		if err := validateReceiver(recv); err != nil {
+		if err := recv.validate(); err != nil {
 			return fmt.Errorf("receivers[%d]: %w", idx, err)
 		}
 	}
@@ -2147,96 +2147,96 @@ func validateTimeIntervalsEntry(ti *TimeIntervals) error {
 	return nil
 }
 
-func validateReceiver(recv Receiver) error {
-	if recv.Name == "" {
+func (r *Receiver) validate() error {
+	if r.Name == "" {
 		return fmt.Errorf("name field cannot be empty")
 	}
-	for i, c := range recv.EmailConfigs {
+	for i, c := range r.EmailConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("email_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.PagerDutyConfigs {
+	for i, c := range r.PagerDutyConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("pagerduty_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.PushoverConfigs {
+	for i, c := range r.PushoverConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("pushover_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.SlackConfigs {
+	for i, c := range r.SlackConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("slack_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.OpsGenieConfigs {
+	for i, c := range r.OpsGenieConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("opsgenie_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.WebhookConfigs {
+	for i, c := range r.WebhookConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("webhook_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.VictorOpsConfigs {
+	for i, c := range r.VictorOpsConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("victorops_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.WechatConfigs {
+	for i, c := range r.WechatConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("wechat_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.TelegramConfigs {
+	for i, c := range r.TelegramConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("telegram_configs[%d]: %w", i, err)
 		}
 	}
-	for i, c := range recv.MattermostConfigs {
+	for i, c := range r.MattermostConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("mattermost_configs[%d]: %w", i, err)
 		}
 	}
-	for idx, c := range recv.MSTeamsConfigs {
+	for idx, c := range r.MSTeamsConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("msteams_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.DiscordConfigs {
+	for idx, c := range r.DiscordConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("discord_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.SNSConfigs {
+	for idx, c := range r.SNSConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("sns_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.WebexConfigs {
+	for idx, c := range r.WebexConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("webex_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.JiraConfigs {
+	for idx, c := range r.JiraConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("jira_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.IncidentioConfigs {
+	for idx, c := range r.IncidentioConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("incidentio_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.RocketchatConfigs {
+	for idx, c := range r.RocketchatConfigs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("rocketchat_configs[%d]: %w", idx, err)
 		}
 	}
-	for idx, c := range recv.MSTeamsV2Configs {
+	for idx, c := range r.MSTeamsV2Configs {
 		if err := c.validate(); err != nil {
 			return fmt.Errorf("msteamsv2_configs[%d]: %w", idx, err)
 		}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmalertmanagerconfig](https://docs.victoriametrics.com/operator/resources/vmalertmanagerconfig/): Remove prefix from empty subroute receiver. See [#2185](https://github.com/VictoriaMetrics/operator/issues/2185).
+
 ## [v0.70.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 18 May 2026
 

--- a/internal/controller/operator/factory/vmalertmanager/config.go
+++ b/internal/controller/operator/factory/vmalertmanager/config.go
@@ -383,6 +383,9 @@ func buildInhibitRule(ns string, rule vmv1beta1.InhibitRule, mustAddNamespaceMat
 }
 
 func buildCRPrefixedName(cr *vmv1beta1.VMAlertmanagerConfig, name string) string {
+	if len(name) == 0 {
+		return name
+	}
 	return fmt.Sprintf("%s-%s-%s", cr.Namespace, cr.Name, name)
 }
 

--- a/internal/controller/operator/factory/vmalertmanager/config_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/config_test.go
@@ -1542,6 +1542,56 @@ receivers:
 templates: []
 `,
 	})
+
+	f(opts{
+		predefinedObjects: []runtime.Object{
+			&vmv1beta1.VMAlertmanagerConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "base",
+					Namespace: "default",
+				},
+				Spec: vmv1beta1.VMAlertmanagerConfigSpec{
+					Receivers: []vmv1beta1.Receiver{
+						{
+							Name: "blackhole",
+						},
+					},
+					Route: &vmv1beta1.Route{
+						Receiver: "blackhole",
+						RawRoutes: []apiextensionsv1.JSON{
+							mustRouteToJSON(t, vmv1beta1.SubRoute{
+								// No receiver defined; inherits from parent in alertmanager
+								Matchers: []string{`namespace=~"ns1|ns2"`},
+								RawRoutes: []apiextensionsv1.JSON{
+									mustRouteToJSON(t, vmv1beta1.SubRoute{
+										Matchers: []string{`team!~"team1"`},
+									}),
+								},
+							}),
+						},
+					},
+				},
+			},
+		},
+		want: `route:
+  receiver: blackhole
+  routes:
+  - routes:
+    - routes:
+      - matchers:
+        - team!~"team1"
+      matchers:
+      - namespace=~"ns1|ns2"
+    matchers:
+    - namespace = "default"
+    receiver: default-base-blackhole
+    continue: true
+receivers:
+- name: blackhole
+- name: default-base-blackhole
+templates: []
+`,
+	})
 }
 
 func TestAddConfigTemplates(t *testing.T) {


### PR DESCRIPTION
fixes #2185

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop prefixing empty subroute receiver names in Alertmanager config generation. This restores receiver inheritance and prevents invalid receiver names in nested routes.

- **Bug Fixes**
  - Skip CR prefixing when receiver name is empty in `buildCRPrefixedName` (fixes #2185).
  - Added tests for subroute inheritance and updated the changelog.

<sup>Written for commit 69df595b62bebd01dcc589dc8e96b6fc8c6011b3. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

