### PR TITLE
olm: fixed channel type in CI

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -96,7 +96,7 @@ jobs:
             for TEMPLATE in ${OPERATOR_DIR}/catalog-templates/*.yaml; do
               export TPL=$(basename ${TEMPLATE})
               export PREV_HEAD=$(yq '.entries[] | select(.schema == "olm.channel") | .entries[-1].name' "${TEMPLATE}")
-              yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": "beta", "replaces": strenv(PREV_HEAD)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
+              yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": ["beta"], "replaces": strenv(PREV_HEAD)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
               NEW_VERSION="${NEW_VERSION}" PREV_HEAD="${PREV_HEAD}" \
                 yq -i '(.entries[] | select(.schema == "olm.channel") | .entries) += [{"name": "victoriametrics-operator.v" + strenv(NEW_VERSION), "replaces": strenv(PREV_HEAD)}]' "${TEMPLATE}"
               yq -i '.entries += [load("/tmp/new-bundle.yaml")]' "${TEMPLATE}"


### PR DESCRIPTION
fixed channel type in release-config.yaml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OLM CI to use the correct channel type. Channels are now written as an array ["beta"] instead of a string in release-config.yaml to match the schema and avoid OperatorHub publish errors.

<sup>Written for commit 95354f05307e7d8ed6800c92f0b165e98dba9cfb. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

