### PR TITLE
internal/config: update VM_METRICS_VERSION to v1.144.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ aliases:
 
 ## tip
 
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VM apps to [v1.144.0](https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/v1.144.0) version
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): added `VM_COMMON_LABELS` and `VM_COMMON_ANNOTATIONS` environment variables to apply common labels/annotations to all Kubernetes resources managed by the operator. These cannot override labels/annotations already set by the operator or via `spec.managedMetadata`. This also ensures HTTPRoutes and PVCs include ManagedMetadata labels and annotations
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): support enableServiceLinks property in all CRs. See [#2194](https://github.com/VictoriaMetrics/operator/pull/2194).
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,6 +1,6 @@
 | Environment variables |
 | --- |
-| VM_METRICS_VERSION: `v1.143.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
+| VM_METRICS_VERSION: `v1.144.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a> |
 | VM_LOGS_VERSION: `v1.50.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a> |
 | VM_ANOMALY_VERSION: `v1.29.3` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a> |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a> |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ var (
 	initConf sync.Once
 
 	defaultEnvs = map[string]string{
-		"VM_METRICS_VERSION":  "v1.143.0",
+		"VM_METRICS_VERSION":  "v1.144.0",
 		"VM_LOGS_VERSION":     "v1.50.0",
 		"VM_ANOMALY_VERSION":  "v1.29.3",
 		"VM_TRACES_VERSION":   "v0.7.0",


### PR DESCRIPTION
Changelog [v1.144.0](https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/docs/victoriametrics/changelog/CHANGELOG.md#v11440)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update default `VM_METRICS_VERSION` to `v1.144.0` across config and docs to align operator defaults with the VictoriaMetrics v1.144.0 release.

<sup>Written for commit dd75b09c6ee3f9a73092d7bc5c98b724c830c570. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

