### PR TITLE
Update VictoriaLogs Docker image tag from v1.51.0 to v1.52.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ aliases:
 
 ## tip
 
+* Dependency: [vmoperator](https://docs.victoriametrics.com/operator/): Updated default versions for VL apps to [v1.52.0](https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.52.0).
+
 * FEATURE: [vlagent](https://docs.victoriametrics.com/operator/resources/vlagent/): add `basicAuth` field support to `remoteWrite` entries. See [#2371](https://github.com/VictoriaMetrics/operator/issues/2371).
 * FEATURE: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): add `defaultVMAccessClaim` field to `spec.jwt`, mapped to vmauth's `jwt.default_vm_access_claim`. It lets a `VMUser` accept JWTs that don't carry a `vm_access` claim, matching `vmauth` v1.147.0+ behavior. See [#2375](https://github.com/VictoriaMetrics/operator/issues/2375).
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,7 +1,7 @@
 | Environment variables |
 | --- |
 | VM_METRICS_VERSION: `v1.147.0` <a href="#variables-vm-metrics-version" id="variables-vm-metrics-version">#</a><br>Defines default image version for VictoriaMetrics components: VMSingle, VMCluster (vmselect/vminsert/vmstorage), VMAgent, VMAlert, VMAuth, VMBackup. Used as the image tag when no explicit version is set in the CR spec. |
-| VM_LOGS_VERSION: `v1.51.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a><br>Defines default image version for VictoriaLogs components: VLogs, VLAgent, VLSingle, VLCluster (vlselect/vlinsert/vlstorage). Used as the image tag when no explicit version is set in the CR spec. |
+| VM_LOGS_VERSION: `v1.52.0` <a href="#variables-vm-logs-version" id="variables-vm-logs-version">#</a><br>Defines default image version for VictoriaLogs components: VLogs, VLAgent, VLSingle, VLCluster (vlselect/vlinsert/vlstorage). Used as the image tag when no explicit version is set in the CR spec. |
 | VM_ANOMALY_VERSION: `v1.29.7` <a href="#variables-vm-anomaly-version" id="variables-vm-anomaly-version">#</a><br>Defines default image version for VMAnomaly. Used as the image tag when no explicit version is set in the CR spec. |
 | VM_TRACES_VERSION: `v0.9.4` <a href="#variables-vm-traces-version" id="variables-vm-traces-version">#</a><br>Defines default image version for VictoriaTraces components: VTSingle, VTCluster (vtselect/vtinsert/vtstorage). Used as the image tag when no explicit version is set in the CR spec. |
 | VM_OPERATOR_VERSION: `v0.73.1` <a href="#variables-vm-operator-version" id="variables-vm-operator-version">#</a><br>Defines the operator's own version. Used for config-reloader image tag interpolation. |

--- a/docs/resources/vlagent.md
+++ b/docs/resources/vlagent.md
@@ -77,7 +77,7 @@ metadata:
 spec:
   image:
     repository: victoriametrics/vlagent
-    tag: v1.51.0
+    tag: v1.52.0
     pullPolicy: Always
 ```
 
@@ -91,7 +91,7 @@ metadata:
 spec:
   image:
     repository: victoriametrics/vlagent
-    tag: v1.51.0
+    tag: v1.52.0
     pullPolicy: Always
   imagePullSecrets:
     - name: my-repo-secret

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,7 @@ var (
 
 	defaultEnvs = map[string]string{
 		"VM_METRICS_VERSION":  "v1.147.0",
-		"VM_LOGS_VERSION":     "v1.51.0",
+		"VM_LOGS_VERSION":     "v1.52.0",
 		"VM_ANOMALY_VERSION":  "v1.29.7",
 		"VM_TRACES_VERSION":   "v0.9.4",
 		"VM_OPERATOR_VERSION": getVersion("v0.73.1"),

--- a/internal/controller/operator/factory/vlagent/vlagent_test.go
+++ b/internal/controller/operator/factory/vlagent/vlagent_test.go
@@ -1192,7 +1192,7 @@ serviceaccountname: vlagent-agent
 		Spec: vmv1.VLAgentSpec{
 			CommonAppsParams: vmv1beta1.CommonAppsParams{
 				Image: vmv1beta1.Image{
-					Tag: "v1.51.0",
+					Tag: "v1.52.0",
 				},
 				UseDefaultResources: ptr.To(false),
 				Port:                "9425",
@@ -1218,7 +1218,7 @@ serviceaccountname: vlagent-agent
 	}, []runtime.Object{}, `
 containers:
   - name: vlagent
-    image: victoriametrics/vlagent:v1.51.0
+    image: victoriametrics/vlagent:v1.52.0
     args:
       - -httpListenAddr=:9425
       - -kubernetesCollector


### PR DESCRIPTION
See https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.52.0