### PR TITLE
vmagent: fixed target reference for HPA

### DIFF
--- a/api/operator/v1/vmanomaly_types.go
+++ b/api/operator/v1/vmanomaly_types.go
@@ -316,11 +316,7 @@ func (cr *VMAnomaly) GetStatus() *VMAnomalyStatus {
 
 // DefaultStatusFields implements reconcile.ObjectWithDeepCopyAndStatus interface
 func (cr *VMAnomaly) DefaultStatusFields(vs *VMAnomalyStatus) {
-	var shardCnt int32
-	if cr.IsSharded() {
-		shardCnt = *cr.Spec.ShardCount
-	}
-	vs.Shards = shardCnt
+	vs.Shards = cr.GetShardCount()
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface

--- a/api/operator/v1/vmanomaly_types_test.go
+++ b/api/operator/v1/vmanomaly_types_test.go
@@ -1,0 +1,26 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestVMAnomaly_DefaultStatusFields(t *testing.T) {
+	f := func(cr *VMAnomaly, wantShards int32) {
+		t.Helper()
+		var status VMAnomalyStatus
+		cr.DefaultStatusFields(&status)
+		assert.Equal(t, wantShards, status.Shards)
+	}
+
+	// no shardCount set: must report 1 so VPA scale subresource gets a non-zero statusReplicasPath
+	f(&VMAnomaly{Spec: VMAnomalySpec{}}, 1)
+
+	// shardCount explicitly set
+	f(&VMAnomaly{Spec: VMAnomalySpec{ShardCount: ptr.To(int32(3))}}, 3)
+
+	// shardCount=1 explicitly
+	f(&VMAnomaly{Spec: VMAnomalySpec{ShardCount: ptr.To(int32(1))}}, 1)
+}

--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -488,12 +488,8 @@ func (cr *VMAgent) DefaultStatusFields(vs *VMAgentStatus) {
 	if cr.Spec.ReplicaCount != nil {
 		replicaCount = *cr.Spec.ReplicaCount
 	}
-	var shardCnt int32
-	if cr.IsSharded() {
-		shardCnt = *cr.Spec.ShardCount
-	}
 	vs.Replicas = replicaCount
-	vs.Shards = shardCnt
+	vs.Shards = cr.GetShardCount()
 	vs.Selector = labels.SelectorFromSet(cr.SelectorLabels()).String()
 }
 

--- a/api/operator/v1beta1/vmagent_types_test.go
+++ b/api/operator/v1beta1/vmagent_types_test.go
@@ -126,3 +126,28 @@ func TestVMAgent_Validate(t *testing.T) {
 		},
 	}, true)
 }
