### PR TITLE
olm: add release-config.yaml

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -92,8 +92,11 @@ jobs:
             opm render ${OPERATOR_DIR}/${NEW_VERSION} --output=yaml \
               | yq 'select(.schema == "olm.bundle")' > /tmp/new-bundle.yaml
 
+            yq -n '.catalog_templates = []' > ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
             for TEMPLATE in ${OPERATOR_DIR}/catalog-templates/*.yaml; do
-              PREV_HEAD=$(yq '.entries[] | select(.schema == "olm.channel") | .entries[-1].name' "${TEMPLATE}")
+              export TPL=$(basename ${TEMPLATE})
+              export PREV_HEAD=$(yq '.entries[] | select(.schema == "olm.channel") | .entries[-1].name' "${TEMPLATE}")
+              yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": "beta", "replaces": strenv(PREV_HEAD)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
               NEW_VERSION="${NEW_VERSION}" PREV_HEAD="${PREV_HEAD}" \
                 yq -i '(.entries[] | select(.schema == "olm.channel") | .entries) += [{"name": "victoriametrics-operator.v" + strenv(NEW_VERSION), "replaces": strenv(PREV_HEAD)}]' "${TEMPLATE}"
               yq -i '.entries += [load("/tmp/new-bundle.yaml")]' "${TEMPLATE}"


### PR DESCRIPTION
new operator releases for openshift are not published due to absence of release-config.yaml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generation of `release-config.yaml` in the OperatorHub workflow so new OpenShift operator releases are published. Populates `catalog_templates` from existing templates and links the new version to the previous channel head.

- **Bug Fixes**
  - Initialize `${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml` with empty `catalog_templates`.
  - For each template in `${OPERATOR_DIR}/catalog-templates/*.yaml`, export `TPL=$(basename ...)` and `PREV_HEAD`, then append `{"template_name": TPL, "channels": "beta", "replaces": PREV_HEAD}` via `yq`.
  - Keep existing steps to render the new bundle with `opm` and update channel entries.

<sup>Written for commit 59292f1f0b8d3f376b5e37beb1646780ebcc59f6. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2195?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

