### PR TITLE
Docs: Fix a few broken links and duplicate headers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -799,7 +799,7 @@ Operator will preserve `annotations`, but any changes to it will be ignored. `la
 ![AppVersion: v1.102.0](https://img.shields.io/badge/v1.102.0-success?label=Default%20VM%20version&logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictoriametrics%2Fchangelog%2F%23v11020)
 ![AppVersion: v0.28.0](https://img.shields.io/badge/v0.28.0-success?label=Default%20VL%20version&logo=VictoriaMetrics&labelColor=gray&link=https%3A%2F%2Fdocs.victoriametrics.com%2Fvictorialogs%2Fchangelog%2F%23v0280)
 
-**It is recommended upgrading to [operator v0.47.2](https://docs.victoriametrics.com/operator/changelog/#v0471---23-aug-2024) because v0.47.1 contains a bug, which can lead to endless statefulset reconcile loop.**
+**It is recommended upgrading to [operator v0.47.2](https://docs.victoriametrics.com/operator/changelog/#v0472) because v0.47.1 contains a bug, which can lead to endless statefulset reconcile loop.**
 
 - [operator](https://docs.victoriametrics.com/operator/): properly update statefulset on `revisionHistoryLimitCount` change. See this [issue](https://github.com/VictoriaMetrics/operator/issues/1070) for details.
 - [vmalertmanagerconfig](https://docs.victoriametrics.com/operator/resources/vmalertmanagerconfig/): properly construct `tls_config` for `emails` notifications. See this [issue](https://github.com/VictoriaMetrics/operator/issues/1080) for details.
@@ -996,7 +996,7 @@ Operator will preserve `annotations`, but any changes to it will be ignored. `la
 - scrape CRDs: fix scrape_config filed `disable_keep_alive`, before it's misconfigured as `disable_keepalive` and won't work.
 - scrape CRDs: deprecated option `relabel_debug` and  `metric_relabel_debug`, they were deprecated since [v1.85.0](https://docs.victoriametrics.com/victoriametrics/changelog/#v1.85.0).
 
-## [v0.43.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.42.3)
+## [v0.42.3](https://github.com/VictoriaMetrics/operator/releases/tag/v0.42.3)
 
 **Release date:** 12 Mar 2024
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1868,8 +1868,8 @@ Appears in: [VLInsert](#vlinsert), [VLSelect](#vlselect), [VLStorage](#vlstorage
 | Field | Description |
 | --- | --- |
 | recommenders<a href="#embeddedvpa-recommenders" id="embeddedvpa-recommenders">#</a><br/>_VerticalPodAutoscalerRecommenderSelector array_ | _(Optional)_<br/>Recommenders specifies custom VPA recommender names. |
-| resourcePolicy<a href="#embeddedvpa-resourcepolicy" id="embeddedvpa-resourcepolicy">#</a><br/>_[PodResourcePolicy](#podresourcepolicy)_ | _(Required)_<br/>ResourcePolicy controls how the autoscaler computes recommended resources per container. |
-| updatePolicy<a href="#embeddedvpa-updatepolicy" id="embeddedvpa-updatepolicy">#</a><br/>_[PodUpdatePolicy](#podupdatepolicy)_ | _(Required)_<br/>UpdatePolicy controls how the autoscaler applies changes to pod resources. |
+| resourcePolicy<a href="#embeddedvpa-resourcepolicy" id="embeddedvpa-resourcepolicy">#</a><br/>_[PodResourcePolicy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#podresourcepolicy)_ | _(Required)_<br/>ResourcePolicy controls how the autoscaler computes recommended resources per container. |
+| updatePolicy<a href="#embeddedvpa-updatepolicy" id="embeddedvpa-updatepolicy">#</a><br/>_[PodUpdatePolicy](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#podupdatepolicy)_ | _(Required)_<br/>UpdatePolicy controls how the autoscaler applies changes to pod resources. |
 
 #### Endpoint
 
@@ -2866,7 +2866,7 @@ Appears in: [VMRuleSpec](#vmrulespec)
 | limit<a href="#rulegroup-limit" id="rulegroup-limit">#</a><br/>_integer_ | _(Optional)_<br/>Limit the number of alerts an alerting rule and series a recording<br />rule can produce |
 | name<a href="#rulegroup-name" id="rulegroup-name">#</a><br/>_string_ | _(Required)_<br/>Name of group |
 | notifier_headers<a href="#rulegroup-notifier_headers" id="rulegroup-notifier_headers">#</a><br/>_string array_ | _(Optional)_<br/>NotifierHeaders contains optional HTTP headers added to each alert request which will send to notifier<br />Must be in form `header-name: value`<br />For example:<br /> headers:<br />   - "CustomHeader: foo"<br />   - "CustomHeader2: bar" |
-| params<a href="#rulegroup-params" id="rulegroup-params">#</a><br/>_[Values](#values)_ | _(Optional)_<br/>Params optional HTTP URL parameters added to each rule request |
+| params<a href="#rulegroup-params" id="rulegroup-params">#</a><br/>_[Values](https://pkg.go.dev/net/url#Values)_ | _(Optional)_<br/>Params optional HTTP URL parameters added to each rule request |
 | rules<a href="#rulegroup-rules" id="rulegroup-rules">#</a><br/>_[Rule](#rule) array_ | _(Required)_<br/>Rules list of alert rules |
 | tenant<a href="#rulegroup-tenant" id="rulegroup-tenant">#</a><br/>_string_ | _(Optional)_<br/>Tenant id for group, can be used only with enterprise version of vmalert.<br />See more details [here](https://docs.victoriametrics.com/victoriametrics/vmalert/#multitenancy). |
 | type<a href="#rulegroup-type" id="rulegroup-type">#</a><br/>_string_ | _(Optional)_<br/>Type defines datasource type for enterprise version of vmalert<br />possible values - prometheus,graphite,vlogs |

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,5 +1,15 @@
 render:
   kubernetesVersion: '1.35'
+  knownTypes:
+    - name: PodResourcePolicy
+      package: k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1
+      link: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#podresourcepolicy
+    - name: PodUpdatePolicy
+      package: k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1
+      link: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/api.md#podupdatepolicy
+    - name: Values
+      package: net/url
+      link: https://pkg.go.dev/net/url#Values
 
 processor:
   ignoreTypes:

--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -58,9 +58,9 @@ Field `extraArgs` is supported for the following custom resources:
 
 Supported flags for each application can be found the in the corresponding documentation:
 
-- [VMAgent](https://docs.victoriametrics.com/operator/resources/vmagent/#advanced-usage)
-- [VMAlert](https://docs.victoriametrics.com/operator/resources/vmalert/#configuration)
-- [VMAuth](https://docs.victoriametrics.com/operator/resources/vmauth/#advanced-usage)
+- [VMAgent](https://docs.victoriametrics.com/victoriametrics/vmagent/#advanced-usage)
+- [VMAlert](https://docs.victoriametrics.com/victoriametrics/vmalert/#configuration)
+- [VMAuth](https://docs.victoriametrics.com/victoriametrics/vmauth/#advanced-usage)
 - [VMCluster](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#list-of-command-line-flags)
 - [VMSingle](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#list-of-command-line-flags)
 - [VLAgent](https://docs.victoriametrics.com/victorialogs/vlagent/#advanced-usage)

--- a/docs/resources/vmagent.md
+++ b/docs/resources/vmagent.md
@@ -41,7 +41,7 @@ so user can set custom configuration while still benefiting from the Operator's 
 You can see the full actual specification of the `VMAgent` resource in the **[API docs -> VMAgent](https://docs.victoriametrics.com/operator/api/#vmagent)**.
 
 If you can't find necessary field in the specification of the custom resource,
-see [Extra arguments section](https://docs.victoriametrics.com/operator/resources/vmagent/#extra-arguments).
+see [Extra arguments section](https://docs.victoriametrics.com/operator/resources/#extra-arguments).
 
 Also, you can check out the [examples](https://docs.victoriametrics.com/operator/resources/vmagent/#examples) section.
 


### PR DESCRIPTION
Found a few broken links in the docs. There was a duplicated header in the changelog.

There are 4 still broken anchors in `docs/api.md`, but I can't seem to find where they should point to. Maybe the section was removed from the API? Any ideas are welcome!

| Anchor | Referenced At (line) | Context | Should Point To | Root Cause? |
|---|---|---|---|---|
| `#podresourcepolicy` | 1871 | Field `resourcePolicy` in `#### EmbeddedVPA` — `_[PodResourcePolicy](#podresourcepolicy)_` | `#### PodResourcePolicy` | External `vpav1.PodResourcePolicy` type — doc generator doesn't render headings for external types |
| `#podupdatepolicy` | 1872 | Field `updatePolicy` in `#### EmbeddedVPA` — `_[PodUpdatePolicy](#podupdatepolicy)_` | `#### PodUpdatePolicy` | External `vpav1.PodUpdatePolicy` type — doc generator doesn't render headings for external types |
| `#subroute` | 2818 | "Appears in" line of `#### Route` — `[SubRoute](#subroute)` | `#### SubRoute` | Type alias `type SubRoute Route` — doc generator doesn't render it despite template support for aliases |
| `#values` | 2869 | Field `params` in `#### RuleGroup` — `_[Values](#values)_` | `#### Values` | Go stdlib `url.Values` type — doc generator doesn't render headings for stdlib types |


This is linked to: https://github.com/VictoriaMetrics/vmdocs/issues/221