### PR TITLE
chore: consistently controller's loggers and metrics

### DIFF
--- a/internal/controller/operator/objects_stat.go
+++ b/internal/controller/operator/objects_stat.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -49,7 +50,7 @@ func newCollector() *objectCollector {
 	registeredObjects := []string{
 		"vmagent", "vmalert", "vmsingle", "vmcluster", "vmalertmanager", "vmauth", "vlogs", "vlsingle",
 		"vlcluster", "vmalertmanagerconfig", "vmrule", "vmuser", "vmservicescrape", "vmstaticscrape",
-		"vmnodescrape", "vmpodscrape", "vmprobescrape", "vmscrapeconfig", "vmanomaly", "vlagent",
+		"vmnodescrape", "vmpodscrape", "vmprobe", "vmscrapeconfig", "vmanomaly", "vlagent",
 		"vtsingle", "vtcluster", "vmdistributed", "podmonitor", "prometheusrule", "servicemonitor",
 		"alertmanagerconfig", "probe", "scrapeconfig", "vmanomalyconfig",
 	}
@@ -93,6 +94,10 @@ func deregisterObjectByCollector(name, ns, controller string) {
 
 // RegisterObjectStat registers or deregisters object at metrics
 func RegisterObjectStat(obj client.Object, controller string) {
+	if controller == "" {
+		return
+	}
+	controller = strings.ToLower(controller)
 	if obj.GetDeletionTimestamp().IsZero() {
 		registerObjectByCollector(obj.GetName(), obj.GetNamespace(), controller)
 		return

--- a/internal/controller/operator/promalertmanagerconfig_controller.go
+++ b/internal/controller/operator/promalertmanagerconfig_controller.go
@@ -40,15 +40,17 @@ type PromAlertmanagerConfigReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromAlertmanagerConfigReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromAlertmanagerConfigReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromAlertmanagerConfig")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("alertmanagerconfig").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -69,14 +71,14 @@ func (r *PromAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ct
 
 	// Fetch the PromAlertmanagerConfig instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "alertmanagerconfig", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "alertmanagerconfig")
+	RegisterObjectStat(&instance, r.name)
 	var cr *vmv1beta1.VMAlertmanagerConfig
 	if cr, err = converter.AlertmanagerConfig(&instance, r.BaseConf); err != nil {
-		err = &parsingError{err.Error(), "alertmanagerconfig"}
+		err = &parsingError{err.Error(), r.name}
 		return
 	}
 	var owner *metav1.OwnerReference

--- a/internal/controller/operator/prompodmonitor_controller.go
+++ b/internal/controller/operator/prompodmonitor_controller.go
@@ -39,15 +39,17 @@ type PromPodMonitorReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromPodMonitorReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromPodMonitorReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromPodMonitor")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("podmonitor").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -68,11 +70,11 @@ func (r *PromPodMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Fetch the PromPodMonitor instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "podmonitor", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "podmonitor")
+	RegisterObjectStat(&instance, r.name)
 	cr := converter.PodMonitor(ctx, &instance, r.BaseConf)
 	var owner *metav1.OwnerReference
 	if len(cr.OwnerReferences) > 0 {

--- a/internal/controller/operator/promprobe_controller.go
+++ b/internal/controller/operator/promprobe_controller.go
@@ -39,15 +39,17 @@ type PromProbeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromProbeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromProbeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromProbe")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("probe").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -68,11 +70,11 @@ func (r *PromProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Fetch the PromProbe instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "probe", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "probe")
+	RegisterObjectStat(&instance, r.name)
 	cr := converter.Probe(ctx, &instance, r.BaseConf)
 	var owner *metav1.OwnerReference
 	if len(cr.OwnerReferences) > 0 {

--- a/internal/controller/operator/promrule_controller.go
+++ b/internal/controller/operator/promrule_controller.go
@@ -39,15 +39,17 @@ type PromRuleReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromRuleReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromRuleReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromRule")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("prometheusrule").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -68,11 +70,11 @@ func (r *PromRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 	// Fetch the PrometheusRule instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "prometheusrule", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "prometheusrule")
+	RegisterObjectStat(&instance, r.name)
 	cr := converter.PrometheusRule(ctx, &instance, r.BaseConf)
 	var owner *metav1.OwnerReference
 	if len(cr.OwnerReferences) > 0 {

--- a/internal/controller/operator/promscrapeconfig_controller.go
+++ b/internal/controller/operator/promscrapeconfig_controller.go
@@ -40,15 +40,17 @@ type PromScrapeConfigReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromScrapeConfigReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromScrapeConfigReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromScrapeConfig")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("scrapeconfig").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -69,14 +71,14 @@ func (r *PromScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Fetch the PromScrapeConfig instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "scrapeconfig", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "scrapeconfig")
+	RegisterObjectStat(&instance, r.name)
 	var cr *vmv1beta1.VMScrapeConfig
 	if cr, err = converter.ScrapeConfig(ctx, &instance, r.BaseConf); err != nil {
-		err = &parsingError{err.Error(), "scrapeconfig"}
+		err = &parsingError{err.Error(), r.name}
 		return
 	}
 	var owner *metav1.OwnerReference

--- a/internal/controller/operator/promservicemonitor_controller.go
+++ b/internal/controller/operator/promservicemonitor_controller.go
@@ -39,15 +39,17 @@ type PromServiceMonitorReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *PromServiceMonitorReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *PromServiceMonitorReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.PromServiceMonitor")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
-	activeConverterWatchers.WithLabelValues("servicemonitor").Add(1)
+	activeConverterWatchers.WithLabelValues(r.name).Add(1)
 }
 
 // Scheme implements interface.
@@ -68,11 +70,11 @@ func (r *PromServiceMonitorReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Fetch the PromServiceMonitor instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "servicemonitor", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "servicemonitor")
+	RegisterObjectStat(&instance, r.name)
 	cr := converter.ServiceMonitor(ctx, &instance, r.BaseConf)
 	var owner *metav1.OwnerReference
 	if len(cr.OwnerReferences) > 0 {

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -40,12 +40,14 @@ type VLAgentReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VLAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VLAgentReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VLAgent")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -71,18 +73,18 @@ func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}()
 	// Fetch the VLAgent instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: "vlagent", requestObject: req}
+		err = &getError{origin: err, controller: r.name, requestObject: req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vlagent")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVLAgentDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vlagent"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -41,12 +41,14 @@ type VLClusterReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VLClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VLClusterReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VLCluster")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,17 +67,17 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vlcluster", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vlcluster")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vlcluster"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -39,12 +39,14 @@ type VLogsReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VLogsReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VLogsReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VLogs")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -71,17 +73,17 @@ func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vlogs", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vlogs")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVLogsDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vlogs"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	l.Info("VLogs CustomResource transited into read-only state. Please migrate to the VLSingle.")

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -41,12 +41,14 @@ type VLSingleReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VLSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VLSingleReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VLSingle")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -66,17 +68,17 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vlsingle", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vlsingle")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVLSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vlsingle"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -50,12 +50,14 @@ type VMAgentReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAgentReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAgentReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAgent")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -91,7 +93,7 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Fetch the VMAgent instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: "vmagent", requestObject: req}
+		err = &getError{origin: err, controller: r.name, requestObject: req}
 		return
 	}
 
@@ -100,14 +102,14 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		defer agentSync.RUnlock()
 	}
 
-	RegisterObjectStat(&instance, "vmagent")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVMAgentDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmagent"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -47,12 +47,14 @@ type VMAlertReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAlertReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAlertReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAlert")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -76,7 +78,7 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmalert", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
@@ -85,14 +87,14 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		defer alertSync.RUnlock()
 	}
 
-	RegisterObjectStat(&instance, "vmalert")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVMAlertDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmalert"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -47,12 +47,14 @@ type VMAlertmanagerReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAlertmanagerReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAlertmanagerReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAlertmanager")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -79,7 +81,7 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmalertmanager", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
@@ -88,13 +90,13 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		defer alertmanagerSync.RUnlock()
 	}
 
-	RegisterObjectStat(&instance, "vmalertmanager")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVMAlertManagerDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmalertmanager"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanagerconfig_controller.go
+++ b/internal/controller/operator/vmalertmanagerconfig_controller.go
@@ -40,12 +40,14 @@ type VMAlertmanagerConfigReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAlertmanagerConfigReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAlertmanagerConfigReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAlertmanagerConfig")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -66,13 +68,13 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmalertmanagerconfig", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmalertmanagerconfig")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmalertmanagerconfig"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if alertmanagerReconcileLimit.Throttle() {

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -47,12 +47,14 @@ type VMAnomalyReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAnomalyReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAnomalyReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAnomaly")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -78,7 +80,7 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 	// Fetch the VMAnomaly instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: "vmanomaly", requestObject: req}
+		err = &getError{origin: err, controller: r.name, requestObject: req}
 		return
 	}
 
@@ -87,14 +89,14 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		defer anomalySync.Unlock()
 	}
 
-	RegisterObjectStat(&instance, "vmanomaly")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVMAnomalyDelete(ctx, r.Client, &instance)
 		return
 	}
 
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmanomaly"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmanomalyconfig_controller.go
+++ b/internal/controller/operator/vmanomalyconfig_controller.go
@@ -40,12 +40,14 @@ type VMAnomalyConfigReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAnomalyConfigReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAnomalyConfigReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAnomalyConfig")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -68,11 +70,11 @@ func (r *VMAnomalyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the VMAnomalyConfig instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmanomalyconfig", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmanomalyconfig")
+	RegisterObjectStat(&instance, r.name)
 
 	if anomalyReconcileLimit.Throttle() {
 		// fast path, rate limited

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -47,12 +47,14 @@ type VMAuthReconciler struct {
 	BaseConf     *config.BaseOperatorConf
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMAuthReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMAuthReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMAuth")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -76,7 +78,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}()
 
 	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		return result, &getError{err, "vmauth", req}
+		return result, &getError{err, r.name, req}
 	}
 
 	if !instance.IsUnmanaged() {
@@ -84,7 +86,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		defer authSync.RUnlock()
 	}
 
-	RegisterObjectStat(&instance, "vmauth")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		if err = finalize.OnVMAuthDelete(ctx, r, &instance); err != nil {
 			err = fmt.Errorf("cannot remove finalizer from vmauth: %w", err)
@@ -92,7 +94,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmauth"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -24,12 +24,14 @@ type VMClusterReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMClusterReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMCluster")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -55,18 +57,18 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 	}()
 
 	if err = r.Client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmcluster", request}