+
+func TestVMAgent_DefaultStatusFields(t *testing.T) {
+	f := func(cr *VMAgent, wantShards, wantReplicas int32) {
+		t.Helper()
+		var status VMAgentStatus
+		cr.DefaultStatusFields(&status)
+		assert.Equal(t, wantShards, status.Shards, "shards")
+		assert.Equal(t, wantReplicas, status.Replicas, "replicas")
+	}
+
+	// no shardCount set: must report 1 so VPA scale subresource gets a non-zero statusReplicasPath
+	f(&VMAgent{Spec: VMAgentSpec{}}, 1, 0)
+
+	// shardCount explicitly set
+	f(&VMAgent{Spec: VMAgentSpec{ShardCount: ptr.To(int32(3))}}, 3, 0)
+
+	// shardCount=1 explicitly
+	f(&VMAgent{Spec: VMAgentSpec{ShardCount: ptr.To(int32(1))}}, 1, 0)
+
+	// daemonset mode disables sharding, should still report 1
+	f(&VMAgent{Spec: VMAgentSpec{ShardCount: ptr.To(int32(3)), DaemonSetMode: true}}, 1, 0)
+
+	// replicaCount is tracked independently
+	f(&VMAgent{Spec: VMAgentSpec{CommonAppsParams: CommonAppsParams{ReplicaCount: ptr.To(int32(2))}}}, 1, 2)
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ aliases:
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): added `VM_COMMON_LABELS` and `VM_COMMON_ANNOTATIONS` environment variables to apply common labels/annotations to all Kubernetes resources managed by the operator. These cannot override labels/annotations already set by the operator or via `spec.managedMetadata`. This also ensures HTTPRoutes and PVCs include ManagedMetadata labels and annotations
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): support enableServiceLinks property in all CRs. See [#2194](https://github.com/VictoriaMetrics/operator/pull/2194).
 
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fix VPA scale subresource lookup failure when `spec.shardCount` is unset by always reporting at least 1 in `status.shards`. See [#2229](https://github.com/VictoriaMetrics/operator/issues/2229).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): fix HPA targeting the underlying Deployment/StatefulSet (pod replicas) instead of the VMAgent CR scale subresource (`spec.shardCount`); HPA now correctly scales the number of shards. See [#2229](https://github.com/VictoriaMetrics/operator/issues/2229).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): update status currentRevision and currentReplicas for StatefulSet with OnDelete update strategy. See [#1242](https://github.com/VictoriaMetrics/operator/issues/1242).
 * BUGFIX: [config-reloader](https://docs.victoriametrics.com/operator/): fix `configreloader_last_reload_success_timestamp_seconds` metric to report time in seconds instead of milliseconds.
 

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -262,13 +262,7 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 					}
 				}
 			}
