### PR TITLE
docs: add link to prudctinization to quick start's next step

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -759,6 +759,8 @@ It distributes workloads across multiple storage pods, making it well-suited for
 If you're running at a larger scale, check out the [enterprise features](https://docs.victoriametrics.com/operator/enterprise/).
 These include multitenancy, downsampling, automated backups, advanced security and much more. All built for serious production use.
 
+When you're ready to move to production, the VictoriaMetrics [productionization guide](https://docs.victoriametrics.com/victoriametrics/quick-start/#productionization) covers key recommendations for capacity planning, security aspects, monitoring, and more.
+
 If you have any questions, check out our [FAQ](https://docs.victoriametrics.com/operator/faq/), or ask in one of our communities:
 - [VictoriaMetrics Slack](https://victoriametrics.slack.com/)
 - [VictoriaMetrics Telegram](https://t.me/VictoriaMetrics_en)


### PR DESCRIPTION
Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/10966 and https://github.com/VictoriaMetrics/VictoriaMetrics/issues/249#issuecomment-4468637250

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a link to the VictoriaMetrics productionization guide in Quick Start’s Next Steps to help users move to production. It points readers to capacity planning, security, monitoring, and other recommendations.

<sup>Written for commit 6142fbd33f7f9002c06b7a085e3049a67e109071. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