+		err = &getError{err, r.name, request}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmcluster")
+	RegisterObjectStat(&instance, r.name)
 
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmcluster"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -39,12 +39,14 @@ type VMDistributedReconciler struct {
 	BaseConf     *config.BaseOperatorConf
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMDistributedReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMDistributedReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMDistributedReconciler")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -64,12 +66,12 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Fetch VMDistributed instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmdistributed", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
 	// Register metrics
-	RegisterObjectStat(&instance, "vmdistributed")
+	RegisterObjectStat(&instance, r.name)
 
 	// Check if the instance is being deleted
 	if !instance.DeletionTimestamp.IsZero() {
@@ -80,7 +82,7 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	// Check parsing error
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "VMDistributed"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmnodescrape_controller.go
+++ b/internal/controller/operator/vmnodescrape_controller.go
@@ -37,12 +37,14 @@ type VMNodeScrapeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMNodeScrapeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMNodeScrapeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMNodeScrape")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -66,13 +68,13 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Fetch the VMNodeScrape instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmnodescrape", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmnodescrape")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmnodescrape"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vmpodscrape_controller.go
+++ b/internal/controller/operator/vmpodscrape_controller.go
@@ -37,12 +37,14 @@ type VMPodScrapeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMPodScrapeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMPodScrapeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMPodScrape")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,13 +67,13 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}()
 	// Fetch the VMPodScrape instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmpodscrape", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmpodscrape")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmpodscrape"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmprobe_controller.go
+++ b/internal/controller/operator/vmprobe_controller.go
@@ -37,12 +37,14 @@ type VMProbeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMProbeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMProbeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMProbe")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,13 +67,13 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	// Fetch the VMPodScrape instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmprobescrape", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmprobescrape")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmprobescrape"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmrule_controller.go
+++ b/internal/controller/operator/vmrule_controller.go
@@ -40,12 +40,14 @@ type VMRuleReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMRuleReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMRuleReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMRule")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -69,13 +71,13 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	// Fetch the VMRule instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmrule", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmrule")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmrule"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if alertReconcileLimit.Throttle() {

--- a/internal/controller/operator/vmscrapeconfig_controller.go
+++ b/internal/controller/operator/vmscrapeconfig_controller.go
@@ -37,12 +37,14 @@ type VMScrapeConfigReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMScrapeConfigReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMScrapeConfigReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMScrapeConfig")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,13 +67,13 @@ func (r *VMScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Fetch the VMScrapeConfig instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmscrapeconfig", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmscrapeconfig")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmscrapeconfig"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmservicescrape_controller.go
+++ b/internal/controller/operator/vmservicescrape_controller.go
@@ -37,12 +37,14 @@ type VMServiceScrapeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMServiceScrapeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMServiceScrapeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMServiceScrape")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,13 +67,13 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the VMServiceScrape instance
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmservicescrape", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmservicescrape")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmservicescrape"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -50,12 +50,14 @@ type VMSingleReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMSingleReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMSingle")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -96,17 +98,17 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmsingle", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vmsingle")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVMSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmsingle"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmstaticscrape_controller.go
+++ b/internal/controller/operator/vmstaticscrape_controller.go
@@ -20,12 +20,14 @@ type VMStaticScrapeReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMStaticScrapeReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMStaticScrapeReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMStaticScrape")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -45,12 +47,12 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmstaticscrape", req}
+		err = &getError{err, r.name, req}
 		return
 	}
