### PR TITLE
fix: remove orphaned vmsingle feature configmaps

### DIFF
--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -651,13 +651,19 @@ func createOrUpdateStreamAggrConfig(ctx context.Context, rclient client.Client, 
 
 func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle) error {
 	// TODO check storage for nil
-	// TODO check for stream aggr removed
 
 	svcName := cr.PrefixedName()
 	keepServices := sets.New[string](svcName)
 	keepServiceScrapes := sets.New[string]()
+	keepConfigMaps := sets.New[string]()
 	if !ptr.Deref(cr.Spec.DisableSelfServiceScrape, false) {
 		keepServiceScrapes.Insert(svcName)
+	}
+	if cr.HasAnyRelabellingConfigs() {
+		keepConfigMaps.Insert(build.ResourceName(build.RelabelConfigResourceKind, cr))
+	}
+	if cr.HasAnyStreamAggrRule() {
+		keepConfigMaps.Insert(build.ResourceName(build.StreamAggrConfigResourceKind, cr))
 	}
 	if cr.Spec.ServiceSpec != nil && !cr.Spec.ServiceSpec.UseAsDefault {
 		extraSvcName := cr.Spec.ServiceSpec.NameOrDefault(svcName)
@@ -668,6 +674,9 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	}
 	if err := finalize.RemoveOrphanedVMServiceScrapes(ctx, rclient, cr, keepServiceScrapes, true); err != nil {
 		return fmt.Errorf("cannot remove serviceScrapes: %w", err)
+	}
+	if err := finalize.RemoveOrphanedConfigMaps(ctx, rclient, cr, keepConfigMaps, true); err != nil {
+		return fmt.Errorf("cannot remove configmaps: %w", err)
 	}
 
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}

--- a/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -190,4 +191,65 @@ func TestCreateOrUpdate_Paused(t *testing.T) {
 	err = fclient.Get(ctx, nsn, &dep)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+}
+
+func TestCreateOrUpdate_RemovesOrphanedFeatureConfigMaps(t *testing.T) {
+	ctx := context.TODO()
+	cr := &vmv1beta1.VMSingle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-single",
+			Namespace: "default",
+		},
+		Spec: vmv1beta1.VMSingleSpec{
+			CommonScrapeParams: vmv1beta1.CommonScrapeParams{
+				IngestOnlyMode: ptr.To(true),
+			},
+		},
+	}
+	cr.Status.LastAppliedSpec = &vmv1beta1.VMSingleSpec{
+		CommonRelabelParams: vmv1beta1.CommonRelabelParams{
+			InlineRelabelConfig: []*vmv1beta1.RelabelConfig{{
+				Action:       "drop",
+				SourceLabels: []string{"instance"},
+			}},
+		},
+		StreamAggrConfig: &vmv1beta1.StreamAggrConfig{
+			Rules: []vmv1beta1.StreamAggrRule{{
+				Match:    vmv1beta1.StringOrArray{"foo"},
+				Interval: "1m",
+				Outputs:  []string{"count_samples"},
+			}},
+		},
+	}
+
+	relabelName := types.NamespacedName{
+		Name:      build.ResourceName(build.RelabelConfigResourceKind, cr),
+		Namespace: cr.Namespace,
+	}
+	streamAggrName := types.NamespacedName{
+		Name:      build.ResourceName(build.StreamAggrConfigResourceKind, cr),
+		Namespace: cr.Namespace,
+	}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{
+		&corev1.ConfigMap{
+			ObjectMeta: build.ResourceMeta(build.RelabelConfigResourceKind, cr),
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: build.ResourceMeta(build.StreamAggrConfigResourceKind, cr),
+		},
+	})
+	build.AddDefaults(fclient.Scheme())
+	fclient.Scheme().Default(cr)
+
+	assert.NoError(t, CreateOrUpdate(ctx, cr, fclient))
+
+	var relabelCM corev1.ConfigMap
+	err := fclient.Get(ctx, relabelName, &relabelCM)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
+
+	var streamAggrCM corev1.ConfigMap
+	err = fclient.Get(ctx, streamAggrName, &streamAggrCM)
+	assert.Error(t, err)
+	assert.True(t, k8serrors.IsNotFound(err))
 }


### PR DESCRIPTION
bug:
if a `VMSingle` had `inlineRelabelConfig`, `relabelConfig`, or `streamAggrConfig` before, and later those fields are removed, the generated ConfigMaps just hang around. stale stuff, not referenced anymore.

fix:
clean orphaned relabel and stream aggr ConfigMaps during `VMSingle` reconcile.

repro:
1. Create a `VMSingle` with `spec.inlineRelabelConfig` or `spec.streamAggrConfig`.
2. Wait until operator creates the generated ConfigMap.
3. Remove those fields from the `VMSingle` spec.
4. Reconcile again. before this PR, the old ConfigMaps stay there.
5. With this PR, they get cleaned up.

tests:
`go test ./internal/controller/operator/factory/vmsingle/... ./internal/controller/operator/factory/finalize/... ./internal/controller/operator/factory/reconcile/...`