### PR TITLE
vmanomaly: fix marshalling of verify_tls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ aliases:
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): fix VPA scale subresource lookup failure when `spec.shardCount` is unset by always reporting at least 1 in `status.shards`. See [#2229](https://github.com/VictoriaMetrics/operator/issues/2229).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): fix HPA targeting the underlying Deployment/StatefulSet (pod replicas) instead of the VMAgent CR scale subresource (`spec.shardCount`); HPA now correctly scales the number of shards. See [#2229](https://github.com/VictoriaMetrics/operator/issues/2229).
 * BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): emit the `OnlineQuantileModel` smoothing parameter under its correct key `global_smoothing` instead of the unrecognized `global_smooth`, which vmanomaly silently ignored.
+* BUGFIX: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): pass the configured TLS CA bundle to the reader, writer and monitoring clients. Previously the CA was mounted as a volume but dropped during config generation, so a `tlsConfig` with only a CA produced no `verify_tls` reference to it; `insecureSkipVerify` is now also propagated correctly.
 
 ## [v0.70.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.70.0)
 **Release date:** 20 May 2026

--- a/internal/controller/operator/factory/vmanomaly/config/config.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config.go
@@ -443,9 +443,15 @@ type clientConfig struct {
 	Password        string    `yaml:"password,omitempty"`
 	BearerToken     string    `yaml:"bearer_token,omitempty"`
 	BearerTokenFile string    `yaml:"bearer_token_file,omitempty"`
-	VerifyTLS       bool      `yaml:"verify_tls,omitempty"`
-	TLSCertFile     string    `yaml:"tls_cert_file,omitempty"`
-	TLSKeyFile      string    `yaml:"tls_key_file,omitempty"`
+	// VerifyTLS mirrors vmanomaly's `verify_tls` option, which is overloaded:
+	// false disables verification, true uses the system CA store and a string
+	// is treated as a path to the CA bundle to verify against.
+	// See:
+	//   https://docs.victoriametrics.com/anomaly-detection/components/writer/#config-parameters
+	//   https://docs.victoriametrics.com/anomaly-detection/components/reader/#config-parameters
+	VerifyTLS   any    `yaml:"verify_tls,omitempty"`
+	TLSCertFile string `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile  string `yaml:"tls_key_file,omitempty"`
 }
 
 func (c *clientConfig) override(cr *vmv1.VMAnomaly, cfg *vmv1.VMAnomalyHTTPClientSpec, ac *build.AssetsCache) error {
@@ -456,7 +462,15 @@ func (c *clientConfig) override(cr *vmv1.VMAnomaly, cfg *vmv1.VMAnomalyHTTPClien
 		}
 		c.TLSCertFile = creds.CertFile
 		c.TLSKeyFile = creds.KeyFile
-		c.VerifyTLS = !cfg.TLSConfig.InsecureSkipVerify
+		switch {
+		case cfg.TLSConfig.InsecureSkipVerify:
+			c.VerifyTLS = false
+		case creds.CAFile != "":
+			// vmanomaly expects the CA bundle path to be passed via `verify_tls`.
+			c.VerifyTLS = creds.CAFile
+		default:
+			c.VerifyTLS = true
+		}
 	}
 	if cfg.BasicAuth != nil {
 		creds, err := ac.BuildBasicAuthCreds(cr.Namespace, cfg.BasicAuth)

--- a/internal/controller/operator/factory/vmanomaly/config/config_test.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config_test.go
@@ -319,6 +319,212 @@ server:
 `,
 	})
 
