### PR TITLE
reconcile: update statefulset status on success for OnDelete update strategy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ aliases:
 
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): support enableServiceLinks property in all CRs. See [#2194](https://github.com/VictoriaMetrics/operator/pull/2194).
 
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): update status currentRevision and currentReplicas for StatefulSet with OnDelete update strategy. See [#1242](https://github.com/VictoriaMetrics/operator/issues/1242).
+
 ## [v0.70.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 20 May 2026
 

--- a/internal/controller/operator/factory/reconcile/statefulset.go
+++ b/internal/controller/operator/factory/reconcile/statefulset.go
@@ -212,13 +212,32 @@ type rollingUpdateOpts struct {
 	delete         bool
 }
 
+// patchSTSCurrentRevision patches statefulset status.currentRevision to match status.updateRevision
+// after all pods are updated. This is needed because Kubernetes does not update currentRevision
+// for OnDelete strategy, leaving stale data visible to monitoring tools.
+// See https://github.com/VictoriaMetrics/operator/issues/1242
+func patchSTSCurrentRevision(ctx context.Context, rclient client.Client, nsn types.NamespacedName, updateRevision string, replicas int32) error {
+	var sts appsv1.StatefulSet
+	if err := rclient.Get(ctx, nsn, &sts); err != nil {
+		return fmt.Errorf("cannot get statefulset for status update: %w", err)
+	}
+	if sts.Status.CurrentRevision == updateRevision {
+		return nil
+	}
+	logger.WithContext(ctx).Info(fmt.Sprintf("updating statefulset=%s/%s status currentRevision from %q to %q", nsn.Namespace, nsn.Name, sts.Status.CurrentRevision, updateRevision))
+	sts.Status.CurrentRevision = updateRevision
+	// currentReplicas is not updated with OnDelete strategy too
+	sts.Status.CurrentReplicas = replicas
+	if err := rclient.Status().Update(ctx, &sts); err != nil {
+		return fmt.Errorf("cannot update statefulset=%s/%s currentRevision status: %w", nsn.Namespace, nsn.Name, err)
+	}
+	return nil
+}
+
 // we perform rolling update on sts by manually evicting pods one by one or in batches
 // we check sts revision (kubernetes controller-manager is responsible for that)
 // and compare pods revision label with sts revision
 // if it doesn't match - updated is needed
-//
-// we always check if sts.Status.CurrentRevision needs update, to keep it equal to UpdateRevision
-// see https://github.com/kubernetes/kube-state-metrics/issues/1324#issuecomment-1779751992
 func performRollingUpdateOnSts(ctx context.Context, rclient client.Client, obj *appsv1.StatefulSet, o rollingUpdateOpts) error {
 	time.Sleep(podWaitReadyInterval)
 	nsn := types.NamespacedName{
@@ -278,10 +297,10 @@ func performRollingUpdateOnSts(ctx context.Context, rclient client.Client, obj *
 		return fmt.Errorf("actual pod count: %d less than needed: %d, possible statefulset misconfiguration", totalPodsCount, neededPodCount)
 	}
 
-	updatedNeeded := len(podsForUpdate) != 0 || len(updatedPods) != 0
-	if !updatedNeeded {
+	updateNeeded := len(podsForUpdate) != 0 || len(updatedPods) != 0
+	if !updateNeeded {
 		l.V(1).Info("no pod needs to be updated")
-		return nil
+		return patchSTSCurrentRevision(ctx, rclient, nsn, stsVersion, int32(neededPodCount))
 	}
 
 	l.Info(fmt.Sprintf("discovered already updated pods=%d, pods needed to be update=%d", len(updatedPods), len(podsForUpdate)))
@@ -355,7 +374,7 @@ func performRollingUpdateOnSts(ctx context.Context, rclient client.Client, obj *
 
 	l.Info(fmt.Sprintf("finished statefulset update from revision=%q to revision=%q", sts.Status.CurrentRevision, stsVersion))
 
-	return nil
+	return patchSTSCurrentRevision(ctx, rclient, nsn, stsVersion, int32(neededPodCount))
 }
 
 // PodIsReady check is pod is ready

--- a/internal/controller/operator/factory/vmalertmanager/vmalertmanager_reconcile_test.go
+++ b/internal/controller/operator/factory/vmalertmanager/vmalertmanager_reconcile_test.go
@@ -162,7 +162,8 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 				{Verb: "Get", Kind: "Service", Resource: vmalertmanagerName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmalertmanagerName},
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName},
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName}, // patchSTSCurrentRevision
 			},
 		})
 
