### PR TITLE
docs: remove extra header from helm converter docs

### DIFF
--- a/docs/helm-converter.md
+++ b/docs/helm-converter.md
@@ -10,8 +10,6 @@ aliases:
   - /operator/helm-converter.html
 ---
 
-# Helm to Operator Converter
-
 The `helm-converter` is a CLI tool designed to help with the migration process from Helm charts to their corresponding VictoriaMetrics Operator Custom Resources (CRs).
 
 It takes your existing Helm `values.yaml` file and generates the equivalent Operator Custom Resource YAML manifest. This manifest is not a 1:1 replacement, but it takes care of the bulk of the conversion work.


### PR DESCRIPTION
`name` would already add it, so no need to duplicate it
<img width="2826" height="1160" alt="Screenshot 2026-06-26 at 10 02 53" src="https://github.com/user-attachments/assets/d2414fd7-d6dc-4ae9-b67c-3d3001788ebc" />
