### PR TITLE
fix: clarify target-dir mismatch for rules-dir

### DIFF
--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -183,8 +183,8 @@ type dirWatcher struct {
 // If targetDirs is non-empty it must have the same length as dirs.
 // A watched dir with no corresponding target only triggers a reload on change.
 func newDirWatchers(dirs []string, targetDirs []string) (*dirWatcher, error) {
-	if len(targetDirs) > 0 && len(targetDirs) != len(dirs) {
-		return nil, fmt.Errorf("--target-dir count (%d) must match --watched-dir count (%d)", len(targetDirs), len(dirs))
+	if err := validateTargetDirCount(len(targetDirs), len(dirs)); err != nil {
+		return nil, err
 	}
 	w, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -45,7 +45,7 @@ var (
 	rulesDir = flagutil.NewArrayString(
 		"rules-dir", "the same as watched-dir, legacy")
 	targetDir = flagutil.NewArrayString(
-		"target-dir", "when provided, must have the same number of argument as --watched-dir; each non-empty value causes files from the corresponding watched directory to be decompressed (if needed) and written to that target directory on change")
+		"target-dir", "when provided, must have the same number of arguments as the directories passed via --watched-dir or --rules-dir; each non-empty value causes files from the corresponding watched directory to be decompressed (if needed) and written to that target directory on change")
 	reloadURL = flag.String(
 		"reload-url", "http://127.0.0.1:8429/-/reload", "reload URL to trigger config reload")
 	reloadURLAuthKey = flagutil.NewPassword("reload-url-auth-key", "authKey for config reload API requests")
@@ -97,8 +97,8 @@ func main() {
 	if len(activeDirs) == 0 {
 		activeDirs = *rulesDir
 	}
-	if len(*targetDir) > 0 && len(*targetDir) != len(activeDirs) {
-		logger.Fatalf("--target-dir count (%d) must match --watched-dir count (%d)", len(*targetDir), len(activeDirs))
+	if err := validateTargetDirCount(len(*targetDir), len(activeDirs)); err != nil {
+		logger.Fatalf("%s", err)
 	}
 	logger.Infof("starting config reloader")
 	r := reloader{
@@ -392,6 +392,13 @@ func writeNewContent(data []byte) error {
 	}
 	if err := os.Rename(tmpDst, *configFileDst); err != nil {
 		return fmt.Errorf("cannot rename tmp file: %w", err)
+	}
+	return nil
+}
+
+func validateTargetDirCount(targetCount, watchedCount int) error {
+	if targetCount > 0 && targetCount != watchedCount {
+		return fmt.Errorf("--target-dir count (%d) must match watched directory count (%d) from --watched-dir/--rules-dir", targetCount, watchedCount)
 	}
 	return nil
 }

--- a/cmd/config-reloader/main_test.go
+++ b/cmd/config-reloader/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -218,4 +219,29 @@ func TestCfgWatcherSuccessTimestampUsesSeconds(t *testing.T) {
 	if configLastReloadSuccess.Get() != 1 {
 		t.Fatalf("expected reload success metric to be 1, got %d", configLastReloadSuccess.Get())
 	}
+}
+
+func TestValidateTargetDirCount(t *testing.T) {
+	t.Run("accepts empty target dirs", func(t *testing.T) {
+		if err := validateTargetDirCount(0, 1); err != nil {
+			t.Fatalf("expected empty target-dir list to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("accepts matching counts", func(t *testing.T) {
+		if err := validateTargetDirCount(2, 2); err != nil {
+			t.Fatalf("expected matching counts to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("mentions both supported source flags on mismatch", func(t *testing.T) {
+		err := validateTargetDirCount(2, 1)
+		if err == nil {
+			t.Fatal("expected mismatched counts to return an error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "--watched-dir/--rules-dir") {
+			t.Fatalf("expected error to mention both supported source flags, got %q", msg)
+		}
+	})
 }

--- a/docs/config-reloader-flags.md
+++ b/docs/config-reloader-flags.md
@@ -135,7 +135,7 @@ Usage of bin/config-reloader:
     	Supports an array of values separated by comma or specified via multiple flags.
     	Each array item can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -target-dir array
-    	when provided, must have the same number of argument as --watched-dir; each non-empty value causes files from the corresponding watched directory to be decompressed (if needed) and written to that target directory on change
+    	when provided, must have the same number of arguments as the directories passed via --watched-dir or --rules-dir; each non-empty value causes files from the corresponding watched directory to be decompressed (if needed) and written to that target directory on change
     	Supports an array of values separated by comma or specified via multiple flags.
     	Each array item can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -tls array


### PR DESCRIPTION
fixes a misleading `config-reloader` error when `--target-dir` is used with legacy `--rules-dir`.

right now the binary says `--watched-dir` even if the user passed only `--rules-dir`. kinda confusing, since `--rules-dir` is still supported for compat.

repro:
`go run ./cmd/config-reloader -rules-dir=/tmp/a -target-dir=/tmp/x,/tmp/y`

before:
`--target-dir count (2) must match --watched-dir count (1)`

after:
`--target-dir count (2) must match watched directory count (1) from --watched-dir/--rules-dir`

also adds a tiny regression test and updates the generated flag doc.
