### PR TITLE
e2e: move e2e to separate workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,17 +44,20 @@ permissions: {}
 jobs:
   build:
     name: Build and Test
-    runs-on:  vm-runner
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
       checks: write
+    outputs:
+      run_e2e: ${{ steps.changes.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
+
       - name: Setup build environment
         id: setup
         uses: ./.github/actions/setup-build-env
@@ -74,10 +77,6 @@ jobs:
 
       - name: Lint, Test and Build
         if: github.event.pull_request.draft == false
-        env:
-          DOCKER_BUILD_ARGS: --cache-from=type=gha --cache-to=type=gha,mode=max
-          TAG: ${{ steps.setup.outputs.image-tag }}
-          LICENSE_KEY: ${{ secrets.ENTERPRISE_COMPONENTS_LICENSE_KEY }}
         run: |
           make lint
           make manifests
@@ -86,8 +85,50 @@ jobs:
           # check for uncommited changes to crds, docs or API
           git diff --exit-code
           make test
-          git fetch origin ${{ github.base_ref || 'master' }}
-          BASE_REF=origin/${{ github.base_ref || 'master' }} TAG=${TAG} make test-e2e
+
+      - name: Save Go cache
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: ./.github/actions/save-go-cache
+
+      - name: Check changed files
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        id: changes
+        with:
+          filters: |
+            src:
+              - '**'
+              - '!Makefile'
+
+  e2e:
+    name: E2E / ${{ matrix.name }}
+    needs: build
+    if: github.event.pull_request.draft == false && needs.build.outputs.run_e2e == 'true'
+    runs-on: vm-runner
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: main
+            e2e_target: ./test/e2e/
+          - name: upgrade
+            e2e_target: ./test/e2e/upgrade/...
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Setup build environment
+        id: setup
+        uses: ./.github/actions/setup-build-env
+      - name: E2E Tests
+        env:
+          DOCKER_BUILD_ARGS: --cache-from=type=gha --cache-to=type=gha,mode=max
+          LICENSE_KEY: ${{ secrets.ENTERPRISE_COMPONENTS_LICENSE_KEY }}
+          E2E_TARGET: ${{ matrix.e2e_target }}
+        run: |
+          TAG=${GITHUB_SHA:0:7} BASE_REF=origin/${{ github.base_ref || 'master' }} make test-e2e
       - name: Save Go cache
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: ./.github/actions/save-go-cache

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ VERSION ?= $(if $(findstring $(TAG),$(TAG:v%=%)),0.0.0,$(TAG:v%=%))
 DATEINFO_TAG ?= $(shell date -u +'%Y%m%d-%H%M%S')
 NAMESPACE ?= vm
 OVERLAY ?= config/manager
-E2E_TESTS_CONCURRENCY ?= $(shell getconf _NPROCESSORS_ONLN)
-E2E_TARGET ?= ./test/e2e/...
 FIPS_VERSION=v1.0.0
 BASEIMAGE ?=scratch
 
@@ -59,6 +57,7 @@ export FLAGS_HEADER
 
 include docs/Makefile
 include codespell/Makefile
+include test/Makefile
 
 .PHONY: all
 all: build
@@ -161,21 +160,6 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 	cd api/ && go test ./operator/...
-
-# Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
-.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
-test-e2e: load-kind ginkgo crust-gather mirrord
-	env CGO_ENABLED=1 OPERATOR_IMAGE=$(OPERATOR_IMAGE) CONFIG_RELOADER_IMAGE=$(CONFIG_RELOADER_IMAGE) REPORTS_DIR=$(shell pwd) CRUST_GATHER_BIN=$(CRUST_GATHER_BIN) $(MIRRORD_BIN) exec -f ./mirrord.json -- $(GINKGO_BIN) \
-		-ldflags="-linkmode=external" \
-		--output-interceptor-mode=none \
-		-procs=$(E2E_TESTS_CONCURRENCY) \
-		-randomize-all \
-		-timeout=60m \
-		-junit-report=report.xml $(E2E_TARGET)
-
-.PHONY: test-e2e-upgrade  # Run only the e2e upgrade tests against a Kind k8s instance that is spun up.
-test-e2e-upgrade: E2E_TARGET=./test/e2e/upgrade/...
-test-e2e-upgrade: test-e2e
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
@@ -345,30 +329,6 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build $(OVERLAY) | $(KUBECTL) delete $(if $(NAMESPACE),-n $(NAMESPACE),) --ignore-not-found=$(or $(ignore-not-found),false) -f -
 
-# builds image and loads it into kind.
-ensure-kind-cluster: kind
-	if [ "`$(KIND) get clusters`" != "kind" ]; then \
-		$(KIND) create cluster --config=./kind.yaml; \
-	else \
-		$(KUBECTL) cluster-info --context kind-kind; \
-	fi
-
-load-kind: docker-build docker-build-config-reloader ensure-kind-cluster
-	if [ "$(CONTAINER_TOOL)" != "podman" ]; then \
-		$(KIND) load docker-image $(REGISTRY)/$(ORG)/$(REPO):$(TAG); \
-		$(KIND) load docker-image $(CONFIG_RELOADER_IMAGE); \
-	fi
-
-deploy-kind: OVERLAY=config/base-with-webhook
-deploy-kind: load-kind deploy
-
-# deploy-kind-no-build skips docker-build/load — use when image is already loaded (e.g. from test-e2e's load-kind dep)
-deploy-kind-no-build: OVERLAY=config/base-with-webhook
-deploy-kind-no-build: ensure-kind-cluster deploy
-
-undeploy-kind: OVERLAY=config/base-with-webhook-no-crd
-undeploy-kind: ensure-kind-cluster undeploy
-
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
@@ -383,14 +343,10 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 CLIENT_GEN = $(LOCALBIN)/client-gen-$(CODEGENERATOR_VERSION)
 LISTER_GEN = $(LOCALBIN)/lister-gen-$(CODEGENERATOR_VERSION)
 INFORMER_GEN = $(LOCALBIN)/informer-gen-$(CODEGENERATOR_VERSION)
-KIND = $(LOCALBIN)/kind-$(KIND_VERSION)
 OPERATOR_SDK = $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
 OPM = $(LOCALBIN)/opm-$(OPM_VERSION)
 YQ = $(LOCALBIN)/yq-$(YQ_VERSION)
 CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs-$(CRD_REF_DOCS_VERSION)
-GINKGO_BIN ?= $(LOCALBIN)/ginkgo-$(GINKGO_VERSION)
-CRUST_GATHER_BIN ?= $(LOCALBIN)/crust-gather-$(CRUST_GATHER_VERSION)
-MIRRORD_BIN ?= $(LOCALBIN)/mirrord-$(MIRRORD_VERSION)
 COSIGN_BIN ?= $(LOCALBIN)/cosign-$(COSIGN_VERSION)
 
 ## Tool Versions
@@ -399,15 +355,10 @@ CONTROLLER_TOOLS_VERSION ?= v0.21.0
 ENVTEST_VERSION ?= release-0.23
 GOLANGCI_LINT_VERSION ?= v2.12.2
 CODEGENERATOR_VERSION ?= v0.36.2
-KIND_VERSION ?= v0.32.0
 OLM_VERSION ?= 0.45.0
-
 OPERATOR_SDK_VERSION ?= v1.42.2
 OPM_VERSION ?= v1.72.0
 YQ_VERSION ?= v4.53.3
-GINKGO_VERSION ?= v2.31.0
-CRUST_GATHER_VERSION ?= v0.15.2
-MIRRORD_VERSION ?= 3.217.1
 COSIGN_VERSION ?= v3.1.1
 
 CRD_REF_DOCS_VERSION ?= 4deb8b1eb0169ac22ac5d777feaeb26a00e38a33
@@ -423,7 +374,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: install-tools
-install-tools: crd-ref-docs client-gen lister-gen informer-gen controller-gen kustomize envtest ginkgo
+install-tools: crd-ref-docs client-gen lister-gen informer-gen controller-gen kustomize envtest
 
 .PHONY: crd-ref-docs
 crd-ref-docs: $(CRD_REF_DOCS)
@@ -435,10 +386,6 @@ $(CRD_REF_DOCS): $(LOCALBIN)
 client-gen: $(CLIENT_GEN)
 $(CLIENT_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CLIENT_GEN),k8s.io/code-generator/cmd/client-gen,$(CODEGENERATOR_VERSION))
-
-.PHONY: ginkgo
-ginkgo:
-	$(call go-install-tool,$(GINKGO_BIN),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
 .PHONY: lister-gen
 lister-gen: $(LISTER_GEN)
@@ -471,11 +418,6 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
-.PHONY: kind
-kind: $(KIND)
-$(KIND): $(LOCALBIN)
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,$(KIND_VERSION))
-
 .PHONY: yq
 yq: $(YQ)
 $(YQ): $(LOCALBIN)
@@ -484,21 +426,6 @@ $(YQ): $(LOCALBIN)
 UNAME_S=$(shell uname -s 2>/dev/null)
 OS=$(shell echo $(UNAME_S) | tr A-Z a-z)
 ARCH=$(if $(filter x86_64,$(shell uname -m 2>/dev/null)),amd64,arm64)
-MIRRORD_OS=$(if $(filter darwin,$(OS)),mac,linux)
-MIRRORD_ARCH=$(if $(filter mac,$(MIRRORD_OS)),universal,$(if $(filter x86_64,$(shell uname -m 2>/dev/null)),x86_64,aarch64))
-.PHONY: crust-gather
-crust-gather: $(CRUST_GATHER_BIN)
-$(CRUST_GATHER_BIN): $(LOCALBIN)
-	$(call download-github-release,$(CRUST_GATHER_BIN),crust-gather/crust-gather,$(CRUST_GATHER_VERSION),kubectl-crust-gather_$(CRUST_GATHER_VERSION)_$(OS)_$(ARCH).tar.gz,kubectl-crust-gather)
-
-.PHONY: mirrord
-mirrord: $(MIRRORD_BIN)
-$(MIRRORD_BIN): $(LOCALBIN)
-	$(call download-github-release,$(MIRRORD_BIN),metalbear-co/mirrord,$(MIRRORD_VERSION),mirrord_$(MIRRORD_OS)_$(MIRRORD_ARCH).zip,mirrord)
-
-.PHONY: allure-report
-allure-report:
-	@[ -d ./allure-results ] && npx allure awesome --single-file ./allure-results -o ./allure-report || echo "allure-results dir not found, skipping report generation"
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/renovate.json
+++ b/renovate.json
@@ -87,7 +87,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Makefile$/"
+        "/^test\\/Makefile$/"
       ],
       "matchStrings": [
         "KIND_VERSION \\?= (?<currentValue>v.*)"
@@ -132,7 +132,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Makefile$/"
+        "/^test\\/Makefile$/"
       ],
       "matchStrings": [
         "GINKGO_VERSION \\?= (?<currentValue>v.*)"
@@ -143,7 +143,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Makefile$/"
+        "/^test\\/Makefile$/"
       ],
       "matchStrings": [
         "CRUST_GATHER_VERSION \\?= (?<currentValue>v.*)"
@@ -178,7 +178,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Makefile$/"
+        "/^test\\/Makefile$/"
       ],
       "matchStrings": [
         "MIRRORD_VERSION \\?= (?<currentValue>.*)"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,85 @@
+##@ E2E testing
+# Targets here require docker, a Kind cluster, or e2e test tooling.
+# Kept in a separate file so changes to e2e tool versions do not retrigger
+# the full CI workflow for ordinary source-code changes.
+# This file is included by the root Makefile.
+
+E2E_TESTS_CONCURRENCY ?= $(shell getconf _NPROCESSORS_ONLN)
+E2E_TARGET ?= ./test/e2e/...
+
+## Tool Binaries
+KIND = $(LOCALBIN)/kind-$(KIND_VERSION)
+GINKGO_BIN ?= $(LOCALBIN)/ginkgo-$(GINKGO_VERSION)
+CRUST_GATHER_BIN ?= $(LOCALBIN)/crust-gather-$(CRUST_GATHER_VERSION)
+MIRRORD_BIN ?= $(LOCALBIN)/mirrord-$(MIRRORD_VERSION)
+
+## Tool Versions
+KIND_VERSION ?= v0.32.0
+GINKGO_VERSION ?= v2.31.0
+CRUST_GATHER_VERSION ?= v0.15.2
+MIRRORD_VERSION ?= 3.217.1
+
+MIRRORD_OS=$(if $(filter darwin,$(OS)),mac,linux)
+MIRRORD_ARCH=$(if $(filter mac,$(MIRRORD_OS)),universal,$(if $(filter x86_64,$(shell uname -m 2>/dev/null)),x86_64,aarch64))
+
+# Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
+.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
+test-e2e: load-kind ginkgo crust-gather mirrord
+	env CGO_ENABLED=1 OPERATOR_IMAGE=$(OPERATOR_IMAGE) CONFIG_RELOADER_IMAGE=$(CONFIG_RELOADER_IMAGE) REPORTS_DIR=$(shell pwd) CRUST_GATHER_BIN=$(CRUST_GATHER_BIN) $(MIRRORD_BIN) exec -f ./mirrord.json -- $(GINKGO_BIN) \
+		-ldflags="-linkmode=external" \
+		--output-interceptor-mode=none \
+		-procs=$(E2E_TESTS_CONCURRENCY) \
+		-randomize-all \
+		-timeout=60m \
+		-junit-report=report.xml $(E2E_TARGET)
+
+.PHONY: test-e2e-upgrade  # Run only the e2e upgrade tests against a Kind k8s instance that is spun up.
+test-e2e-upgrade: E2E_TARGET=./test/e2e/upgrade/...
+test-e2e-upgrade: test-e2e
+
+# builds image and loads it into kind.
+ensure-kind-cluster: kind
+	if [ "`$(KIND) get clusters`" != "kind" ]; then \
+		$(KIND) create cluster --config=./kind.yaml; \
+	else \
+		$(KUBECTL) cluster-info --context kind-kind; \
+	fi
+
+load-kind: docker-build docker-build-config-reloader ensure-kind-cluster
+	if [ "$(CONTAINER_TOOL)" != "podman" ]; then \
+		$(KIND) load docker-image $(REGISTRY)/$(ORG)/$(REPO):$(TAG); \
+		$(KIND) load docker-image $(CONFIG_RELOADER_IMAGE); \
+	fi
+
+deploy-kind: OVERLAY=config/base-with-webhook
+deploy-kind: load-kind deploy
+
+# deploy-kind-no-build skips docker-build/load — use when image is already loaded (e.g. from test-e2e's load-kind dep)
+deploy-kind-no-build: OVERLAY=config/base-with-webhook
+deploy-kind-no-build: ensure-kind-cluster deploy
+
+undeploy-kind: OVERLAY=config/base-with-webhook-no-crd
+undeploy-kind: ensure-kind-cluster undeploy
+
+.PHONY: allure-report
+allure-report:
+	@[ -d ./allure-results ] && npx allure awesome --single-file ./allure-results -o ./allure-report || echo "allure-results dir not found, skipping report generation"
+
+.PHONY: ginkgo
+ginkgo:
+	$(call go-install-tool,$(GINKGO_BIN),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
+
+.PHONY: kind
+kind: $(KIND)
+$(KIND): $(LOCALBIN)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind,$(KIND_VERSION))
+
+.PHONY: crust-gather
+crust-gather: $(CRUST_GATHER_BIN)
+$(CRUST_GATHER_BIN): $(LOCALBIN)
+	$(call download-github-release,$(CRUST_GATHER_BIN),crust-gather/crust-gather,$(CRUST_GATHER_VERSION),kubectl-crust-gather_$(CRUST_GATHER_VERSION)_$(OS)_$(ARCH).tar.gz,kubectl-crust-gather)
+
+.PHONY: mirrord
+mirrord: $(MIRRORD_BIN)
+$(MIRRORD_BIN): $(LOCALBIN)
+	$(call download-github-release,$(MIRRORD_BIN),metalbear-co/mirrord,$(MIRRORD_VERSION),mirrord_$(MIRRORD_OS)_$(MIRRORD_ARCH).zip,mirrord)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move E2E tests to a dedicated GitHub Actions job that only runs on non-draft PRs when code changes (ignores the root `Makefile`). This speeds up CI and cleanly separates unit/integration from E2E.

- **CI Behavior**
  - Add separate `e2e` job (matrix: main, upgrade) on vm-runner; gated by `dorny/paths-filter`.
  - `build` runs on `ubuntu-latest`, sets `run_e2e` from changed files, and saves Go cache on `master`; `e2e` sets `TAG` from short SHA, uses `E2E_TARGET`, runs `make test-e2e`, and also saves the Go cache.

- **Refactors**
  - Move E2E targets, Kind helpers, and test tooling to `test/Makefile`; drop E2E tooling from the root `Makefile` and remove `ginkgo` from `install-tools`.
  - Update `renovate.json` to track E2E tool versions in `test/Makefile`.

<sup>Written for commit 765edb26dcf37d7aa289476a6f6c24c8e6807381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