+	// TLS without a CA bundle and InsecureSkipVerify=false => verify_tls: true
+	f(opts{
+		cr: &vmv1.VMAnomaly{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-anomaly",
+				Namespace: "monitoring",
+			},
+			Spec: vmv1.VMAnomalySpec{
+				License: &vmv1beta1.License{
+					Key: ptr.To("test"),
+				},
+				ConfigRawYaml: `
+models:
+  model_zscore:
+    class: 'zscore'
+    z_threshold: 2.5
+    queries: ['test_query']
+schedulers:
+  scheduler_1m:
+    class: "scheduler.periodic.PeriodicScheduler"
+    infer_every: 1m
+    fit_every: 2m
+    fit_window: 3h
+reader:
+  queries:
+    test_query:
+      expr: vm_metric
+writer:
+  datasource_url: "http://test.com"
+`,
+				Reader: &vmv1.VMAnomalyReadersSpec{
+					DatasourceURL:  "http://reader.test",
+					SamplingPeriod: "30s",
+					VMAnomalyHTTPClientSpec: vmv1.VMAnomalyHTTPClientSpec{
+						TLSConfig: &vmv1beta1.TLSConfig{
+							Cert: vmv1beta1.SecretOrConfigMap{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "tls"},
+									Key:                  "cert",
+								},
+							},
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "tls"},
+								Key:                  "key",
+							},
+						},
+					},
+				},
+				Writer: &vmv1.VMAnomalyWritersSpec{
+					DatasourceURL: "http://writer.test",
+				},
+			},
+		},
+		predefinedObjects: []runtime.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls",
+					Namespace: "monitoring",
+				},
+				Data: map[string][]byte{
+					"cert": []byte("cert"),
+					"key":  []byte("key"),
+				},
+			},
+		},
+		expected: `
+models:
+  model_zscore:
+    class: zscore
+    queries:
+    - test_query
+    z_threshold: 2.5
+schedulers:
+  scheduler_1m:
+    class: scheduler.periodic.PeriodicScheduler
+    fit_every: 2m
+    fit_window: 3h
+    infer_every: 1m
+reader:
+  class: vm
+  datasource_url: http://reader.test
+  sampling_period: 30s
+  queries:
+    test_query:
+      expr: vm_metric
+  verify_tls: true
+  tls_cert_file: /test/monitoring_tls_cert
+  tls_key_file: /test/monitoring_tls_key
+writer:
+  class: vm
+  datasource_url: http://writer.test
+monitoring:
+  pull:
+    port: "8080"
+server:
+  port: "8490"
+`,
+	})
+
+	// InsecureSkipVerify=true takes precedence over a provided CA => verify_tls: false
+	f(opts{
+		cr: &vmv1.VMAnomaly{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-anomaly",
+				Namespace: "monitoring",
+			},
+			Spec: vmv1.VMAnomalySpec{
+				License: &vmv1beta1.License{
+					Key: ptr.To("test"),
+				},
+				ConfigRawYaml: `
+models:
+  model_zscore:
+    class: 'zscore'
+    z_threshold: 2.5
+    queries: ['test_query']
+schedulers:
+  scheduler_1m:
+    class: "scheduler.periodic.PeriodicScheduler"
+    infer_every: 1m
+    fit_every: 2m
+    fit_window: 3h
+reader:
+  queries:
+    test_query:
+      expr: vm_metric
+writer:
+  datasource_url: "http://test.com"
+`,
+				Reader: &vmv1.VMAnomalyReadersSpec{
+					DatasourceURL:  "http://reader.test",
+					SamplingPeriod: "30s",
+					VMAnomalyHTTPClientSpec: vmv1.VMAnomalyHTTPClientSpec{
+						TLSConfig: &vmv1beta1.TLSConfig{
+							InsecureSkipVerify: true,
+							CA: vmv1beta1.SecretOrConfigMap{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "tls"},
+									Key:                  "ca",
+								},
+							},
+							Cert: vmv1beta1.SecretOrConfigMap{
+								Secret: &corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "tls"},
+									Key:                  "cert",
+								},
+							},
+							KeySecret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "tls"},
+								Key:                  "key",
+							},
+						},
+					},
+				},
+				Writer: &vmv1.VMAnomalyWritersSpec{
+					DatasourceURL: "http://writer.test",
+				},
+			},
+		},
+		predefinedObjects: []runtime.Object{
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls",
+					Namespace: "monitoring",
+				},
+				Data: map[string][]byte{
+					"ca":   []byte("ca"),
+					"cert": []byte("cert"),
+					"key":  []byte("key"),
+				},
+			},
+		},
+		expected: `
+models:
+  model_zscore:
+    class: zscore
+    queries:
+    - test_query
+    z_threshold: 2.5
+schedulers:
+  scheduler_1m:
+    class: scheduler.periodic.PeriodicScheduler
+    fit_every: 2m
+    fit_window: 3h
+    infer_every: 1m
+reader:
+  class: vm
+  datasource_url: http://reader.test
+  sampling_period: 30s
+  queries:
+    test_query:
+      expr: vm_metric
+  verify_tls: false
+  tls_cert_file: /test/monitoring_tls_cert
+  tls_key_file: /test/monitoring_tls_key
+writer:
+  class: vm
+  datasource_url: http://writer.test
+monitoring:
+  pull:
+    port: "8080"
+server:
+  port: "8490"
+`,
+	})
+
 	// with settings including retention
 	f(opts{
 		cr: &vmv1.VMAnomaly{

--- a/internal/controller/operator/factory/vmanomaly/config/config_test.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config_test.go
@@ -284,7 +284,7 @@ reader:
       - "0"
       - inf
   tenant_id: "0:1"
-  verify_tls: true
+  verify_tls: /test/monitoring_tls_remote-ca
   tls_cert_file: /test/monitoring_tls_remote-cert
   tls_key_file: /test/monitoring_tls_remote-key
 writer:
@@ -297,7 +297,7 @@ writer:
     label2: value2
   connection_retry_attempts: 3
   tenant_id: "0:2"
-  verify_tls: true
+  verify_tls: /test/monitoring_tls_remote-ca
   tls_cert_file: /test/monitoring_tls_remote-cert
   tls_key_file: /test/monitoring_tls_remote-key
 monitoring:
@@ -306,7 +306,7 @@ monitoring:
   push:
     url: http://monitoring
     tenant_id: "0:3"
-    verify_tls: true
+    verify_tls: /test/monitoring_tls_remote-ca
     tls_cert_file: /test/monitoring_tls_remote-cert
     tls_key_file: /test/monitoring_tls_remote-key
     push_frequency: 20s


### PR DESCRIPTION
Sync behaviour of "verify_tls" with vmanomaly itself: accept 3 values: true / false / path to CA to be used for verification.
See:
https://docs.victoriametrics.com/anomaly-detection/components/writer/#config-parameters
https://docs.victoriametrics.com/anomaly-detection/components/reader/#config-parameters