### PR TITLE
Update VictoriaLogs Docker image tag from v1.50.0 to v1.51.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.51.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.51.0).
+
 ## [v0.72.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.72.0)
 **Release date:** 15 June 2026
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,7 +1,7 @@
 | Environment variables |
 | --- |
 | VM_METRICS_VERSION: `v1.145.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a><br>Defines default image version for VictoriaMetrics components: VMSingle, VMCluster (vmselect/vminsert/vmstorage), VMAgent, VMAlert, VMAuth, VMBackup. Used as the image tag when no explicit version is set in the CR spec. |
-| VM_LOGS_VERSION: `v1.50.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a><br>Defines default image version for VictoriaLogs components: VLogs, VLAgent, VLSingle, VLCluster (vlselect/vlinsert/vlstorage). Used as the image tag when no explicit version is set in the CR spec. |
+| VM_LOGS_VERSION: `v1.51.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a><br>Defines default image version for VictoriaLogs components: VLogs, VLAgent, VLSingle, VLCluster (vlselect/vlinsert/vlstorage). Used as the image tag when no explicit version is set in the CR spec. |
 | VM_ANOMALY_VERSION: `v1.29.3` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a><br>Defines default image version for VMAnomaly. Used as the image tag when no explicit version is set in the CR spec. |
 | VM_TRACES_VERSION: `v0.7.0` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a><br>Defines default image version for VictoriaTraces components: VTSingle, VTCluster (vtselect/vtinsert/vtstorage). Used as the image tag when no explicit version is set in the CR spec. |
 | VM_OPERATOR_VERSION: `v0.72.0` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a><br>Defines the operator's own version. Used for config-reloader image tag interpolation. |

--- a/docs/resources/vlagent.md
+++ b/docs/resources/vlagent.md
@@ -77,7 +77,7 @@ metadata:
 spec:
   image:
     repository: victoriametrics/vlagent
-    tag: v1.50.0
+    tag: v1.51.0
     pullPolicy: Always
 ```
 
@@ -91,7 +91,7 @@ metadata:
 spec:
   image:
     repository: victoriametrics/vlagent
-    tag: v1.50.0
+    tag: v1.51.0
     pullPolicy: Always
   imagePullSecrets:
     - name: my-repo-secret

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ var (
 
 	defaultEnvs = map[string]string{
 		"VM_METRICS_VERSION":  "v1.145.0",
-		"VM_LOGS_VERSION":     "v1.50.0",
+		"VM_LOGS_VERSION":     "v1.51.0",
 		"VM_ANOMALY_VERSION":  "v1.29.3",
 		"VM_TRACES_VERSION":   "v0.7.0",
 		"VM_OPERATOR_VERSION": getVersion("v0.72.0"),

--- a/internal/controller/operator/factory/vlagent/vlagent_test.go
+++ b/internal/controller/operator/factory/vlagent/vlagent_test.go
@@ -1091,7 +1091,7 @@ serviceaccountname: vlagent-agent
 		Spec: vmv1.VLAgentSpec{
 			CommonAppsParams: vmv1beta1.CommonAppsParams{
 				Image: vmv1beta1.Image{
-					Tag: "v1.50.0",
+					Tag: "v1.51.0",
 				},
 				UseDefaultResources: ptr.To(false),
 				Port:                "9425",
@@ -1117,7 +1117,7 @@ serviceaccountname: vlagent-agent
 	}, []runtime.Object{}, `
 containers:
   - name: vlagent
-    image: victoriametrics/vlagent:v1.50.0
+    image: victoriametrics/vlagent:v1.51.0
     args:
       - -httpListenAddr=:9425
       - -kubernetesCollector


### PR DESCRIPTION
See https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.51.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the default VictoriaLogs image tag from v1.50.0 to v1.51.0 so the operator deploys the latest release by default. Updates `VM_LOGS_VERSION` and `vlagent` examples/tests to `v1.51.0`.

- **Migration**
  - No action needed if you use defaults.
  - To pin another version, set `VM_LOGS_VERSION` or the CR `image.tag`.

<sup>Written for commit 0b96a84ba39e30da34562941c13b62b7a8a45199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

