### PR TITLE
vmagent: preserve replica count in stateful mode with HPA enabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): skip replica count update, when VMAgent is in a stateful mode. See [#2190](https://github.com/VictoriaMetrics/operator/issues/2190).
+
 ## [v0.70.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 18 May 2026
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ aliases:
 
 ## tip
 
-* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): skip replica count update, when VMAgent is in a stateful mode. See [#2190](https://github.com/VictoriaMetrics/operator/issues/2190).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): skip replica count update when VMAgent is in stateful mode and HPA is enabled. See [#2190](https://github.com/VictoriaMetrics/operator/issues/2190).
 
 ## [v0.70.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 18 May 2026

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -310,6 +310,11 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 			o := reconcile.StatefulSetOpts{
 				SelectorLabels: selectorLabels,
 				UpdateBehavior: cr.Spec.StatefulRollingUpdateStrategyBehavior,
+				PatchSpec: func(existingSpec, newSpec *appsv1.StatefulSetSpec) {
+					if cr.Spec.HPA != nil {
+						newSpec.Replicas = existingSpec.Replicas
+					}
+				},
 			}
 			if err := reconcile.StatefulSet(ctx, rclient, newApp, prevApp, &owner, &o); err != nil {
 				rv.err = fmt.Errorf("cannot reconcile %T for vmagent(%d): %w", newApp, shardNum, err)

--- a/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
@@ -219,6 +219,53 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 		})
 }
 
+func TestCreateOrUpdate_StatefulSetWithHPA(t *testing.T) {
+	cr := &vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-vmagent",
+			Namespace: "default",
+		},
+		Spec: vmv1beta1.VMAgentSpec{
+			StatefulMode:                  true,
+			StatefulRollingUpdateStrategy: appsv1.RollingUpdateStatefulSetStrategyType,
+			RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{
+				{URL: "http://remote-write"},
+			},
+			CommonAppsParams: vmv1beta1.CommonAppsParams{
+				ReplicaCount: ptr.To(int32(1)),
+			},
+			HPA: &vmv1beta1.EmbeddedHPA{
+				MinReplicas: ptr.To(int32(1)),
+				MaxReplicas: 5,
+			},
+		},
+	}
+	stsNSN := types.NamespacedName{Namespace: cr.Namespace, Name: cr.PrefixedName()}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{cr})
+	ctx := context.TODO()
+	build.AddDefaults(fclient.Scheme())
+	fclient.Scheme().Default(cr)
+
+	// initial creation: StatefulSet created with 1 replica
+	assert.NoError(t, CreateOrUpdate(ctx, cr, fclient))
+
+	var sts appsv1.StatefulSet
+	assert.NoError(t, fclient.Get(ctx, stsNSN, &sts))
+	assert.Equal(t, int32(1), *sts.Spec.Replicas)
+
+	// simulate HPA scaling the StatefulSet to 3 replicas
+	sts.Spec.Replicas = ptr.To(int32(3))
+	assert.NoError(t, fclient.Update(ctx, &sts))
+
+	// reconcile with a different desired replica count in the spec
+	cr.Spec.ReplicaCount = ptr.To(int32(2))
+	assert.NoError(t, CreateOrUpdate(ctx, cr, fclient))
+
+	// HPA-managed replica count must not be overwritten
+	assert.NoError(t, fclient.Get(ctx, stsNSN, &sts))
+	assert.Equal(t, int32(3), *sts.Spec.Replicas)
+}
+
 func TestCreateOrUpdate_Paused(t *testing.T) {
 	cr := &vmv1beta1.VMAgent{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
fixes #2190

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `vmagent` from overwriting `StatefulSet` replica count in stateful mode when HPA is enabled, so HPA-driven scaling is preserved. Fixes #2190.

- **Bug Fixes**
  - In stateful mode with HPA, skip updating `.spec.replicas` during reconcile via `PatchSpec`.
  - Added a unit test to ensure HPA-selected replicas persist and a CHANGELOG entry.

<sup>Written for commit e33707646500183f4ad4d97811cdbece139348fc. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

