### PR TITLE
fix(config): return error on malformed label without '=' instead of panicking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ aliases:
 ## tip
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): add missing `list` verb to config-reloader's secrets RBAC rule. See [#2384](https://github.com/VictoriaMetrics/operator/issues/2384).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): return an error instead of panicking when a `Labels` map value is malformed (missing the `=` separator) during config parsing.
 
 ## [v0.73.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.73.1)
 **Release date:** 08 July 2026

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -983,8 +983,11 @@ func (labels *Labels) Set(value string) error {
 	if value != "" {
 		split := strings.Split(value, ",")
 		for _, pair := range split {
-			sp := strings.Split(pair, "=")
-			m[sp[0]] = sp[1]
+			key, val, found := strings.Cut(pair, "=")
+			if !found {
+				return fmt.Errorf("invalid label %q: expected key=value format", pair)
+			}
+			m[key] = val
 		}
 	}
 	labels.LabelsMap = m

--- a/internal/config/config_labels_test.go
+++ b/internal/config/config_labels_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLabelsSet(t *testing.T) {
+	f := func(value string, want map[string]string, wantErr bool) {
+		t.Helper()
+		var l Labels
+		err := l.Set(value)
+		if wantErr {
+			if err == nil {
+				t.Fatalf("expecting error for value %q, got nil", value)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for value %q: %s", value, err)
+		}
+		if !reflect.DeepEqual(l.LabelsMap, want) {
+			t.Fatalf("unexpected labels for value %q: got %v, want %v", value, l.LabelsMap, want)
+		}
+	}
+
+	// comma-separated key=value pairs
+	f("a=b,c=d", map[string]string{"a": "b", "c": "d"}, false)
+	// single pair
+	f("env=prod", map[string]string{"env": "prod"}, false)
+	// empty value yields no labels
+	f("", map[string]string{}, false)
+	// value without '=' must error instead of panicking on index out of range
+	f("invalid", nil, true)
+	f("a=b,c", nil, true)
+}
+
+func TestLabelsMerge(t *testing.T) {
+	var l Labels
+	if err := l.Set("common=yes"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	got := l.Merge(map[string]string{"extra": "1"})
+	want := map[string]string{"common": "yes", "extra": "1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected merge result: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Labels.Set split a flag value on commas then on '=' and indexed sp[1], so a label value without an '=' (e.g. a bare key) made sp have one element and the code panicked with index out of range. Return a clear error for malformed key=value pairs instead of crashing at startup. Added a unit test covering valid and malformed input.