### PR TITLE
docs: fix broken Prometheus migration image path

### DIFF
--- a/docs/integrations/prometheus.md
+++ b/docs/integrations/prometheus.md
@@ -64,7 +64,7 @@ operator:
 
 Otherwise, VictoriaMetrics Operator would try to discover prometheus-operator API and convert it.
 
-![migration from prometheus](./migration_prometheus-conversion.webp)
+![migration from prometheus](../migration_prometheus-conversion.webp)
 
 For more information about the operator's workflow, see [this doc](https://docs.victoriametrics.com/operator/).
 


### PR DESCRIPTION
tiny docs fix.

the Prometheus integration page had a broken image path, so the migration diagram was missing.

repro:
1. open `docs/integrations/prometheus.md`
2. the image points to `./migration_prometheus-conversion.webp`
3. that resolves to `docs/integrations/migration_prometheus-conversion.webp`, and that file does not exist

this switches it to `../migration_prometheus-conversion.webp`, which points to the real file at `docs/migration_prometheus-conversion.webp`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing migration diagram on the Prometheus integration page by changing the image path from `./migration_prometheus-conversion.webp` to `../migration_prometheus-conversion.webp`, so it resolves to `docs/migration_prometheus-conversion.webp`.

<sup>Written for commit 674fc766b1e0bc9de4bf352e471333c70740dbf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

