### PR TITLE
fix: handle config-reloader secret watch tombstones

### DIFF
--- a/cmd/config-reloader/k8s_watch.go
+++ b/cmd/config-reloader/k8s_watch.go
@@ -78,7 +78,11 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 	syncChan := make(chan syncEvent, 10)
 	if _, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			s := obj.(*corev1.Secret)
+			s, ok := secretFromEvent(obj)
+			if !ok {
+				logger.Errorf("cannot process create event for unexpected object type %T", obj)
+				return
+			}
 			select {
 			case syncChan <- syncEvent{op: "create", obj: s}:
 			default:
@@ -86,7 +90,11 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			s := newObj.(*corev1.Secret)
+			s, ok := secretFromEvent(newObj)
+			if !ok {
+				logger.Errorf("cannot process update event for unexpected object type %T", newObj)
+				return
+			}
 			select {
 			case syncChan <- syncEvent{op: "update", obj: s}:
 			default:
@@ -94,7 +102,11 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			s := obj.(*corev1.Secret)
+			s, ok := secretFromEvent(obj)
+			if !ok {
+				logger.Errorf("cannot process delete event for unexpected object type %T", obj)
+				return
+			}
 			select {
 			case syncChan <- syncEvent{op: "delete", obj: s}:
 			default:
@@ -106,6 +118,21 @@ func newKubernetesWatcher(ctx context.Context, secretName, namespace string) (*k
 	}
 
 	return &k8sWatcher{inf: inf, c: c, events: syncChan, namespace: namespace, secretName: secretName}, nil
+}
+
+func secretFromEvent(obj interface{}) (*corev1.Secret, bool) {
+	switch s := obj.(type) {
+	case *corev1.Secret:
+		return s, true
+	case cache.DeletedFinalStateUnknown:
+		secret, ok := s.Obj.(*corev1.Secret)
+		return secret, ok
+	case *cache.DeletedFinalStateUnknown:
+		secret, ok := s.Obj.(*corev1.Secret)
+		return secret, ok
+	default:
+		return nil, false
+	}
 }
 
 var errNotModified = fmt.Errorf("file content not modified")

--- a/cmd/config-reloader/k8s_watch_test.go
+++ b/cmd/config-reloader/k8s_watch_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestSecretFromEvent(t *testing.T) {
+	secret := &corev1.Secret{}
+
+	t.Run("secret object", func(t *testing.T) {
+		got, ok := secretFromEvent(secret)
+		if !ok {
+			t.Fatal("expected secret object to be accepted")
+		}
+		if got != secret {
+			t.Fatal("expected original secret pointer to be returned")
+		}
+	})
+
+	t.Run("deleted final state unknown value", func(t *testing.T) {
+		got, ok := secretFromEvent(cache.DeletedFinalStateUnknown{Obj: secret})
+		if !ok {
+			t.Fatal("expected tombstone value to be accepted")
+		}
+		if got != secret {
+			t.Fatal("expected tombstone secret pointer to be returned")
+		}
+	})
+
+	t.Run("deleted final state unknown pointer", func(t *testing.T) {
+		got, ok := secretFromEvent(&cache.DeletedFinalStateUnknown{Obj: secret})
+		if !ok {
+			t.Fatal("expected tombstone pointer to be accepted")
+		}
+		if got != secret {
+			t.Fatal("expected tombstone secret pointer to be returned")
+		}
+	})
+
+	t.Run("unexpected type", func(t *testing.T) {
+		if _, ok := secretFromEvent("not-a-secret"); ok {
+			t.Fatal("expected unexpected object type to be rejected")
+		}
+	})
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* BUGFIX: [config-reloader](https://docs.victoriametrics.com/operator/): fix possible panic on Secret watch events when the informer's local cache fell out of sync and Kubernetes delivered a stale tombstone entry instead of the Secret object. The config-reloader now unwraps tombstones correctly and logs an error for any other unexpected types.
+
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.51.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.51.0).
 
 ## [v0.72.0](https://github.com/VictoriaMetrics/operator/releases/tag/v0.72.0)


### PR DESCRIPTION
this fixes a small crash in `config-reloader`.

when the secret informer misses a delete event and catches it on relist, `client-go` can send `cache.DeletedFinalStateUnknown` to `DeleteFunc`. current code does `obj.(*corev1.Secret)` and panics, so the reloader falls over.

fix is pretty small:
- unwrap tombstones before queueing secret events
- keep the normal `*corev1.Secret` path the same
- add a unit test for raw secret and tombstone payloads

repro:
1. run the secret informer in `cmd/config-reloader`
2. let the watch close and miss a Secret delete
3. on the next relist, `client-go` delivers `cache.DeletedFinalStateUnknown`
4. current `DeleteFunc` type asserts to `*corev1.Secret` and crashes

checks:
- `go test ./cmd/config-reloader/...`
- `make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a crash in `config-reloader` when the secret watcher receives tombstone events. We now unwrap `cache.DeletedFinalStateUnknown` instead of asserting directly to `*corev1.Secret`.

- **Bug Fixes**
  - Added `secretFromEvent` to handle `*corev1.Secret` and tombstones (value and pointer) from `client-go`.
  - Updated Add/Update/Delete handlers to use `secretFromEvent` and log unexpected types.
  - Added unit tests for raw secret, tombstone variants, and unexpected types.
  - Updated `docs/CHANGELOG.md` to note the fix.

<sup>Written for commit afa7bed5764e80a0ddedf443052524ada4ec9d48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/operator/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

