### PR TITLE
config-reloader: fix success timestamp metric units

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -264,7 +264,7 @@ func (c *cfgWatcher) start(ctx context.Context) {
 				continue
 			}
 			configLastReloadSuccess.Set(1)
-			configLastOkReloadTime.Set(uint64(time.Now().UnixMilli()))
+			configLastOkReloadTime.Set(uint64(time.Now().Unix()))
 			logger.Infof("reload config ok.")
 		}
 	}()

--- a/cmd/config-reloader/main_test.go
+++ b/cmd/config-reloader/main_test.go
@@ -183,3 +183,39 @@ func TestCfgWatcherDelayIntervalCancelledContext(t *testing.T) {
 		t.Fatalf("expected 0 reload calls after context cancel, got %d", got)
 	}
 }
+
+func TestCfgWatcherSuccessTimestampUsesSeconds(t *testing.T) {
+	origDelay := *delayInterval
+	*delayInterval = 0
+	defer func() { *delayInterval = origDelay }()
+
+	configLastOkReloadTime.Set(0)
+	configLastReloadSuccess.Set(0)
+
+	updates := make(chan struct{}, 1)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.start(ctx)
+	start := time.Now().Unix()
+
+	updates <- struct{}{}
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	w.close()
+
+	got := int64(configLastOkReloadTime.Get())
+	end := time.Now().Unix()
+
+	if got < start || got > end {
+		t.Fatalf("expected success timestamp in unix seconds between %d and %d, got %d", start, end, got)
+	}
+	if configLastReloadSuccess.Get() != 1 {
+		t.Fatalf("expected reload success metric to be 1, got %d", configLastReloadSuccess.Get())
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): support enableServiceLinks property in all CRs. See [#2194](https://github.com/VictoriaMetrics/operator/pull/2194).
 
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): update status currentRevision and currentReplicas for StatefulSet with OnDelete update strategy. See [#1242](https://github.com/VictoriaMetrics/operator/issues/1242).
+* BUGFIX: [config-reloader](https://docs.victoriametrics.com/operator/): fix `configreloader_last_reload_success_timestamp_seconds` metric to report time in seconds instead of milliseconds.
 
 ## [v0.70.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 20 May 2026


### PR DESCRIPTION
Fixes `configreloader_last_reload_success_timestamp_seconds`.

The metric name says seconds, but the reloader was writing `time.Now().UnixMilli()`.
So after any successful reload the exported value is 1000x too big. Kinda busted for dashboards and alerts.

Repro:
1. On `master`, run `go test ./cmd/config-reloader -run TestCfgWatcherSuccessTimestampUsesSeconds -count=1`
2. It fails with a value like `1780068551994`
3. This patch switches to `time.Now().Unix()` and adds the test, so it passes

Related: #916