### PR TITLE
add api package to release guide

### DIFF
--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -21,7 +21,9 @@ menu:
 1. Run `make docs` in order to update variables documentation files.
 1. Run `make build-installer` to build Github tag artefacts. Everything inside `/dist` should be included to the release.
 1. Cut new version in [CHANGELOG.md](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/CHANGELOG.md)
-1. create release tag with `git tag vX.X.X` command and push it to the origin - `git push origin vX.X.X`
+1. Create release tag with `git tag <tag>` command and push it to the origin - `git push origin <tag>`, where `<tag>`:
+   * `vX.Y.Z` - for operator
+   * `api/vX.Y.Z` - for operator's api package
 1. Go to github [Releases Page](https://github.com/VictoriaMetrics/operator/releases) and `Draft new Release` with the name of pushed tag.
 1. Update the release description with the content of [CHANGELOG](https://github.com/VictoriaMetrics/operator/blob/master/docs/CHANGELOG.md) for this release.
 


### PR DESCRIPTION
related to https://github.com/VictoriaMetrics/operator/issues/2205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified release tagging in the guide and added instructions for publishing the operator’s `api` package. Use `git tag <tag>` and `git push origin <tag>`, where `<tag>` is `vX.Y.Z` for the operator or `api/vX.Y.Z` for the `api` package.

<sup>Written for commit c440e5db449207db421242694de9cc1b02b79d4d. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

