### PR TITLE
docs: fix stale setup and contribution notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ make build # it will update crds
 make lint # linting project
 make test #unit tests
 make docs # update docs - needed to pass CI if updating API types
-make test-e2e #e2e tests with minikube
+make test-e2e #e2e tests with Kind
 ```
 
 ## adding new api

--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	$(KUSTOMIZE) build config/base-with-webhook > dist/install-with-webhook.yaml
 	$(KUSTOMIZE) build config/crd/overlay > dist/crd.yaml
 
+# Generate and validate the OLM bundle
 olm: operator-sdk yq docs
 	$(eval DIGEST = $(shell $(CONTAINER_TOOL) buildx imagetools inspect $(REGISTRY)/$(ORG)/$(REPO):$(TAG)-ubi --format "{{print .Manifest.Digest}}"))
 	rm -rf bundle*
@@ -373,6 +374,7 @@ controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessar
 $(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
+# Install the local development toolchain used by build, test, and docs targets.
 .PHONY: install-tools
 install-tools: crd-ref-docs client-gen lister-gen informer-gen controller-gen kustomize envtest
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -157,8 +157,7 @@ oc get pods -n vm
 
 ### Run locally
 
-It's possible to build and run OLM package locally on Kind K8s cluster using `make deploy-kind-olm`.
-Command builds operator image, bundle and index images, runs Kind with a local registry and deploys OLM package to Kind.
+OLM bundles for published releases are produced by the release workflow.
 
 ## CPU architectures
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,7 @@ test-e2e: load-kind ginkgo crust-gather mirrord
 test-e2e-upgrade: E2E_TARGET=./test/e2e/upgrade/...
 test-e2e-upgrade: test-e2e
 
-# builds image and loads it into kind.
+# Create the local Kind cluster if it doesn't exist
 ensure-kind-cluster: kind
 	if [ "`$(KIND) get clusters`" != "kind" ]; then \
 		$(KIND) create cluster --config=./kind.yaml; \
@@ -45,19 +45,22 @@ ensure-kind-cluster: kind
 		$(KUBECTL) cluster-info --context kind-kind; \
 	fi
 
+# Build operator images and load them into the local Kind cluster
 load-kind: docker-build docker-build-config-reloader ensure-kind-cluster
 	if [ "$(CONTAINER_TOOL)" != "podman" ]; then \
 		$(KIND) load docker-image $(REGISTRY)/$(ORG)/$(REPO):$(TAG); \
 		$(KIND) load docker-image $(CONFIG_RELOADER_IMAGE); \
 	fi
 
+# Build images, load them into Kind, and deploy the operator with webhooks
 deploy-kind: OVERLAY=config/base-with-webhook
 deploy-kind: load-kind deploy
 
-# deploy-kind-no-build skips docker-build/load — use when image is already loaded (e.g. from test-e2e's load-kind dep)
+# Deploy to the local Kind cluster without rebuilding or reloading images
 deploy-kind-no-build: OVERLAY=config/base-with-webhook
 deploy-kind-no-build: ensure-kind-cluster deploy
 
+# Remove the operator from the local Kind cluster without deleting CRDs
 undeploy-kind: OVERLAY=config/base-with-webhook-no-crd
 undeploy-kind: ensure-kind-cluster undeploy
 


### PR DESCRIPTION
This cleans up a few stale setup notes.

Bug
- `docs/setup.md` told users to run `make deploy-kind-olm`, but that target is gone
- `CONTRIBUTING.md` said `make test-e2e` uses minikube, while the Makefile runs Kind
- `make help` did not list `install-tools` and the Kind targets that the docs point people to

Fix
- remove the stale `deploy-kind-olm` instruction
- update the `test-e2e` note to Kind
- add help text for `install-tools`, `olm`, and the Kind helper targets

Repro
1. Check out current `master`
2. Run `make deploy-kind-olm`
3. It blows up with `make: *** No rule to make target 'deploy-kind-olm'. Stop.`
4. Run `make help`
5. `deploy-kind` and `install-tools` are missing there too

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up stale setup and contribution notes and aligns docs with the current Kind-based workflow. Adds clearer target descriptions for local Kind and tooling tasks.

- **Bug Fixes**
  - Removed `deploy-kind-olm` instructions from `docs/setup.md`; clarified that release workflow produces OLM bundles.
  - Updated `CONTRIBUTING.md` to note `make test-e2e` runs on Kind.
  - Added descriptions for `install-tools`, `olm`, and Kind targets: `ensure-kind-cluster`, `load-kind`, `deploy-kind`, `deploy-kind-no-build`, `undeploy-kind`.

<sup>Written for commit 53f1c20b38b004887732ed13c895c184eb2bc6b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