-	RegisterObjectStat(&instance, "vmstaticscrape")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmstaticscrape"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -43,12 +43,14 @@ type VMUserReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VMUserReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VMUserReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VMUser")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -69,7 +71,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vmuser", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 	if !instance.DeletionTimestamp.IsZero() {
@@ -79,9 +81,9 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		}
 		return
 	}
-	RegisterObjectStat(&instance, "vmuser")
+	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vmuser"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -41,12 +41,14 @@ type VTClusterReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VTClusterReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VTClusterReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VTCluster")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -65,17 +67,17 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vtcluster", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vtcluster")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnClusterDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vtcluster"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -41,12 +41,14 @@ type VTSingleReconciler struct {
 	Log          logr.Logger
 	OriginScheme *runtime.Scheme
 	BaseConf     *config.BaseOperatorConf
+	name         string
 }
 
 // Init implements crdController interface
-func (r *VTSingleReconciler) Init(rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+func (r *VTSingleReconciler) Init(name string, rclient client.Client, l logr.Logger, sc *runtime.Scheme, cf *config.BaseOperatorConf) {
+	r.name = name
 	r.Client = rclient
-	r.Log = l.WithName("controller.VTSingle")
+	r.Log = l.WithName("controller." + name)
 	r.OriginScheme = sc
 	r.BaseConf = cf
 }
@@ -66,17 +68,17 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}()
 
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, "vtsingle", req}
+		err = &getError{err, r.name, req}
 		return
 	}
 
