### PR TITLE
fix: add VPA RBAC marker

### DIFF
--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -77,6 +77,7 @@ func (r *VMAgentReconciler) Init(name string, rclient client.Client, l logr.Logg
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;watch;list
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles;rolebindings;clusterrolebindings;clusterroles,verbs=get;create,update;list
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create,update;list
+// +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {


### PR DESCRIPTION
Allow listing VPAs for operator, otherwise it logs
```
{"level":"error","ts":"2026-07-22T11:16:00Z","logger":"controller-runtime.cache.UnhandledError","msg":"Failed to
watch","reflector":"pkg/mod/k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343","type":"*v1.VerticalPodAutoscaler","error":"failed to list *v1.VerticalPodAutoscaler: verticalpodautoscalers.autoscaling.k8s.io is forbidden: User \"system:serviceaccount:monitoring:vmks-victoria-metrics-operator\" cannot list resource \"verticalpodautoscalers\" in API group \"autoscaling.k8s.io\" at the cluster scope"}
```