### PR TITLE
ci: use digest instead of tag for image signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,8 @@ publish:
 
 COSIGN ?= $(shell which cosign 2>/dev/null || echo $(COSIGN_BIN))
 
+digest = $(shell $(CONTAINER_TOOL) buildx imagetools inspect $(REGISTRY)/$(ORG)/$(REPO):$(1) --format "{{print .Manifest.Digest}}")
+
 .PHONY: cosign
 cosign: $(COSIGN_BIN)
 $(COSIGN_BIN): $(LOCALBIN)
@@ -276,11 +278,11 @@ $(COSIGN_BIN): $(LOCALBIN)
 .PHONY: sign
 sign: $(COSIGN)
 	for registry in $(PUBLISH_REGISTRIES); do \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG) && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-ubi && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):$(TAG)-fips && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):config-reloader-$(TAG) && \
-		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO):config-reloader-$(TAG)-fips ; \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO)@$(call digest,$(TAG)) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO)@$(call digest,$(TAG)-ubi) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO)@$(call digest,$(TAG)-fips) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO)@$(call digest,config-reloader-$(TAG)) && \
+		$(COSIGN) sign --yes $${registry}/$(ORG)/$(REPO)@$(call digest,config-reloader-$(TAG)-fips) ; \
 	done
 
 .PHONY: build-installer


### PR DESCRIPTION
as tags are mutable, its better to use digests for signing and in future cosign will remove support for tag signing as seen in the build warnings: 

> WARNING: Image reference docker.io/victoriametrics/operator:v0.70.1 uses a tag, not a digest, to identify the image to sign.
    This can lead you to sign a different image than the intended one. Please use a
    digest (example.com/ubuntu@sha256:abc123...) rather than tag
    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
    images by tag will be removed in a future release.