@@ -192,7 +193,8 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 				{Verb: "Get", Kind: "Service", Resource: vmalertmanagerName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmalertmanagerName},
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName},
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmalertmanagerName}, // patchSTSCurrentRevision
 			},
 		})
 }

--- a/internal/controller/operator/factory/vmanomaly/vmanomaly_reconcile_test.go
+++ b/internal/controller/operator/factory/vmanomaly/vmanomaly_reconcile_test.go
@@ -205,7 +205,8 @@ schedulers:
 				// StatefulSet
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName},
 				{Verb: "Update", Kind: "StatefulSet", Resource: vmanomalyName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName},
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName}, // patchSTSCurrentRevision
 			},
 		})
 
@@ -255,7 +256,8 @@ schedulers:
 				{Verb: "Get", Kind: "Secret", Resource: vmanomalyName},
 				// StatefulSet
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName},
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmanomalyName}, // patchSTSCurrentRevision
 			},
 		})
 }

--- a/internal/controller/operator/factory/vmcluster/vmcluster_reconcile_test.go
+++ b/internal/controller/operator/factory/vmcluster/vmcluster_reconcile_test.go
@@ -198,13 +198,15 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 
 				// VMStorage
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // wait for ready
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // patchSTSCurrentRevision
 				{Verb: "Get", Kind: "Service", Resource: vmstorageName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmstorageName},
 
 				// VMSelect
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // wait for ready
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // patchSTSCurrentRevision
 				{Verb: "Get", Kind: "Service", Resource: vmselectName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmselectName},
 
@@ -232,13 +234,15 @@ func Test_CreateOrUpdate_Actions(t *testing.T) {
 
 				// VMStorage
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // wait for ready
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmstorageName}, // patchSTSCurrentRevision
 				{Verb: "Get", Kind: "Service", Resource: vmstorageName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmstorageName},
 
 				// VMSelect
 				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName},
-				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // wait for ready
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // getLatestStsState
+				{Verb: "Get", Kind: "StatefulSet", Resource: vmselectName}, // patchSTSCurrentRevision
 				{Verb: "Get", Kind: "Service", Resource: vmselectName},
 				{Verb: "Get", Kind: "VMServiceScrape", Resource: vmselectName},
 

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -60,6 +60,7 @@ func (r *VLAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runti
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create,update;list
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vlagent", req.Name, "namespace", req.Namespace)
 	ctx = logger.AddToContext(ctx, l)

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -79,6 +79,7 @@ func (r *VMAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runti
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create,update;list
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=*
 func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmagent", req.Name, "namespace", req.Namespace)

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -67,6 +67,7 @@ func (r *VMAlertmanagerReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmalertmanagers/finalizers,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=*
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=*
 func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -63,6 +63,7 @@ func (r *VMAnomalyReconciler) Init(rclient client.Client, l logr.Logger, sc *run
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmanomalies/finalizers,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create,update;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=*
 // +kubebuilder:rbac:groups="",resources=pods,verbs=*

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -44,6 +44,7 @@ func (r *VMClusterReconciler) Scheme() *runtime.Scheme {
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.victoriametrics.com,resources=vmclusters/finalizers,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=*
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Request) (result ctrl.Result, err error) {
 	l := r.Log.WithValues("vmcluster", request.Name, "namespace", request.Namespace)
 	ctx = logger.AddToContext(ctx, l)


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/1242

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update StatefulSet status for OnDelete strategy by patching status.currentRevision to match status.updateRevision and syncing status.currentReplicas after pods converge or when no updates are needed. Prevents stale status in monitoring and fixes #1242.

- **Bug Fixes**
  - Patch StatefulSet status after rollout completes and when no update is needed.
  - Set status.currentRevision and status.currentReplicas to reflect the actual state.
  - Add RBAC to get/update/patch apps/statefulsets/status for vlagent, vmagent, vmalertmanager, vmanomaly, and vmcluster; update changelog.

<sup>Written for commit 60f4e06faf587d1eacb3e5ed7531e44df3849939. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

