### PR TITLE
fix: require k8s >= 1.30 for preStop Sleep lifecycle hook

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ aliases:
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): default `spec.shardCount` to `0` at the CRD schema level, fixing `VerticalPodAutoscaler`'s `/scale` subresource lookups failing with `the spec replicas field ".spec.shardCount" does not exist` whenever sharding wasn't configured (the common case). See [#2473](https://github.com/VictoriaMetrics/operator/issues/2473).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): set default values for each possible `level` label of `operator_log_messages_total` metric. See [#2477](https://github.com/VictoriaMetrics/operator/issues/2477).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fix reconciliation error on Kubernetes 1.29 caused by setting an empty `preStop` lifecycle handler. The native `Sleep` preStop action now requires Kubernetes >= 1.30, since the `PodLifecycleSleepAction` feature gate is not enabled by default on 1.29.
+
 
 ## [v0.74.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.74.1)
 **Release date:** 04 Aug 2026

--- a/internal/controller/operator/factory/build/container_test.go
+++ b/internal/controller/operator/factory/build/container_test.go
@@ -228,9 +228,13 @@ func TestLifecycle(t *testing.T) {
 	k8stools.ServerMinorVersion = 28
 	f(&vmv1beta1.CommonAppsParams{PreStopSleepSeconds: ptr.To[int32](15)}, nil)
 
-	// supported k8s version (>= 1.29) — native SleepAction
-	k8stools.ServerMajorVersion = 1
+	// PodLifecycleSleepAction is alpha (off by default) in 1.29 — must not set an empty handler
 	k8stools.ServerMinorVersion = 29
+	f(&vmv1beta1.CommonAppsParams{PreStopSleepSeconds: ptr.To[int32](15)}, nil)
+
+	// supported k8s version (>= 1.30) — native SleepAction
+	k8stools.ServerMajorVersion = 1
+	k8stools.ServerMinorVersion = 30
 	t.Cleanup(func() { k8stools.ServerMajorVersion = 0; k8stools.ServerMinorVersion = 0 })
 
 	// sleep >= terminationGracePeriodSeconds — no hook to avoid SIGKILL during preStop

--- a/internal/controller/operator/factory/k8stools/version.go
+++ b/internal/controller/operator/factory/k8stools/version.go
@@ -61,5 +61,5 @@ func IsFSGroupChangePolicySupported() bool {
 // The PodLifecycleSleepAction feature gate was introduced as alpha in 1.29 and promoted to beta (on by default) in 1.30.
 // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-hooks
 func IsPodLifecycleSleepActionSupported() bool {
-	return ServerMajorVersion == 1 && ServerMinorVersion >= 29
+	return ServerMajorVersion == 1 && ServerMinorVersion >= 30
 }

--- a/internal/controller/operator/factory/vlagent/main_test.go
+++ b/internal/controller/operator/factory/vlagent/main_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Native SleepAction is supported from k8s 1.29; set it globally for all tests in this package.
+	// Native SleepAction is supported from k8s 1.30 (feature gate is off by default in 1.29); set it globally for all tests in this package.
 	k8stools.ServerMajorVersion = 1
-	k8stools.ServerMinorVersion = 29
+	k8stools.ServerMinorVersion = 30
 	os.Exit(m.Run())
 }

--- a/internal/controller/operator/factory/vmagent/main_test.go
+++ b/internal/controller/operator/factory/vmagent/main_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Native SleepAction is supported from k8s 1.29; set it globally for all tests in this package.
+	// Native SleepAction is supported from k8s 1.30 (feature gate is off by default in 1.29); set it globally for all tests in this package.
 	k8stools.ServerMajorVersion = 1
-	k8stools.ServerMinorVersion = 29
+	k8stools.ServerMinorVersion = 30
 	os.Exit(m.Run())
 }

--- a/internal/controller/operator/factory/vmauth/main_test.go
+++ b/internal/controller/operator/factory/vmauth/main_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Native SleepAction is supported from k8s 1.29; set it globally for all tests in this package.
+	// Native SleepAction is supported from k8s 1.30 (feature gate is off by default in 1.29); set it globally for all tests in this package.
 	k8stools.ServerMajorVersion = 1
-	k8stools.ServerMinorVersion = 29
+	k8stools.ServerMinorVersion = 30
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
PreStop hook feature gate is still Alpha in 1.29, so its best to avoid attempting to use native sleep