### PR TITLE
fix: preserve webhook method with reload auth key

### DIFF
--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -240,26 +240,25 @@ type reloader struct {
 func (r *reloader) reload(ctx context.Context) error {
 	configReloadsTotal.Inc()
 	authKey := reloadURLAuthKey.Get()
-
-	var resp *http.Response
+	reloadTarget := *reloadURL
 	if len(authKey) > 0 {
-		formData := url.Values{
-			"authKey": []string{authKey},
-		}
-		var err error
-		resp, err = r.c.PostForm(*reloadURL, formData)
+		reloadURLParsed, err := url.Parse(reloadTarget)
 		if err != nil {
-			return fmt.Errorf("cannot execute postForm request for reload api: %w", err)
+			return fmt.Errorf("cannot parse reload api url: %w", err)
 		}
-	} else {
-		req, err := http.NewRequestWithContext(ctx, *webhookMethod, *reloadURL, nil)
-		if err != nil {
-			return fmt.Errorf("cannot build request for reload api: %w", err)
-		}
-		resp, err = r.c.Do(req)
-		if err != nil {
-			return fmt.Errorf("cannot execute request for reload api: %w", err)
-		}
+		query := reloadURLParsed.Query()
+		query.Set("authKey", authKey)
+		reloadURLParsed.RawQuery = query.Encode()
+		reloadTarget = reloadURLParsed.String()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, *webhookMethod, reloadTarget, nil)
+	if err != nil {
+		return fmt.Errorf("cannot build request for reload api: %w", err)
+	}
+	resp, err := r.c.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot execute request for reload api: %w", err)
 	}
 	defer resp.Body.Close()
 	text, _ := io.ReadAll(resp.Body)

--- a/cmd/config-reloader/main_test.go
+++ b/cmd/config-reloader/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -244,4 +246,40 @@ func TestValidateTargetDirCount(t *testing.T) {
 			t.Fatalf("expected error to mention both supported source flags, got %q", msg)
 		}
 	})
+}
+
+func TestReloadPreservesWebhookMethodWhenAuthKeyIsConfigured(t *testing.T) {
+	origReloadURL := *reloadURL
+	origWebhookMethod := *webhookMethod
+	origAuthKey := reloadURLAuthKey.Get()
+	defer func() {
+		*reloadURL = origReloadURL
+		*webhookMethod = origWebhookMethod
+		_ = flag.Set("reload-url-auth-key", origAuthKey)
+	}()
+
+	var gotMethod string
+	var gotAuthKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuthKey = r.URL.Query().Get("authKey")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	*reloadURL = server.URL
+	*webhookMethod = http.MethodPut
+	_ = flag.Set("reload-url-auth-key", "secret-value")
+
+	r := reloader{c: server.Client()}
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatalf("reload returned unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Fatalf("expected reload request method %q, got %q", http.MethodPut, gotMethod)
+	}
+	if gotAuthKey != "secret-value" {
+		t.Fatalf("expected authKey query value to be forwarded, got %q", gotAuthKey)
+	}
 }


### PR DESCRIPTION
`config-reloader` was forcing `POST` whenever `--reload-url-auth-key` was set, so `--webhook-method` got ignored. That flag combo is kinda busted on current `master`.

This keeps the configured method and sends `authKey` in the query string, so it matches VictoriaMetrics reload auth handling and does the obvious thing.

Repro:
1. Expose a reload endpoint that expects `PUT` and reads `authKey` from query args.
2. Run `config-reloader` with `--webhook-method=PUT` and `--reload-url-auth-key=secret-value`.
3. Current `master` sends `POST`, not `PUT`.
4. This patch sends `PUT` with `?authKey=secret-value`.

Checks:
- `make test`
- `make lint`
