### PR TITLE
fix: merge VMAnomaly child queries

### DIFF
--- a/internal/controller/operator/factory/vmanomaly/config/config.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config.go
@@ -222,9 +222,6 @@ func (c *config) build(cr *vmv1.VMAnomaly, pos *ParsedObjects, ac *build.AssetsC
 	if cr.Spec.Reader == nil {
 		return fmt.Errorf("reader is required for anomaly name=%q", crCanonicalName)
 	}
-	if c.Reader == nil || len(c.Reader.Queries) == 0 {
-		return fmt.Errorf("reader.queries must be provided via configRawYaml or configSecret, name=%q", crCanonicalName)
-	}
 	if cr.Spec.Writer == nil {
 		return fmt.Errorf("writer is required for anomaly name=%q", crCanonicalName)
 	}
@@ -241,8 +238,12 @@ func (c *config) build(cr *vmv1.VMAnomaly, pos *ParsedObjects, ac *build.AssetsC
 		return fmt.Errorf("failed to update HTTP client for anomaly reader, name=%q: %w", crCanonicalName, err)
 	}
 	r.Class = "vm"
-
-	r.Queries = c.Reader.Queries
+	if c.Reader != nil {
+		r.Queries = c.Reader.Queries
+	}
+	if r.Queries == nil {
+		r.Queries = make(map[string]*query)
+	}
 	c.Reader = &r
 
 	// override writer

--- a/internal/controller/operator/factory/vmanomaly/config/config_test.go
+++ b/internal/controller/operator/factory/vmanomaly/config/config_test.go
@@ -2107,3 +2107,46 @@ server:
 	})
 
 }
+
+func TestLoad_ChildConfigProvidesMainModelQuery(t *testing.T) {
+	cr := &vmv1.VMAnomaly{
+		ObjectMeta: metav1.ObjectMeta{Name: "anomaly", Namespace: "default"},
+		Spec: vmv1.VMAnomalySpec{
+			SelectAllByDefault: true,
+			ConfigRawYaml: `
+models:
+  main:
+    class: zscore
+    queries: [default-child-query]
+    schedulers: [main]
+schedulers:
+  main:
+    class: periodic
+    infer_every: 1m
+`,
+			Reader: &vmv1.VMAnomalyReadersSpec{
+				DatasourceURL:  "http://reader.test",
+				SamplingPeriod: "1m",
+			},
+			Writer: &vmv1.VMAnomalyWritersSpec{DatasourceURL: "http://writer.test"},
+		},
+	}
+	child := &vmv1.VMAnomalyConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "child", Namespace: "default"},
+		Spec: runtime.RawExtension{Raw: []byte(`{
+  "queries": {
+    "query": {"expr": "up"}
+  }
+}`)},
+	}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{child})
+	build.AddDefaults(fclient.Scheme())
+	fclient.Scheme().Default(cr)
+	ac := build.NewAssetsCache(context.TODO(), fclient, nil)
+
+	pos, err := NewParsedObjects(context.TODO(), fclient, cr)
+	require.NoError(t, err)
+	loaded, err := pos.Load(cr, ac)
+	require.NoError(t, err)
+	assert.Contains(t, string(loaded), "default-child-query")
+}


### PR DESCRIPTION
Remove the VMAnomaly limitation to require reader.query, so that they can be provided in child `VMAnomalyConfig`

fixes https://github.com/VictoriaMetrics/operator/issues/2534