### PR TITLE
ignore not found errors during attempt to update resource status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): update status currentRevision and currentReplicas for StatefulSet with OnDelete update strategy. See [#1242](https://github.com/VictoriaMetrics/operator/issues/1242).
 * BUGFIX: [config-reloader](https://docs.victoriametrics.com/operator/): fix `configreloader_last_reload_success_timestamp_seconds` metric to report time in seconds instead of milliseconds.
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): enable strict CR spec unmarshalling when creating objects. See [#2882](https://github.com/VictoriaMetrics/helm-charts/issues/2882).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): ignore `NotFound` errors, that may occur during attempt to update status on a missing resource.
 
 ## [v0.70.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 20 May 2026

--- a/internal/controller/operator/factory/reconcile/status.go
+++ b/internal/controller/operator/factory/reconcile/status.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -87,6 +88,9 @@ func updateChildStatusConditions[T any, PT interface {
 	return retryOnConflict(func() error {
 		dst := PT(new(T))
 		if err := rclient.Get(ctx, nsn, dst); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 		st := dst.GetStatusMetadata()
@@ -98,6 +102,9 @@ func updateChildStatusConditions[T any, PT interface {
 		writeAggregatedStatus(st, vmv1beta1.ConditionDomainTypeAppliedSuffix)
 		if !reflect.DeepEqual(prevSt, st) {
 			if err := rclient.Status().Update(ctx, dst); err != nil {
+				if k8serrors.IsNotFound(err) {
+					return nil
+				}
 				return fmt.Errorf("failed to patch status of broken VMAlertmanagerConfig=%q: %w", childObject.GetName(), err)
 			}
 		}


### PR DESCRIPTION
issue was found in tests that are failing from time to time

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore NotFound errors when getting or updating child resource status in `vmoperator` so reconciliation continues if the resource was deleted. This reduces log noise and avoids false failures when a resource disappears between read and status update.

<sup>Written for commit 12be4f3924347803ae948aa21f85e5041712a3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

