### PR TITLE
fix(vmdistributed): parse exact metric names when polling queues

### DIFF
--- a/internal/controller/operator/factory/vmdistributed/util.go
+++ b/internal/controller/operator/factory/vmdistributed/util.go
@@ -39,40 +39,54 @@ func fetchMetricValues(ctx context.Context, httpClient *http.Client, url, metric
 }
 
 func unmarshalMetric(values map[string]float64, s, name, dimension string) error {
-	for {
-		idx := strings.Index(s, name)
-		if idx == -1 {
-			break
-		}
-		s = s[idx+len(name):]
-		s = skipLeadingWhitespace(s)
-		n := strings.IndexByte(s, '{')
-		var dimValue string
-		if n >= 0 {
-			// Tags found. Parse them.
+	for len(s) > 0 {
+		line := s
+		if n := strings.IndexByte(s, '\n'); n >= 0 {
+			line = s[:n]
 			s = s[n+1:]
+		} else {
+			s = ""
+		}
+		line = strings.TrimSpace(line)
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		n := strings.IndexAny(line, "{ \t\r")
+		metricName := line
+		if n >= 0 {
+			metricName = line[:n]
+		}
+		if metricName != name {
+			continue
+		}
+
+		line = line[len(metricName):]
+		line = skipLeadingWhitespace(line)
+		var dimValue string
+		if len(line) > 0 && line[0] == '{' {
+			line = line[1:]
 			var err error
 			var tags map[string]string
-			s, tags, err = unmarshalTags(s)
+			line, tags, err = unmarshalTags(line)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal tags: %w", err)
 			}
 			dimValue = tags[dimension]
 		}
-		s = skipLeadingWhitespace(s)
-		if len(s) == 0 {
+		line = skipLeadingWhitespace(line)
+		if len(line) == 0 {
 			return fmt.Errorf("value cannot be empty")
 		}
-		valStr := s
-		n = strings.IndexAny(s, " \t\r\n")
+		valStr := line
+		n = strings.IndexAny(line, " \t\r\n")
 		if n >= 0 {
 			valStr = valStr[:n]
 		}
 		v, err := strconv.ParseFloat(valStr, 64)
 		if err != nil {
-			return fmt.Errorf("cannot parse value %q: %w", s, err)
+			return fmt.Errorf("cannot parse value %q: %w", line, err)
 		}
-		s = s[len(valStr):]
 		if len(dimValue) > 0 {
 			values[dimValue] = v
 		}

--- a/internal/controller/operator/factory/vmdistributed/util_test.go
+++ b/internal/controller/operator/factory/vmdistributed/util_test.go
@@ -38,6 +38,25 @@ test_metric{path="no path"} 24
 `, "test_metric", "path", map[string]float64{
 		"no path": 24,
 	})
+
+	t.Run("ignores similarly prefixed metrics", func(t *testing.T) {
+		f(`
+test_metric_total{path="wrong"} 99
+test_metric{path="correct"} 24
+`, "test_metric", "path", map[string]float64{
+			"correct": 24,
+		})
+	})
+
+	t.Run("ignores prometheus metadata lines", func(t *testing.T) {
+		f(`
+# HELP test_metric queue size
+# TYPE test_metric gauge
+test_metric{path="correct"} 24
+`, "test_metric", "path", map[string]float64{
+			"correct": 24,
+		})
+	})
 }
 
 func TestMergeSpecs(t *testing.T) {

--- a/internal/controller/operator/factory/vmdistributed/util_test.go
+++ b/internal/controller/operator/factory/vmdistributed/util_test.go
@@ -39,23 +39,21 @@ test_metric{path="no path"} 24
 		"no path": 24,
 	})
 
-	t.Run("ignores similarly prefixed metrics", func(t *testing.T) {
-		f(`
+	// ignores similarly prefixed metrics
+	f(`
 test_metric_total{path="wrong"} 99
 test_metric{path="correct"} 24
 `, "test_metric", "path", map[string]float64{
-			"correct": 24,
-		})
+		"correct": 24,
 	})
 
-	t.Run("ignores prometheus metadata lines", func(t *testing.T) {
-		f(`
+	// ignores prometheus metadata lines
+	f(`
 # HELP test_metric queue size
 # TYPE test_metric gauge
 test_metric{path="correct"} 24
 `, "test_metric", "path", map[string]float64{
-			"correct": 24,
-		})
+		"correct": 24,
 	})
 }
 


### PR DESCRIPTION
small parser fix for vmdistributed queue polling.

old code matched metric names by substring. that can pick up `# HELP` and `# TYPE` lines when `-metrics.exposeMetadata` is enabled, and it can also grab similarly prefixed metrics first. kinda nasty, easy to miss.

this patch parses `/metrics` line by line and only reads exact metric-name matches.

repro:
1. enable `-metrics.exposeMetadata` on vmagent.
2. hit `/metrics` and look for `vm_persistentqueue_bytes_pending`.
3. before this patch the parser may match metadata lines first, or a same-prefix metric first.
4. after this patch it reads only real samples for the exact metric.

added regression tests for metadata lines and same-prefix metrics.