### PR TITLE
fix(renovate): group go tool version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,13 +27,13 @@
       "groupName": "golang"
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "github.com/onsi/ginkgo/v2"
       ],
       "groupName": "ginkgo"
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "sigs.k8s.io/controller-runtime"
       ],
       "groupName": "controller-runtime"
@@ -197,7 +197,7 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "metalbear-co/mirrord",
-      "versioning": "semver"
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Fix syntax errors, as renovate is unhappy:
```
Location: 'renovate.json'

Error type: 'The renovate configuration file contains some invalid settings'

Message: 'Custom Manager contains disallowed fields: versioning'
```