### PR TITLE
chore: use docker as for vmanomaly renovate version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
         "github.com/onsi/ginkgo/v2"
       ],
       "groupName": "ginkgo"
+    },
+    {
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime"
+      ],
+      "groupName": "controller-runtime"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -184,7 +184,8 @@
         "MIRRORD_VERSION \\?= (?<currentValue>.*)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "metalbear-co/mirrord"
+      "depNameTemplate": "metalbear-co/mirrord",
+      "versioning": "semver"
     },
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -227,8 +227,8 @@
       "matchStrings": [
         "\"VM_ANOMALY_VERSION\":\\s+\"(?<currentValue>v[^\"]+)\""
       ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "VictoriaMetrics/vmanomaly"
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "victoriametrics/vmanomaly"
     },
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,12 @@
         "golang"
       ],
       "groupName": "golang"
+    },
+    {
+      "matchPackageNames": [
+        "github.com/onsi/ginkgo/v2"
+      ],
+      "groupName": "ginkgo"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
vmanomaly repo is private, but renovate could use docker tags (similar to helm-chart)