-	RegisterObjectStat(&instance, "vtsingle")
+	RegisterObjectStat(&instance, r.name)
 	if !instance.DeletionTimestamp.IsZero() {
 		err = finalize.OnVTSingleDelete(ctx, r.Client, &instance)
 		return
 	}
 	if instance.Status.ParsingSpecError != "" {
-		err = &parsingError{instance.Status.ParsingSpecError, "vtsingle"}
+		err = &parsingError{instance.Status.ParsingSpecError, r.name}
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/manager/dry_run.go
+++ b/internal/manager/dry_run.go
@@ -33,7 +33,7 @@ func RunDryRunMode(ctx context.Context, mgr ctrl.Manager, baseConfig *config.Bas
 	c := mgr.GetClient()
 
 	for name, crdCtrl := range controllersByName {
-		crdCtrl.Init(c, setupLog, mgr.GetScheme(), baseConfig)
+		crdCtrl.Init(name, c, setupLog, mgr.GetScheme(), baseConfig)
 		r, ok := crdCtrl.(reconcile.Reconciler)
 		if !ok {
 			setupLog.Info("skipping controller, does not implement Reconciler", "name", name)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -456,7 +456,7 @@ func mustAddRestClientMetrics(r metrics.RegistererGatherer) {
 }
 
 type crdController interface {
-	Init(client.Client, logr.Logger, *runtime.Scheme, *config.BaseOperatorConf)
+	Init(string, client.Client, logr.Logger, *runtime.Scheme, *config.BaseOperatorConf)
 	SetupWithManager(mgr ctrl.Manager) error
 	IsDisabled(cfg *config.BaseOperatorConf, disabledControllers sets.Set[string]) bool
 }
@@ -539,7 +539,7 @@ func initControllers(mgr ctrl.Manager, l logr.Logger, baseClient *kubernetes.Cli
 			l.Info("controller disabled either by provided flag or respective CRD is not found", "name", name, "controller.disableReconcileFor", *disableControllerForCRD)
 			continue
 		}
-		ct.Init(mgr.GetClient(), l, mgr.GetScheme(), bs)
+		ct.Init(name, mgr.GetClient(), l, mgr.GetScheme(), bs)
 		if err := ct.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("cannot setup controller=%q: %w", name, err)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized controller logger names and metrics labels by passing the controller name into each reconciler and using it across logs, metrics, and object stats. Labels are now normalized to lowercase, and the vmprobe metric label is corrected for consistency.

- **Refactors**
  - Added a `name` field to reconcilers and changed Init to `Init(name, ...)`, setting logger to `controller.<name>`.
  - Replaced hard-coded label strings with `r.name` in errors, `RegisterObjectStat`, and `activeConverterWatchers`.
  - Lowercased controller names in `RegisterObjectStat` to keep metrics labels consistent.
  - Updated the `crdController` interface and manager (incl. dry-run) to pass the controller name during initialization.
  - Corrected the object collector entry from `vmprobescrape` to `vmprobe`.
  - Made `RegisterObjectStat` a no-op when the controller name is empty to avoid unlabeled metrics.

- **Migration**
  - If you implement `crdController`, update `Init` to `Init(name string, client.Client, logr.Logger, *runtime.Scheme, *config.BaseOperatorConf)`.

<sup>Written for commit 7112fed3852db07f9d0f6fe631fb8df77ddffef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

