### PR TITLE
.github: enforce least permissions for github action jobs

### DIFF
--- a/.github/workflows/close-pr.yaml
+++ b/.github/workflows/close-pr.yaml
@@ -1,8 +1,5 @@
 name: Close PR
 
-permissions:
-  pull-requests: write
-
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +15,8 @@ on:
         description: PR number to close
         required: true
         type: string
+
+permissions: {}
 
 jobs:
   update:

--- a/.github/workflows/crds.yaml
+++ b/.github/workflows/crds.yaml
@@ -1,12 +1,10 @@
 name: Update CRDs for chart repo
 
-permissions:
-  contents: read
-  pull-requests: write
-
 on:
   release:
     types: [published]
+
+permissions: {}
 
 jobs:
   update-crds:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,8 +9,7 @@ on:
       - 'README.md'
       - '.github/workflows/docs.yaml'
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   update-docs:
@@ -22,6 +21,7 @@ jobs:
       - name: Checkout operator repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          token: ${{ secrets.VM_BOT_GH_TOKEN }}
           path: __vm-operator
 
       - name: Checkout docs repo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -1,15 +1,13 @@
 name: Publish OperatorHub release
 
-permissions:
-  contents: read
-  pull-requests: write
-
 on:
   workflow_run:
     workflows:
       - Release
     types:
       - completed
+
+permissions: {}
 
 jobs:
   update:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
     types:
       - created
       - prereleased
+
+permissions: {}
+
 jobs:
   release:
     name: Release on GitHub

--- a/.github/workflows/sandbox.yaml
+++ b/.github/workflows/sandbox.yaml
@@ -15,9 +15,7 @@ on:
         default: master
         type: string
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   update:
@@ -29,6 +27,7 @@ jobs:
         with:
           repository: VictoriaMetrics/operator
           ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.VM_BOT_GH_TOKEN }}
 
       - name: Publish image
         id: publish

--- a/.github/workflows/upgrade-tests.yaml
+++ b/.github/workflows/upgrade-tests.yaml
@@ -1,14 +1,13 @@
 name: Upgrade Tests
 on:
   workflow_dispatch:
+permissions: {}
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
-      security-events: write
       checks: write
     steps:
       - name: Free space


### PR DESCRIPTION
Scope permissions to job level and set `permissions: {}` at workflow level.