### PR TITLE
fix: use tcp startup probes for tls-backed workloads

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 ## tip
 
 * BUGFIX: [config-reloader](https://docs.victoriametrics.com/operator/): fix possible panic on Secret watch events when the informer's local cache fell out of sync and Kubernetes delivered a stale tombstone entry instead of the Secret object. The config-reloader now unwraps tombstones correctly and logs an error for any other unexpected types.
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): switch default app probes to `tcpSocket` `startupProbe` when TLS is enabled on the managed HTTP endpoint. This avoids broken kubelet `httpGet` checks against TLS and mTLS-protected workloads. See [#1824](https://github.com/VictoriaMetrics/operator/issues/1824).
 
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.51.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.51.0).
 * Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VT apps to [v0.9.3](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.3) version. 

--- a/internal/controller/operator/factory/build/container.go
+++ b/internal/controller/operator/factory/build/container.go
@@ -32,7 +32,7 @@ func Probe(container *corev1.Container, cr probeCRD, params *vmv1beta1.CommonApp
 	port := intstr.Parse(cr.ProbePort())
 	scheme := cr.ProbeScheme()
 	path := cr.ProbePath()
-	getProbe := func(probe *corev1.Probe, createIfNil bool) *corev1.Probe {
+	getProbe := func(probe *corev1.Probe, createIfNil bool, forceTCP bool) *corev1.Probe {
 		if probe == nil {
 			if createIfNil {
 				probe = new(corev1.Probe)
@@ -41,13 +41,13 @@ func Probe(container *corev1.Container, cr probeCRD, params *vmv1beta1.CommonApp
 			}
 		}
 		if probe.HTTPGet == nil && probe.TCPSocket == nil && probe.Exec == nil {
-			if cr.UseProxyProtocol() {
+			if forceTCP || cr.UseProxyProtocol() {
 				probe.TCPSocket = new(corev1.TCPSocketAction)
 			} else {
 				probe.HTTPGet = new(corev1.HTTPGetAction)
 			}
 		}
-		if cr.UseProxyProtocol() && probe.TCPSocket != nil {
+		if probe.TCPSocket != nil {
 			if probe.TCPSocket.Port.StrVal == "" && probe.TCPSocket.Port.IntVal == 0 {
 				probe.TCPSocket.Port = port
 			}
@@ -80,11 +80,16 @@ func Probe(container *corev1.Container, cr probeCRD, params *vmv1beta1.CommonApp
 	if params != nil {
 		liveness, readiness, startup = params.LivenessProbe, params.ReadinessProbe, params.StartupProbe
 	}
-	if cr.ProbeNeedLiveness() {
-		container.LivenessProbe = getProbe(liveness, true)
+	hasCustomProbe := liveness != nil || readiness != nil || startup != nil
+	if !hasCustomProbe && scheme == string(corev1.URISchemeHTTPS) {
+		container.StartupProbe = getProbe(nil, true, true)
+		return
 	}
-	container.StartupProbe = getProbe(startup, false)
-	container.ReadinessProbe = getProbe(readiness, true)
+	if cr.ProbeNeedLiveness() {
+		container.LivenessProbe = getProbe(liveness, true, false)
+	}
+	container.StartupProbe = getProbe(startup, false, true)
+	container.ReadinessProbe = getProbe(readiness, true, false)
 }
 
 // Resources creates container resources with conditional defaults values

--- a/internal/controller/operator/factory/build/container_test.go
+++ b/internal/controller/operator/factory/build/container_test.go
@@ -72,6 +72,7 @@ func Test_buildProbe(t *testing.T) {
 			assert.NotNil(t, container.LivenessProbe)
 			assert.NotNil(t, container.ReadinessProbe)
 			assert.Equal(t, corev1.URIScheme("HTTP"), container.ReadinessProbe.HTTPGet.Scheme)
+			assert.Nil(t, container.StartupProbe)
 		},
 	})
 
@@ -85,10 +86,11 @@ func Test_buildProbe(t *testing.T) {
 		},
 		container: corev1.Container{},
 		validate: func(container corev1.Container) {
-			assert.NotNil(t, container.LivenessProbe)
-			assert.Equal(t, corev1.URIScheme("HTTPS"), container.LivenessProbe.HTTPGet.Scheme)
-			assert.NotNil(t, container.ReadinessProbe)
-			assert.Equal(t, corev1.URIScheme("HTTPS"), container.ReadinessProbe.HTTPGet.Scheme)
+			assert.Nil(t, container.LivenessProbe)
+			assert.Nil(t, container.ReadinessProbe)
+			require.NotNil(t, container.StartupProbe)
+			require.NotNil(t, container.StartupProbe.TCPSocket)
+			assert.Equal(t, intstr.Parse("8051"), container.StartupProbe.TCPSocket.Port)
 		},
 	})
 

--- a/internal/controller/operator/factory/vmauth/vmauth_test.go
+++ b/internal/controller/operator/factory/vmauth/vmauth_test.go
@@ -839,6 +839,115 @@ containers:
 serviceaccountname: vmauth-auth
 
 `)
+
+	// tls-backed default probes use tcp startupProbe
+	f(&vmv1beta1.VMAuth{
+		ObjectMeta: metav1.ObjectMeta{Name: "auth-tls", Namespace: "default"},
+		Spec: vmv1beta1.VMAuthSpec{
+			CommonAppsParams: vmv1beta1.CommonAppsParams{
+				UseDefaultResources: ptr.To(false),
+				Image: vmv1beta1.Image{
+					Repository: "vm-repo",
+					Tag:        "v1.97.1",
+				},
+				Port: "8429",
+				ExtraArgs: map[string]string{
+					"tls": "true",
+				},
+			},
+			CommonConfigReloaderParams: vmv1beta1.CommonConfigReloaderParams{
+				ConfigReloaderImage: "vmcustom:config-reloader-v0.35.0",
+			},
+		},
+	}, `
+volumes:
+  - name: config-out
+    volumesource:
+      emptydir: {}
+initcontainers:
+  - name: config-init
+    image: vmcustom:config-reloader-v0.35.0
+    args:
+      - --config-envsubst-file=/opt/vmauth/config.yaml
+      - --config-secret-key=config.yaml.gz
+      - --config-secret-name=default/vmauth-config-auth-tls
+      - --only-init-config
+      - --reload-url=https://127.0.0.1:8429/-/reload
+      - --webhook-method=POST
+    volumemounts:
+      - name: config-out
+        mountpath: /opt/vmauth
+containers:
+  - name: vmauth
+    image: vm-repo:v1.97.1
+    imagepullpolicy: IfNotPresent
+    args:
+      - -auth.config=/opt/vmauth/config.yaml
+      - -httpListenAddr=:8429
+      - -tls=true
+    ports:
+      - name: http
+        containerport: 8429
+        protocol: TCP
+    volumemounts:
+      - name: config-out
+        mountpath: /opt/vmauth
+    startupprobe:
+      probehandler:
+        tcpsocket:
+          port:
+            intval: 8429
+      timeoutseconds: 5
+      periodseconds: 5
+      successthreshold: 1
+      failurethreshold: 10
+    lifecycle:
+      prestop:
+        sleep:
+          seconds: 15
+    terminationmessagepolicy: FallbackToLogsOnError
+  - name: config-reloader
+    image: vmcustom:config-reloader-v0.35.0
+    args:
+      - --config-envsubst-file=/opt/vmauth/config.yaml
+      - --config-secret-key=config.yaml.gz
+      - --config-secret-name=default/vmauth-config-auth-tls
+      - --reload-url=https://127.0.0.1:8429/-/reload
+      - --webhook-method=POST
+    ports:
+      - name: reloader-http
+        containerport: 8435
+        protocol: TCP
+    volumemounts:
+      - name: config-out
+        mountpath: /opt/vmauth
+    livenessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            intval: 8435
+          scheme: HTTP
+      timeoutseconds: 1
+      periodseconds: 10
+      successthreshold: 1
+      failurethreshold: 3
+    readinessprobe:
+      probehandler:
+        httpget:
+          path: /health
+          port:
+            intval: 8435
+          scheme: HTTP
+      initialdelayseconds: 5
+      timeoutseconds: 1
+      periodseconds: 10
+      successthreshold: 1
+      failurethreshold: 3
+    terminationmessagepolicy: FallbackToLogsOnError
+serviceaccountname: vmauth-auth-tls
+
+`)
 }
 
 func TestBuildIngressForAuthOk(t *testing.T) {


### PR DESCRIPTION
Fixes #1824

When a managed app enables TLS on its HTTP endpoint, the operator still renders default `httpGet` app probes. kubelet hits that endpoint without a TLS handshake, so health checks can fail even when the pod is fine.

This keeps plain HTTP behavior as-is, and switches the default app probe to a `tcpSocket` `startupProbe` only for TLS-backed endpoints when no custom probes are set. Custom probes still win, no funny business.

Repro:
1. Create a `VMAuth` with `spec.extraArgs.tls: "true"` and no custom probes.
2. Check the rendered pod spec. It gets default `httpGet` probes on the app port.
3. Run it with TLS or mTLS. kubelet probe requests fail, pod looks sick for no good reason.

Checks:
- `go test ./internal/controller/operator/factory/...`
- `make test`
