### PR TITLE
operatorhub: updated source branch for channel

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -15,8 +15,6 @@ jobs:
   update:
     name: Publish new OperatorHub release
     runs-on: ubuntu-latest
-    env:
-      CHANNEL: ${{ startsWith(github.event.workflow_run.head_branch, 'release') && 'stable' || 'beta' }}
     if: ${{ (github.event.workflow_run.conclusion == 'success' && ! contains(github.event.workflow_run.head_branch, '-')) || github.event_name == 'workflow_dispatch' && github.event.workflow_run.release != 'prereleased' }}
     strategy:
       matrix:
@@ -60,6 +58,11 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           path: bundle
 
+      - name: Set channel
+        run: |
+          echo "CHANNEL=$(cat bundle/CHANNEL 2>/dev/null || echo beta)" >> $GITHUB_ENV
+          rm -f bundle/CHANNEL
+
       - name: Add operatorhub bundle
         id: update
         run: |
@@ -79,10 +82,17 @@ jobs:
             } | sort -V | grep -B1 "^${NEW_VERSION}$" | grep -v "^${NEW_VERSION}$"
           )
           export OLD_ENTRY="${OPERATOR_NAME}.v${OLD_VERSION}"
+          export MANIFEST_PATH=bundle/${NEW_VERSION}/manifests/victoriametrics-operator.clusterserviceversion.yaml
 
           if [ ! -z $OLD_VERSION ]; then
-            export MANIFEST_PATH=bundle/${NEW_VERSION}/manifests/victoriametrics-operator.clusterserviceversion.yaml
             yq -i '.spec.replaces = "victoriametrics-operator.v" + strenv(OLD_VERSION)' $MANIFEST_PATH
+          fi
+
+          if [ ! -z $MANIFEST_PATH ]; then
+            yq -i '.metadata["operators.operatorframework.io.bundle.channel.default.v1"] = strenv(CHANNEL)' $MANIFEST_PATH
+            yq -i '.metadata["operators.operatorframework.io.bundle.channels.v1"] = strenv(CHANNEL)' $MANIFEST_PATH
+            yq -i '.annotations["operators.operatorframework.io.bundle.channel.default.v1"] = strenv(CHANNEL)' bundle/${NEW_VERSION}/metadata/annotations.yaml
+            yq -i '.annotations["operators.operatorframework.io.bundle.channels.v1"] = strenv(CHANNEL)' bundle/${NEW_VERSION}/metadata/annotations.yaml
           fi
 
           mv bundle/${NEW_VERSION} ${OPERATOR_DIR}/
@@ -91,7 +101,7 @@ jobs:
             for TEMPLATE in ${OPERATOR_DIR}/catalog-templates/*.yaml; do
               export TPL=$(basename ${TEMPLATE})
               if [ "$CHANNEL" = "stable" ] && ! yq -e '.entries[] | select(.schema == "olm.channel" and .name == "stable")' "$TEMPLATE" > /dev/null 2>&1 && [ -n "$OLD_VERSION" ]; then
-                yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": ["stable","beta"], "replaces": strenv(OLD_ENTRY)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
+                yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": ["stable"], "replaces": strenv(OLD_ENTRY)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
               elif [ -n "$OLD_VERSION" ]; then
                 yq -i '.catalog_templates += [{"template_name": strenv(TPL), "channels": [strenv(CHANNEL)], "replaces": strenv(OLD_ENTRY)}]' ${OPERATOR_DIR}/${NEW_VERSION}/release-config.yaml
               else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,11 @@ jobs:
           TAG=${TAG} make publish
           TAG=${TAG} make sign
           TAG=${TAG} REGISTRY=quay.io make olm
+          if [[ "${{ github.event.release.target_commitish }}" == release-* ]]; then
+            echo "stable" > bundle/CHANNEL
+          else
+            echo "beta" > bundle/CHANNEL
+          fi
           gh release upload ${{github.event.release.tag_name}} ./dist/install-no-webhook.yaml#install-no-webhook.yaml --clobber || echo "fix me NOT enough security permissions"
           gh release upload ${{github.event.release.tag_name}} ./dist/install-with-webhook.yaml#install-with-webhook.yaml --clobber || echo "fix me NOT enough security permissions"
           gh release upload ${{github.event.release.tag_name}} ./config/crd/overlay/crd.yaml#crd.yaml --clobber || echo "fix me NOT enough security permissions"


### PR DESCRIPTION
in release 0.68.5 channel wasn't set correctly since it used tag as a source, which is not correct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OperatorHub channel selection by deriving it from the release target branch, not the tag. Bundles now publish to the correct channel.

- **Bug Fixes**
  - In `release.yaml`, write `bundle/CHANNEL` as "stable" when `target_commitish` starts with `release-`, else "beta".
  - In `operatorhub.yaml`, read `bundle/CHANNEL` (default "beta"), set both CSV and bundle metadata channel annotations to `CHANNEL`, generate catalog templates with only "stable" when `CHANNEL=stable`, and remove the old head-branch logic and the file.

<sup>Written for commit a3e9e858059a10ad7770d3aa1568f63de1fdcdb6. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

