### PR TITLE
fix: handle config-reloader dir watch remove events

### DIFF
--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -290,9 +290,6 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 			case <-ctx.Done():
 				return
 			case event := <-dw.w.Events:
-				if event.Op == fsnotify.Remove {
-					continue
-				}
 				baseDir := filepath.Dir(event.Name)
 				logger.Infof("dir update: base dir: %s", baseDir)
 				reloadNeeded, err := updateCache(baseDir)

--- a/cmd/config-reloader/file_watch_test.go
+++ b/cmd/config-reloader/file_watch_test.go
@@ -79,3 +79,71 @@ func TestDirWatcherSkipsKubernetesHiddenEntries(t *testing.T) {
 		t.Fatal("expected update after modifying visible file")
 	}
 }
+
+func TestDirWatcherTriggersUpdateWhenFileRemoved(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "rules.yaml")
+	if err := os.WriteFile(file, []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write initial file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{dir}, nil)
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	if err := os.Remove(file); err != nil {
+		t.Fatalf("failed to remove watched file: %v", err)
+	}
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after removing watched file")
+	}
+}
+
+func TestDirWatcherSyncRemovesDeletedFilesFromTargetDir(t *testing.T) {
+	srcDir := t.TempDir()
+	targetDir := t.TempDir()
+	file := filepath.Join(srcDir, "rules.yaml")
+	targetFile := filepath.Join(targetDir, "rules.yaml")
+	if err := os.WriteFile(file, []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write initial source file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{srcDir}, []string{targetDir})
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	if _, err := os.Stat(targetFile); err != nil {
+		t.Fatalf("expected file to exist in target dir after initial sync: %v", err)
+	}
+
+	if err := os.Remove(file); err != nil {
+		t.Fatalf("failed to remove source file: %v", err)
+	}
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after removing source file")
+	}
+
+	if _, err := os.Stat(targetFile); !os.IsNotExist(err) {
+		t.Fatalf("expected target file to be removed after source deletion, got err=%v", err)
+	}
+}


### PR DESCRIPTION
tiny fix in `config-reloader`.

when a watched file gets removed from a rules dir, the watcher skips remove events, so it doesnt reload. if a target dir is used, the stale file sticks around there too, kinda meh.

fix:
- process remove events like normal dir changes
- add tests for delete reload and target dir cleanup

repro:
1. start `config-reloader` and watch a dir with `rules.yaml`
2. delete `rules.yaml`
3. before this patch, no reload is triggered
4. if a target dir is configured, the stale file stays there too

checks:
- `make lint`
- `make manifests`
- `make api-gen`
- `make docs`
- `go test ./cmd/config-reloader`
- `go test $(go list ./... | grep -v /e2e)`
