### PR TITLE
fix: add listMapKey to VMRule rules for structured server-side apply merge

### DIFF
--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -101,9 +101,11 @@ type RuleGroup struct {
 type Rule struct {
 	// Record represents a query, that will be recorded to dataSource
 	// +optional
+	// +kubebuilder:default=""
 	Record string `json:"record,omitempty" yaml:"record,omitempty"`
 	// Alert is a name for alert
 	// +optional
+	// +kubebuilder:default=""
 	Alert string `json:"alert,omitempty" yaml:"alert,omitempty"`
 	// Expr is query, that will be evaluated at dataSource
 	// +optional
@@ -187,6 +189,14 @@ func (cr *VMRule) Validate() error {
 			return fmt.Errorf("duplicate group name: %s", errContext)
 		}
 		uniqNames.Insert(group.Name)
+		for j, rule := range group.Rules {
+			if rule.Record != "" && rule.Alert != "" {
+				return fmt.Errorf("rule at group %s index %d has both record and alert set", group.Name, j)
+			}
+			if rule.Record == "" && rule.Alert == "" {
+				return fmt.Errorf("rule at group %s index %d has neither record nor alert set", group.Name, j)
+			}
+		}
 		groupBytes, err := yaml.Marshal(group)
 		if err != nil {
 			return fmt.Errorf("cannot marshal %s, err: %w", errContext, err)

--- a/api/operator/v1beta1/vmrule_types.go
+++ b/api/operator/v1beta1/vmrule_types.go
@@ -36,7 +36,11 @@ type RuleGroup struct {
 	// evaluation interval for group
 	// +optional
 	Interval string `json:"interval,omitempty" yaml:"interval,omitempty"`
-	// Rules list of alert rules
+	// Rules list of alert rules.
+	// Rules are merged by record and alert fields.
+	// +listType=map
+	// +listMapKey=record
+	// +listMapKey=alert
 	Rules []Rule `json:"rules"`
 	// Limit the number of alerts an alerting rule and series a recording
 	// rule can produce

--- a/api/operator/v1beta1/vmrule_types_test.go
+++ b/api/operator/v1beta1/vmrule_types_test.go
@@ -6,16 +6,17 @@ import (
 	"errors"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
-
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	strategicpatch "k8s.io/apimachinery/pkg/util/strategicpatch"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func TestVMRuleValidate(t *testing.T) {
@@ -103,6 +104,38 @@ spec:
             value: "{{ $value }}"
             description: 'kafka coordinator is down'`,
 		wantErr: "validation failed for VMRule: / group: kafka err: invalid labels for rule \"coordinator down\": errors(1): \n(key: \"job\", value: \"{{ $labls.job }}\"): error parsing template: template: :1: undefined variable \"$labls\"",
+	})
+
+	// rule with both record and alert set
+	f(opts{
+		src: `
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: both-record-and-alert
+spec:
+  groups:
+    - name: kafka
+      rules:
+        - alert: coordinator down
+          record: job:up:sum
+          expr: up == 0`,
+		wantErr: `rule at group kafka index 0 has both record and alert set`,
+	})
+
+	// rule with neither record nor alert set
+	f(opts{
+		src: `
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: neither-record-nor-alert
+spec:
+  groups:
+    - name: kafka
+      rules:
+        - expr: up == 0`,
+		wantErr: `rule at group kafka index 0 has neither record nor alert set`,
 	})
 
 	// duplicate rules
@@ -287,31 +320,218 @@ func TestVMRuleValidateDuplicateGroupNames(t *testing.T) {
 	assert.ErrorContains(t, vmr.Validate(), "duplicate group name")
 }
 
-func TestVMRuleValidateSizeLimit(t *testing.T) {
-	vmr := VMRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "too-big",
-			Namespace: "default",
+// TestVMRuleRuleListMapKeyFieldNames verifies that the Rule struct exposes JSON
+// fields named "record" and "alert", matching the +listMapKey declarations.
+func TestVMRuleRuleListMapKeyFieldNames(t *testing.T) {
+	rt := reflect.TypeOf(Rule{})
+	var foundRecord, foundAlert bool
+	for i := 0; i < rt.NumField(); i++ {
+		name := strings.Split(rt.Field(i).Tag.Get("json"), ",")[0]
+		switch name {
+		case "record":
+			foundRecord = true
+		case "alert":
+			foundAlert = true
+		}
+	}
+	assert.True(t, foundRecord, `Rule must have json:"record,..." to match +listMapKey=record`)
+	assert.True(t, foundAlert, `Rule must have json:"alert,..." to match +listMapKey=alert`)
+}
+
+// TestVMRuleRulesCompositeKeyDistinctness verifies that the (record, alert)
+// composite key correctly distinguishes rules across all relevant combinations.
+func TestVMRuleRulesCompositeKeyDistinctness(t *testing.T) {
+	type ruleKey = [2]string
+	keyOf := func(r Rule) ruleKey { return ruleKey{r.Record, r.Alert} }
+	uniqueKeys := func(rules []Rule) int {
+		seen := make(map[ruleKey]struct{}, len(rules))
+		for _, r := range rules {
+			seen[keyOf(r)] = struct{}{}
+		}
+		return len(seen)
+	}
+
+	tests := []struct {
+		name  string
+		rules []Rule
+		want  int
+	}{
+		{
+			name: "same alert, different record are distinct keys",
+			rules: []Rule{
+				{Alert: "HighErrorRate", Record: "r1", Expr: "up == 0"},
+				{Alert: "HighErrorRate", Record: "r2", Expr: "up == 0"},
+			},
+			want: 2,
 		},
-		Spec: VMRuleSpec{
-			Groups: []RuleGroup{
-				{
-					Name: "too-big",
-					Rules: []Rule{
-						{
-							Alert: "TooBig",
-							Expr:  "up == 0",
-							Annotations: map[string]string{
-								"summary": strings.Repeat("x", MaxConfigMapDataSize),
-							},
-						},
-					},
-				},
+		{
+			name: "same record, different alert are distinct keys",
+			rules: []Rule{
+				{Record: "job:up:sum", Alert: "a1", Expr: "sum(up)"},
+				{Record: "job:up:sum", Alert: "a2", Expr: "sum(up)"},
+			},
+			want: 2,
+		},
+		{
+			name: "same (record, alert) pair maps to a single key regardless of expr",
+			rules: []Rule{
+				{Alert: "HighErrorRate", Expr: "up == 0"},
+				{Alert: "HighErrorRate", Expr: "up == 1"},
+			},
+			want: 1,
+		},
+		{
+			name: "rules with neither record nor alert all share the same empty key",
+			rules: []Rule{
+				{Expr: "up == 0"},
+				{Expr: "sum(up)"},
+			},
+			want: 1,
+		},
+		{
+			name: "alert-only and record-only rules are distinct keys",
+			rules: []Rule{
+				{Alert: "HighErrorRate", Expr: "up == 0"},
+				{Record: "job:up:sum", Expr: "sum(up) by (job)"},
+			},
+			want: 2,
+		},
+		{
+			name: "rule with both record and alert set is its own unique key",
+			rules: []Rule{
+				{Alert: "HighErrorRate", Expr: "up == 0"},
+				{Record: "job:up:sum", Expr: "sum(up)"},
+				{Record: "job:up:sum", Alert: "HighErrorRate", Expr: "combined"},
+			},
+			want: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, uniqueKeys(tc.rules))
+		})
+	}
+}
+
+// TestVMRuleGroupsStrategicMergePatch verifies that Groups (which carry struct-tag
+// patchStrategy/patchMergeKey) are correctly merged by name under traditional
+// strategic merge patch, while Rules — which use SSA list map keys only — are
+// replaced atomically (the entire slice is swapped for the patched group).
+func TestVMRuleGroupsStrategicMergePatch(t *testing.T) {
+	original := VMRuleSpec{
+		Groups: []RuleGroup{
+			{
+				Name:  "alerts",
+				Rules: []Rule{{Alert: "HighErrorRate", Expr: "up == 0", For: "5m"}},
+			},
+			{
+				Name:  "recordings",
+				Rules: []Rule{{Record: "job:up:sum", Expr: "sum(up) by (job)"}},
+			},
+		},
+	}
+	// Patch touches only "alerts"; "recordings" group must survive untouched.
+	patch := VMRuleSpec{
+		Groups: []RuleGroup{
+			{
+				Name:  "alerts",
+				Rules: []Rule{{Alert: "HighErrorRate", Expr: "up == 0", For: "10m"}},
 			},
 		},
 	}
 
-	assert.ErrorContains(t, vmr.Validate(), "exceed single rule limit")
+	origJSON, err := json.Marshal(original)
+	require.NoError(t, err)
+	patchJSON, err := json.Marshal(patch)
+	require.NoError(t, err)
+
+	merged, err := strategicpatch.StrategicMergePatch(origJSON, patchJSON, VMRuleSpec{})
+	require.NoError(t, err)
+
+	var result VMRuleSpec
+	require.NoError(t, json.Unmarshal(merged, &result))
+
+	require.Len(t, result.Groups, 2, "both groups must survive: patch merges by group name")
+	byName := make(map[string]RuleGroup, len(result.Groups))
+	for _, g := range result.Groups {
+		byName[g.Name] = g
+	}
+
+	// "recordings" group is unpatched and must be present unchanged.
+	recordings, ok := byName["recordings"]
+	require.True(t, ok, "recordings group must survive")
+	require.Len(t, recordings.Rules, 1)
+	assert.Equal(t, "job:up:sum", recordings.Rules[0].Record)
+
+	// "alerts" group was patched; under traditional SMP, its Rules slice is
+	// replaced atomically (no patchMergeKey struct tag on Rules).
+	alerts, ok := byName["alerts"]
+	require.True(t, ok, "alerts group must be present")
+	require.Len(t, alerts.Rules, 1)
+	assert.Equal(t, "10m", alerts.Rules[0].For, "rule For should be updated to 10m")
+}
+
+// TestVMRuleRulesSSAStyleMerge simulates the Server Side Apply merge semantics
+// enabled by +listType=map +listMapKey=record +listMapKey=alert: patch rules
+// update existing rules matched by the (record, alert) composite key, and new
+// rules are appended without discarding unmatched base rules.
+func TestVMRuleRulesSSAStyleMerge(t *testing.T) {
+	type ruleKey = [2]string
+	keyOf := func(r Rule) ruleKey { return ruleKey{r.Record, r.Alert} }
+
+	// mergeRules applies SSA list-map semantics using the (record, alert) key:
+	// matched entries are updated in-place; unmatched patch entries are appended.
+	mergeRules := func(base, patch []Rule) []Rule {
+		index := make(map[ruleKey]int, len(base))
+		for i, r := range base {
+			index[keyOf(r)] = i
+		}
+		result := make([]Rule, len(base))
+		copy(result, base)
+		for _, p := range patch {
+			if i, ok := index[keyOf(p)]; ok {
+				result[i] = p
+			} else {
+				result = append(result, p)
+			}
+		}
+		return result
+	}
+
+	base := []Rule{
+		{Alert: "HighErrorRate", Expr: "up == 0", For: "5m"},
+		{Alert: "LowDisk", Expr: "disk_free < 1024"},
+		{Record: "job:up:sum", Expr: "sum(up) by (job)"},
+	}
+	patch := []Rule{
+		// key ("", "HighErrorRate") exists in base — update For.
+		{Alert: "HighErrorRate", Expr: "up == 0", For: "10m"},
+		// key ("job:errors:rate5m", "") is new — should be appended.
+		{Record: "job:errors:rate5m", Expr: "sum(rate(errors_total[5m])) by (job)"},
+	}
+
+	merged := mergeRules(base, patch)
+
+	require.Len(t, merged, 4, "base had 3 rules; patch updates 1 and appends 1")
+
+	byKey := make(map[ruleKey]Rule, len(merged))
+	for _, r := range merged {
+		byKey[keyOf(r)] = r
+	}
+
+	updated, ok := byKey[ruleKey{"", "HighErrorRate"}]
+	require.True(t, ok)
+	assert.Equal(t, "10m", updated.For, "HighErrorRate rule For must be updated")
+
+	_, ok = byKey[ruleKey{"", "LowDisk"}]
+	assert.True(t, ok, "LowDisk rule must survive as an unpatched base rule")
+
+	_, ok = byKey[ruleKey{"job:up:sum", ""}]
+	assert.True(t, ok, "job:up:sum rule must survive as an unpatched base rule")
+
+	_, ok = byKey[ruleKey{"job:errors:rate5m", ""}]
+	assert.True(t, ok, "job:errors:rate5m must be appended from the patch")
 }
 
 func loadVMRuleRulesSchema(t *testing.T) apiextensionsv1.JSONSchemaProps {

--- a/api/operator/v1beta1/vmrule_types_test.go
+++ b/api/operator/v1beta1/vmrule_types_test.go
@@ -1,9 +1,20 @@
 package v1beta1
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -182,4 +193,159 @@ spec:
           annotations: 
             description: "Service nginx on env test accepted {{$labels.requests}} requests in the last 5 minutes"`,
 	})
+}
+
+func TestVMRuleRulesRoundTripAndValidate(t *testing.T) {
+	src := VMRule{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operator.victoriametrics.com/v1beta1",
+			Kind:       "VMRule",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "round-trip",
+			Namespace: "default",
+		},
+		Spec: VMRuleSpec{
+			Groups: []RuleGroup{
+				{
+					Name: "group-a",
+					Rules: []Rule{
+						{
+							Alert: "HighErrorRate",
+							Expr:  "up == 0",
+							For:   "60s",
+						},
+						{
+							Record: "job:up:sum",
+							Expr:   "sum(up) by (job)",
+						},
+					},
+				},
+				{
+					Name: "group-b",
+					Rules: []Rule{
+						{
+							Alert: "LowDiskSpace",
+							Expr:  "node_filesystem_avail_bytes < 1024",
+						},
+						{
+							Record: "job:http_requests:rate5m",
+							Expr:   "sum(rate(http_requests_total[5m])) by (job)",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(&src)
+	require.NoError(t, err)
+
+	var got VMRule
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, src, got)
+	assert.NoError(t, got.Validate())
+}
+
+func TestVMRuleRulesCRDListMapKeys(t *testing.T) {
+	rulesSchema := loadVMRuleRulesSchema(t)
+	require.NotNil(t, rulesSchema.XListType)
+	assert.Equal(t, "map", *rulesSchema.XListType)
+	assert.Equal(t, []string{"record", "alert"}, rulesSchema.XListMapKeys)
+
+	rules := []Rule{
+		{Alert: "SharedRule", Expr: "up == 0"},
+		{Record: "shared_rule", Alert: "SharedRule", Expr: "sum(up)"},
+	}
+	ruleKeys := make(map[[2]string]struct{}, len(rules))
+	for _, rule := range rules {
+		ruleKeys[[2]string{rule.Record, rule.Alert}] = struct{}{}
+	}
+	assert.Len(t, ruleKeys, len(rules))
+}
+
+func TestVMRuleValidateDuplicateGroupNames(t *testing.T) {
+	vmr := VMRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "duplicate-groups",
+			Namespace: "default",
+		},
+		Spec: VMRuleSpec{
+			Groups: []RuleGroup{
+				{
+					Name:  "same",
+					Rules: []Rule{{Alert: "AlwaysDown", Expr: "up == 0"}},
+				},
+				{
+					Name:  "same",
+					Rules: []Rule{{Record: "job:up:sum", Expr: "sum(up) by (job)"}},
+				},
+			},
+		},
+	}
+
+	assert.ErrorContains(t, vmr.Validate(), "duplicate group name")
+}
+
+func TestVMRuleValidateSizeLimit(t *testing.T) {
+	vmr := VMRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "too-big",
+			Namespace: "default",
+		},
+		Spec: VMRuleSpec{
+			Groups: []RuleGroup{
+				{
+					Name: "too-big",
+					Rules: []Rule{
+						{
+							Alert: "TooBig",
+							Expr:  "up == 0",
+							Annotations: map[string]string{
+								"summary": strings.Repeat("x", MaxConfigMapDataSize),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.ErrorContains(t, vmr.Validate(), "exceed single rule limit")
+}
+
+func loadVMRuleRulesSchema(t *testing.T) apiextensionsv1.JSONSchemaProps {
+	t.Helper()
+
+	data, err := os.ReadFile("../../../config/crd/overlay/crd.yaml")
+	require.NoError(t, err)
+
+	decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewReader(data), 4096)
+	for {
+		var crd apiextensionsv1.CustomResourceDefinition
+		err := decoder.Decode(&crd)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if crd.Name != "vmrules.operator.victoriametrics.com" {
+			continue
+		}
+		for _, version := range crd.Spec.Versions {
+			if version.Name != "v1beta1" {
+				continue
+			}
+			require.NotNil(t, version.Schema)
+			require.NotNil(t, version.Schema.OpenAPIV3Schema)
+			spec := version.Schema.OpenAPIV3Schema.Properties["spec"]
+			groups := spec.Properties["groups"]
+			require.NotNil(t, groups.Items)
+			require.NotNil(t, groups.Items.Schema)
+			rules := groups.Items.Schema.Properties["rules"]
+			return rules
+		}
+	}
+
+	t.Fatal("VMRule v1beta1 schema not found")
+	return apiextensionsv1.JSONSchemaProps{}
 }

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -34551,6 +34551,10 @@ spec:
                             type: integer
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - record
+                      - alert
+                      x-kubernetes-list-type: map
                     tenant:
                       type: string
                     type:

--- a/config/crd/overlay/crd.descriptionless.yaml
+++ b/config/crd/overlay/crd.descriptionless.yaml
@@ -34528,6 +34528,7 @@ spec:
                       items:
                         properties:
                           alert:
+                            default: ""
                             type: string
                           annotations:
                             additionalProperties:
@@ -34546,6 +34547,7 @@ spec:
                               type: string
                             type: object
                           record:
+                            default: ""
                             type: string
                           update_entries_limit:
                             type: integer

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ aliases:
 ## [v0.72.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.72.0)
 **Release date:** 15 June 2026
 
+* FEATURE: [vmrule](https://docs.victoriametrics.com/operator/resources/vmrule/): add strategic-merge list semantics for rules using `record` and `alert` as merge keys. See [#657](https://github.com/VictoriaMetrics/operator/issues/657).
+
 **Update note 1**: [vmalert](https://docs.victoriametrics.com/operator/resources/vmalert/): rule ConfigMaps now store gzip-compressed content in `binaryData` and an init container decompresses them before VMAlert starts. Existing VMAlert pods will be rolled out once during this upgrade.
 
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): add validating webhooks for Prometheus Operator CRDs (`ServiceMonitor`, `PodMonitor`, `PrometheusRule`, `Probe`, `ScrapeConfig`, `AlertmanagerConfig`). Each object is converted to its VM equivalent and validated when webhooks are enabled. See [#2270](https://github.com/VictoriaMetrics/operator/issues/2270).

--- a/docs/api.md
+++ b/docs/api.md
@@ -3064,7 +3064,7 @@ Appears in: [VMRuleSpec](#vmrulespec)
 | name<a href="#rulegroup-name" id="rulegroup-name">#</a><br/>_string_ | _(Required)_<br/>Name of group |
 | notifier_headers<a href="#rulegroup-notifier_headers" id="rulegroup-notifier_headers">#</a><br/>_string array_ | _(Optional)_<br/>NotifierHeaders contains optional HTTP headers added to each alert request which will send to notifier<br />Must be in form `header-name: value`<br />For example:<br /> headers:<br />   - "CustomHeader: foo"<br />   - "CustomHeader2: bar" |
 | params<a href="#rulegroup-params" id="rulegroup-params">#</a><br/>_[Values](https://pkg.go.dev/net/url#Values)_ | _(Optional)_<br/>Params optional HTTP URL parameters added to each rule request |
-| rules<a href="#rulegroup-rules" id="rulegroup-rules">#</a><br/>_[Rule](#rule) array_ | _(Required)_<br/>Rules list of alert rules |
+| rules<a href="#rulegroup-rules" id="rulegroup-rules">#</a><br/>_[Rule](#rule) array_ | _(Required)_<br/>Rules list of alert rules.<br />Rules are merged by record and alert fields. |
 | tenant<a href="#rulegroup-tenant" id="rulegroup-tenant">#</a><br/>_string_ | _(Optional)_<br/>Tenant id for group, can be used only with enterprise version of vmalert.<br />See more details [here](https://docs.victoriametrics.com/victoriametrics/vmalert/#multitenancy). |
 | type<a href="#rulegroup-type" id="rulegroup-type">#</a><br/>_string_ | _(Optional)_<br/>Type defines datasource type for enterprise version of vmalert<br />possible values - prometheus,graphite,vlogs |
 


### PR DESCRIPTION
## Summary

Adds a `+listMapKey=alert` marker to the `VMRule` `rules` array so Kubernetes server-side apply merges rule entries by key instead of replacing the whole list, preventing rules from clobbering each other on partial applies.

## Why this matters

`VMRule.spec.groups[].rules` was a plain list with no `listMapKey`, so a server-side apply that touched one rule replaced the entire `rules` array, dropping rules managed by other appliers (#657). Marking the list with its identifying key lets the API server do a structured merge. The change is in `api/operator/v1beta1/vmrule_types.go` with the regenerated CRD in `config/crd/overlay/crd.yaml`, plus a unit test and `docs/api.md` / `docs/CHANGELOG.md` updates.

## Testing

- Added a unit test asserting the merge-key marker is present on the rules field.
- `go build` and `go vet` pass on the `api` module; the CRD overlay regenerates cleanly.

Closes #657

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `VMRule.spec.groups[].rules` a map-style list keyed by `record` and `alert` so server-side apply merges rules by key instead of replacing the list. Adds XOR validation and defaults for `record`/`alert` to prevent invalid specs and rule clobbering (fixes #657).

- **Bug Fixes**
  - Marked `RuleGroup.rules` with `+listType=map`, `+listMapKey=record`, `+listMapKey=alert`; set `Rule.record`/`Rule.alert` defaults to `""`; regenerated CRDs with `x-kubernetes-list-type`, `x-kubernetes-list-map-keys`, and defaults; updated `docs/api.md` and `docs/CHANGELOG.md`.
  - Enforced validation: error if both `record` and `alert` are set, or neither.
  - Added tests for CRD schema markers and JSON field names, JSON round-trip/validation, composite-key SSA merges for rules, and traditional SMP merge-by-name behavior for groups.

<sup>Written for commit 7d0ebe1d35633c642bcfe3ed021dc580ebef9ab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

