### PR TITLE
fix: avoid e2e teardown panic after setup failure

### DIFF
--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -200,8 +200,14 @@ func InitOperatorProcess(extraNamespaces ...string) []byte {
 // and cleanup resources
 func ShutdownOperatorProcess() {
 	By("tearing down the test environment")
-	cancelManager(operator.ErrShutdown)
-	Eventually(stopped, 60, 2).Should(BeClosed())
+	shutdownOperatorProcess()
+}
+
+func shutdownOperatorProcess() {
+	if cancelManager != nil {
+		cancelManager(operator.ErrShutdown)
+		Eventually(stopped, 60, 2).Should(BeClosed())
+	}
 	ShutdownTestEnv()
 }
 

--- a/test/e2e/suite/suite_test.go
+++ b/test/e2e/suite/suite_test.go
@@ -1,0 +1,24 @@
+package suite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShutdownOperatorProcessWithoutStartedManager(t *testing.T) {
+	oldTestEnv := testEnv
+	oldCancelManager := cancelManager
+	oldStopped := stopped
+	t.Cleanup(func() {
+		testEnv = oldTestEnv
+		cancelManager = oldCancelManager
+		stopped = oldStopped
+	})
+
+	testEnv = nil
+	cancelManager = nil
+	stopped = make(chan struct{})
+
+	assert.NotPanics(t, shutdownOperatorProcess)
+}


### PR DESCRIPTION
`ShutdownOperatorProcess()` can panic if suite startup exits before `cancelManager` is set. Then the real setup error gets buried, kinda noisy.

This just guards the "manager never started" path and adds a small regression test.

Repro
1. Point kubeconfig at an unreachable or not ready cluster.
2. Run `go test ./test/e2e -run TestE2E`.
3. Before this patch, `SynchronizedBeforeSuite` fails and `SynchronizedAfterSuite` panics on nil `cancelManager`.
4. After this patch, you only get the original setup failure.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent e2e teardown panics when setup fails by safely handling cases where the operator manager never started. Teardown now skips manager shutdown and surfaces the original setup error.

- **Bug Fixes**
  - Guard manager shutdown: only call cancel and wait if the manager was initialized.
  - Add a regression test to ensure teardown does not panic when the manager never started.

<sup>Written for commit 3462f937050687a7a1eb91146d9997926b71e955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

