### PR TITLE
docs: fix broken SubRoute API docs anchor

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3012,7 +3012,7 @@ Appears in: [Receiver](#receiver)
 
 Route defines a node in the routing tree.
 
-Appears in: [SubRoute](#subroute), [VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)
+Appears in: [VMAlertmanagerConfigSpec](#vmalertmanagerconfigspec)
 
 | Field | Description |
 | --- | --- |

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -17,6 +17,7 @@ processor:
     - ".*Status$"
     - "StatusMetadata"
     - "Condition"
+    - "SubRoute"
   ignoreFields:
     - "status$"
     - "TypeMeta$"


### PR DESCRIPTION
Tiny docs paper cut.

`docs/api.md` rendered `Appears in: [SubRoute](#subroute)` under `Route`, but `SubRoute` is an internal helper alias and no `SubRoute` section gets rendered. so the link is dead.

Fix is just adding `SubRoute` to `crd-ref-docs` ignore types, then regenerating `docs/api.md`.

Repro:
1. check out current `master`
2. run `make docs`
3. run `rg '\[SubRoute\]\(#subroute\)|^#### SubRoute$' docs/api.md`
4. you'll see the `SubRoute` link, but no `#### SubRoute` heading. kinda busted.

Checks:
- `make docs`
- `make lint`
- `make test`