-			o := reconcile.DeploymentOpts{
-				PatchSpec: func(existingSpec, newSpec *appsv1.DeploymentSpec) {
-					if cr.Spec.HPA != nil {
-						newSpec.Replicas = existingSpec.Replicas
-					}
-				},
-			}
+			o := reconcile.DeploymentOpts{}
 			if err := reconcile.Deployment(ctx, rclient, newApp, prevApp, &owner, &o); err != nil {
 				rv.err = fmt.Errorf("cannot reconcile deployment for vmagent(%d): %w", shardNum, err)
 				return
@@ -310,11 +304,6 @@ func createOrUpdateApp(ctx context.Context, rclient client.Client, cr, prevCR *v
 			o := reconcile.StatefulSetOpts{
 				SelectorLabels: selectorLabels,
 				UpdateBehavior: cr.Spec.StatefulRollingUpdateStrategyBehavior,
-				PatchSpec: func(existingSpec, newSpec *appsv1.StatefulSetSpec) {
-					if cr.Spec.HPA != nil {
-						newSpec.Replicas = existingSpec.Replicas
-					}
-				},
 			}
 			if err := reconcile.StatefulSet(ctx, rclient, newApp, prevApp, &owner, &o); err != nil {
 				rv.err = fmt.Errorf("cannot reconcile %T for vmagent(%d): %w", newApp, shardNum, err)
@@ -1337,16 +1326,15 @@ func createOrUpdateHPA(ctx context.Context, rclient client.Client, cr, prevCR *v
 	if cr.Spec.HPA == nil {
 		return nil
 	}
-	kind := "Deployment"
-	if cr.Spec.StatefulMode {
-		kind = "StatefulSet"
-	} else if cr.Spec.DaemonSetMode {
+	if cr.Spec.DaemonSetMode {
 		return nil
 	}
+	// Target the VMAgent CR via its scale subresource so HPA controls spec.shardCount,
+	// not pod replicas inside a single shard deployment.
 	targetRef := autoscalingv2.CrossVersionObjectReference{
-		Name:       cr.PrefixedName(),
-		Kind:       kind,
-		APIVersion: "apps/v1",
+		Name:       cr.Name,
+		Kind:       "VMAgent",
+		APIVersion: "operator.victoriametrics.com/v1beta1",
 	}
 	newHPA := build.HPA(cr, targetRef, cr.Spec.HPA)
 	var prevHPA *autoscalingv2.HorizontalPodAutoscaler

--- a/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
@@ -15,6 +15,7 @@ import (
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/reconcile"
 )
 
 func Test_CreateOrUpdate_Actions(t *testing.T) {
@@ -253,17 +254,47 @@ func TestCreateOrUpdate_StatefulSetWithHPA(t *testing.T) {
 	assert.NoError(t, fclient.Get(ctx, stsNSN, &sts))
 	assert.Equal(t, int32(1), *sts.Spec.Replicas)
 
-	// simulate HPA scaling the StatefulSet to 3 replicas
-	sts.Spec.Replicas = ptr.To(int32(3))
-	assert.NoError(t, fclient.Update(ctx, &sts))
-
-	// reconcile with a different desired replica count in the spec
+	// HPA now targets the VMAgent CR scale subresource (spec.shardCount), not the StatefulSet
+	// directly. The operator must always reconcile pod replicas from spec.replicaCount.
 	cr.Spec.ReplicaCount = ptr.To(int32(2))
 	assert.NoError(t, CreateOrUpdate(ctx, cr, fclient))
 
-	// HPA-managed replica count must not be overwritten
 	assert.NoError(t, fclient.Get(ctx, stsNSN, &sts))
-	assert.Equal(t, int32(3), *sts.Spec.Replicas)
+	assert.Equal(t, int32(2), *sts.Spec.Replicas)
+}
+
+func TestCreateOrUpdate_StatusShards(t *testing.T) {
+	f := func(cr *vmv1beta1.VMAgent, wantShards int32) {
+		t.Helper()
+		fclient := k8stools.GetTestClientWithObjects([]runtime.Object{cr})
+		ctx := context.TODO()
+		build.AddDefaults(fclient.Scheme())
+		fclient.Scheme().Default(cr)
+
+		assert.NoError(t, CreateOrUpdate(ctx, cr, fclient))
+		assert.NoError(t, reconcile.UpdateObjectStatus(ctx, fclient, cr, vmv1beta1.UpdateStatusOperational, nil))
+
+		var updated vmv1beta1.VMAgent
+		assert.NoError(t, fclient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.Name}, &updated))
+		assert.Equal(t, wantShards, updated.Status.Shards)
+	}
+
+	// non-sharded: status.shards must be 1 so VPA/HPA scale subresource is non-zero
+	f(&vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-shards", Namespace: "default"},
+		Spec: vmv1beta1.VMAgentSpec{
+			RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{{URL: "http://remote-write"}},
+		},
+	}, 1)
+
+	// explicit shardCount=3
+	f(&vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "three-shards", Namespace: "default"},
+		Spec: vmv1beta1.VMAgentSpec{
+			RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{{URL: "http://remote-write"}},
+			ShardCount:  ptr.To(int32(3)),
+		},
+	}, 3)
 }
 
 func TestCreateOrUpdate_Paused(t *testing.T) {


### PR DESCRIPTION
fixes #2229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HPA for `VMAgent` to scale shards via the CR’s scale subresource instead of pod replicas. Also report at least 1 shard in status for `VMAgent` and `VMAnomaly` when unset to avoid VPA/HPA scale lookup failures. Fixes #2229.

- **Bug Fixes**
  - HPA now targets the `VMAgent` CR (`operator.victoriametrics.com/v1beta1`, name=`cr.Name`, kind=`VMAgent`) to scale `spec.shardCount`; removed replica-patching on Deployments/StatefulSets and always reconcile pod replicas from `spec.replicaCount`.
  - `status.shards` defaults to 1 via `GetShardCount()` for `VMAgent` and `VMAnomaly` (including daemonset mode).
  - Added tests for shard reporting and HPA reconcile behavior; updated `docs/CHANGELOG.md`.

<sup>Written for commit 154eb8311f4dfb6583f57f3711462e52cdc53e75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

