### PR TITLE
added required permissions to sync forks

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -7,7 +7,8 @@ on:
     types:
       - completed
 
-permissions: {}
+permissions:
+  workflows: write
 
 jobs:
   update:


### PR DESCRIPTION
after changes in workflow permission several operator releases in a row failed. added required permissions