### PR TITLE
config-reloader: trigger reload after initial directory sync

### DIFF
--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -301,11 +301,35 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 			logger.Infof("triggering reload after initial sync")
 			triggerReload()
 		}
-		retryInitialSync(ctx, pending, triggerReload)
+		// Pairs whose initial sync failed are retried with backoff, multiplexed
+		// with event processing so a failing pair never blocks the event loop.
+		backoff := initialSyncRetryBackoff
+		var retryC <-chan time.Time
+		if len(pending) > 0 {
+			retryC = time.After(backoff)
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-retryC:
+				var failed []dirPair
+				for _, p := range pending {
+					if err := p.sync(); err != nil {
+						logger.Errorf("cannot copy dir %s to target: %s", p.src, err)
+						failed = append(failed, p)
+					}
+				}
+				if len(failed) < len(pending) {
+					triggerReload()
+				}
+				pending = failed
+				if len(pending) > 0 {
+					backoff = min(backoff*2, 30*time.Second)
+					retryC = time.After(backoff)
+				} else {
+					retryC = nil
+				}
 			case event := <-dw.w.Events:
 				baseDir := filepath.Dir(event.Name)
 				logger.Infof("dir update: base dir: %s", baseDir)
@@ -339,39 +363,7 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 	}()
 }
 
-const maxInitialSyncRetries = 5
-
 var initialSyncRetryBackoff = time.Second
-
-// retryInitialSync retries the pairs whose initial sync failed, triggering a
-// reload whenever a retry makes progress, so already-synced content is never
-// held back by a still-failing pair.
-func retryInitialSync(ctx context.Context, pending []dirPair, triggerReload func()) {
-	backoff := initialSyncRetryBackoff
-	for attempt := 0; len(pending) > 0; attempt++ {
-		if attempt == maxInitialSyncRetries {
-			logger.Errorf("giving up on initial sync after %d retries, waiting for source changes", attempt)
-			return
-		}
-		select {
-		case <-time.After(backoff):
-		case <-ctx.Done():
-			return
-		}
-		backoff = min(backoff*2, 30*time.Second)
-		var failed []dirPair
-		for _, p := range pending {
-			if err := p.sync(); err != nil {
-				logger.Errorf("cannot copy dir %s to target: %s", p.src, err)
-				failed = append(failed, p)
-			}
-		}
-		if len(failed) < len(pending) {
-			triggerReload()
-		}
-		pending = failed
-	}
-}
 
 func (dw *dirWatcher) close() {
 	dw.wg.Wait()

--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -275,16 +275,33 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 		logger.Infof("base dir: %s hash not the same, update needed", eventPath)
 		return true, nil
 	}
+	var pending []dirPair
 	for _, p := range dw.pairs {
 		if _, err := updateCache(p.src); err != nil {
 			logger.Errorf("cannot update dir cache during start: %s", err)
 		}
 		if err := p.sync(); err != nil {
 			logger.Errorf("cannot copy dir %s to target on start: %s", p.src, err)
+			pending = append(pending, p)
+		}
+	}
+	triggerReload := func() {
+		select {
+		case updates <- struct{}{}:
+		default:
 		}
 	}
 	go func() {
 		defer dw.wg.Done()
+		if len(dw.pairs) > 0 {
+			// The application may have already read stale content before the
+			// watcher was established, or before the initial sync replaced it.
+			// Without further source changes, no fsnotify event is guaranteed,
+			// so trigger one reload after startup.
+			logger.Infof("triggering reload after initial sync")
+			triggerReload()
+		}
+		retryInitialSync(ctx, pending, triggerReload)
 		for {
 			select {
 			case <-ctx.Done():
@@ -320,6 +337,40 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 			}
 		}
 	}()
+}
+
+const maxInitialSyncRetries = 5
+
+var initialSyncRetryBackoff = time.Second
+
+// retryInitialSync retries the pairs whose initial sync failed, triggering a
+// reload whenever a retry makes progress, so already-synced content is never
+// held back by a still-failing pair.
+func retryInitialSync(ctx context.Context, pending []dirPair, triggerReload func()) {
+	backoff := initialSyncRetryBackoff
+	for attempt := 0; len(pending) > 0; attempt++ {
+		if attempt == maxInitialSyncRetries {
+			logger.Errorf("giving up on initial sync after %d retries, waiting for source changes", attempt)
+			return
+		}
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
+		backoff = min(backoff*2, 30*time.Second)
+		var failed []dirPair
+		for _, p := range pending {
+			if err := p.sync(); err != nil {
+				logger.Errorf("cannot copy dir %s to target: %s", p.src, err)
+				failed = append(failed, p)
+			}
+		}
+		if len(failed) < len(pending) {
+			triggerReload()
+		}
+		pending = failed
+	}
 }
 
 func (dw *dirWatcher) close() {

--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -294,15 +294,11 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 	go func() {
 		defer dw.wg.Done()
 		if len(dw.pairs) > 0 {
-			// The application may have already read stale content before the
-			// watcher was established, or before the initial sync replaced it.
-			// Without further source changes, no fsnotify event is guaranteed,
-			// so trigger one reload after startup.
+			// Reload here to catch changes between container start and initial sync
 			logger.Infof("triggering reload after initial sync")
 			triggerReload()
 		}
-		// Pairs whose initial sync failed are retried with backoff, multiplexed
-		// with event processing so a failing pair never blocks the event loop.
+		// Retry failed initial syncs without blocking event processing
 		backoff := initialSyncRetryBackoff
 		var retryC <-chan time.Time
 		if len(pending) > 0 {

--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -212,11 +212,13 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 	dirHash := sha256.New()
 	fHash := sha256.New()
 
-	updateCache := func(eventPath string) (bool, error) {
+	// Returns the content hash of eventPath and whether it differs from the
+	// cache; the caller commits the hash only after a successful sync.
+	updateCache := func(eventPath string) ([]byte, bool, error) {
 		dirHash.Reset()
 		walkDir, err := filepath.EvalSymlinks(eventPath)
 		if err != nil {
-			return false, fmt.Errorf("cannot eval symlinks for path: %s", eventPath)
+			return nil, false, fmt.Errorf("cannot eval symlinks for path: %s", eventPath)
 		}
 
 		err = filepath.WalkDir(walkDir, func(path string, d fs.DirEntry, err error) error {
@@ -263,26 +265,28 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 		})
 		if err != nil {
 			logger.Errorf("cannot walk: %s", err)
-			return false, fmt.Errorf("cannot walk path: %s, err: %w", eventPath, err)
+			return nil, false, fmt.Errorf("cannot walk path: %s, err: %w", eventPath, err)
 		}
 
 		newHash := dirHash.Sum(nil)
 		prevHash := filesContentHashPath[eventPath]
 		if bytes.Equal(prevHash, newHash) {
-			return false, nil
+			return newHash, false, nil
 		}
-		filesContentHashPath[eventPath] = newHash
 		logger.Infof("base dir: %s hash not the same, update needed", eventPath)
-		return true, nil
+		return newHash, true, nil
 	}
-	var pending []dirPair
 	for _, p := range dw.pairs {
-		if _, err := updateCache(p.src); err != nil {
+		newHash, _, err := updateCache(p.src)
+		if err != nil {
 			logger.Errorf("cannot update dir cache during start: %s", err)
 		}
 		if err := p.sync(); err != nil {
 			logger.Errorf("cannot copy dir %s to target on start: %s", p.src, err)
-			pending = append(pending, p)
+			continue
+		}
+		if newHash != nil {
+			filesContentHashPath[p.src] = newHash
 		}
 	}
 	triggerReload := func() {
@@ -298,38 +302,14 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 			logger.Infof("triggering reload after initial sync")
 			triggerReload()
 		}
-		// Retry failed initial syncs without blocking event processing
-		backoff := initialSyncRetryBackoff
-		var retryC <-chan time.Time
-		if len(pending) > 0 {
-			retryC = time.After(backoff)
-		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-retryC:
-				var failed []dirPair
-				for _, p := range pending {
-					if err := p.sync(); err != nil {
-						logger.Errorf("cannot copy dir %s to target: %s", p.src, err)
-						failed = append(failed, p)
-					}
-				}
-				if len(failed) < len(pending) {
-					triggerReload()
-				}
-				pending = failed
-				if len(pending) > 0 {
-					backoff = min(backoff*2, 30*time.Second)
-					retryC = time.After(backoff)
-				} else {
-					retryC = nil
-				}
 			case event := <-dw.w.Events:
 				baseDir := filepath.Dir(event.Name)
 				logger.Infof("dir update: base dir: %s", baseDir)
-				reloadNeeded, err := updateCache(baseDir)
+				newHash, reloadNeeded, err := updateCache(baseDir)
 				if err != nil {
 					logger.Errorf("cannot update dir watch cache: %s", err)
 					continue
@@ -350,16 +330,12 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 				if !synced {
 					continue
 				}
-				select {
-				case updates <- struct{}{}:
-				default:
-				}
+				filesContentHashPath[baseDir] = newHash
+				triggerReload()
 			}
 		}
 	}()
 }
-
-var initialSyncRetryBackoff = time.Second
 
 func (dw *dirWatcher) close() {
 	dw.wg.Wait()

--- a/cmd/config-reloader/file_watch.go
+++ b/cmd/config-reloader/file_watch.go
@@ -276,6 +276,7 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 		logger.Infof("base dir: %s hash not the same, update needed", eventPath)
 		return newHash, true, nil
 	}
+	syncedOnStart := false
 	for _, p := range dw.pairs {
 		newHash, _, err := updateCache(p.src)
 		if err != nil {
@@ -288,6 +289,7 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 		if newHash != nil {
 			filesContentHashPath[p.src] = newHash
 		}
+		syncedOnStart = true
 	}
 	triggerReload := func() {
 		select {
@@ -297,7 +299,7 @@ func (dw *dirWatcher) start(ctx context.Context, updates chan struct{}) {
 	}
 	go func() {
 		defer dw.wg.Done()
-		if len(dw.pairs) > 0 {
+		if syncedOnStart {
 			// Reload here to catch changes between container start and initial sync
 			logger.Infof("triggering reload after initial sync")
 			triggerReload()

--- a/cmd/config-reloader/file_watch_test.go
+++ b/cmd/config-reloader/file_watch_test.go
@@ -26,6 +26,13 @@ func TestDirWatcherProcessesRegularFilesWithDoubleDotsInName(t *testing.T) {
 	defer dw.close()
 	defer cancel()
 
+	// Drain the update queued by the initial sync.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
+	}
+
 	if err := os.WriteFile(file, []byte("groups:\n- name: test\n"), 0o644); err != nil {
 		t.Fatalf("failed to update file: %v", err)
 	}
@@ -58,6 +65,13 @@ func TestDirWatcherSkipsKubernetesHiddenEntries(t *testing.T) {
 	dw.start(ctx, updates)
 	defer dw.close()
 	defer cancel()
+
+	// Drain the update queued by the initial sync.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
+	}
 
 	if err := os.WriteFile(hiddenFile, []byte("v2\n"), 0o644); err != nil {
 		t.Fatalf("failed to update hidden file: %v", err)
@@ -98,6 +112,13 @@ func TestDirWatcherTriggersUpdateWhenFileRemoved(t *testing.T) {
 	defer dw.close()
 	defer cancel()
 
+	// Drain the update queued by the initial sync.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
+	}
+
 	if err := os.Remove(file); err != nil {
 		t.Fatalf("failed to remove watched file: %v", err)
 	}
@@ -106,6 +127,163 @@ func TestDirWatcherTriggersUpdateWhenFileRemoved(t *testing.T) {
 	case <-updates:
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected update after removing watched file")
+	}
+}
+
+func TestDirWatcherTriggersReloadAfterInitialSync(t *testing.T) {
+	srcDir := t.TempDir()
+	targetDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(targetDir, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write stale target file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "rules.yaml"), []byte("groups:\n- name: test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{srcDir}, []string{targetDir})
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync replaced stale target content")
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetDir, "rules.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read target file after initial sync: %v", err)
+	}
+	if string(data) != "groups:\n- name: test\n" {
+		t.Fatalf("unexpected target content after initial sync: %q", data)
+	}
+}
+
+func TestDirWatcherRetriesFailedInitialSync(t *testing.T) {
+	origBackoff := initialSyncRetryBackoff
+	initialSyncRetryBackoff = 10 * time.Millisecond
+	defer func() { initialSyncRetryBackoff = origBackoff }()
+
+	srcDir := t.TempDir()
+	base := t.TempDir()
+	blocker := filepath.Join(base, "blocked")
+	targetDir := filepath.Join(blocker, "out")
+	if err := os.WriteFile(filepath.Join(srcDir, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	// A regular file at the target's parent path makes the initial sync fail.
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatalf("failed to write blocker file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{srcDir}, []string{targetDir})
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	// Drain the initial reload, which fires regardless of the failing pair.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
+	}
+
+	if err := os.Remove(blocker); err != nil {
+		t.Fatalf("failed to remove blocker file: %v", err)
+	}
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync retry succeeded")
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetDir, "rules.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read target file after retried sync: %v", err)
+	}
+	if string(data) != "groups: []\n" {
+		t.Fatalf("unexpected target content after retried sync: %q", data)
+	}
+}
+
+func TestDirWatcherReloadsSyncedPairsWhenAnotherKeepsFailing(t *testing.T) {
+	origBackoff := initialSyncRetryBackoff
+	initialSyncRetryBackoff = 10 * time.Millisecond
+	defer func() { initialSyncRetryBackoff = origBackoff }()
+
+	srcA := t.TempDir()
+	targetA := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcA, "rules.yaml"), []byte("groups:\n- name: a\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	srcB := t.TempDir()
+	base := t.TempDir()
+	blocker := filepath.Join(base, "blocked")
+	targetB := filepath.Join(blocker, "out")
+	if err := os.WriteFile(filepath.Join(srcB, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	// A regular file at targetB's parent path makes its sync fail permanently.
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatalf("failed to write blocker file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{srcA, srcB}, []string{targetA, targetB})
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update for the synced pair despite the failing pair")
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetA, "rules.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read synced target file: %v", err)
+	}
+	if string(data) != "groups:\n- name: a\n" {
+		t.Fatalf("unexpected synced target content: %q", data)
+	}
+}
+
+func TestDirWatcherNoInitialReloadWithoutWatchedDirs(t *testing.T) {
+	dw, err := newDirWatchers(nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	select {
+	case <-updates:
+		t.Fatal("did not expect update on start without watched dirs")
+	case <-time.After(300 * time.Millisecond):
 	}
 }
 
@@ -131,6 +309,13 @@ func TestDirWatcherSyncRemovesDeletedFilesFromTargetDir(t *testing.T) {
 
 	if _, err := os.Stat(targetFile); err != nil {
 		t.Fatalf("expected file to exist in target dir after initial sync: %v", err)
+	}
+
+	// Drain the update queued by the initial sync.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
 	}
 
 	if err := os.Remove(file); err != nil {

--- a/cmd/config-reloader/file_watch_test.go
+++ b/cmd/config-reloader/file_watch_test.go
@@ -268,6 +268,65 @@ func TestDirWatcherReloadsSyncedPairsWhenAnotherKeepsFailing(t *testing.T) {
 	}
 }
 
+func TestDirWatcherProcessesEventsWhileInitialSyncRetries(t *testing.T) {
+	origBackoff := initialSyncRetryBackoff
+	initialSyncRetryBackoff = time.Hour
+	defer func() { initialSyncRetryBackoff = origBackoff }()
+
+	srcA := t.TempDir()
+	targetA := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcA, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	srcB := t.TempDir()
+	base := t.TempDir()
+	blocker := filepath.Join(base, "blocked")
+	targetB := filepath.Join(blocker, "out")
+	if err := os.WriteFile(filepath.Join(srcB, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	// A regular file at targetB's parent path makes its sync fail.
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatalf("failed to write blocker file: %v", err)
+	}
+
+	dw, err := newDirWatchers([]string{srcA, srcB}, []string{targetA, targetB})
+	if err != nil {
+		t.Fatalf("failed to create dir watcher: %v", err)
+	}
+
+	updates := make(chan struct{}, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	dw.start(ctx, updates)
+	defer dw.close()
+	defer cancel()
+
+	// Drain the initial reload.
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update after initial sync")
+	}
+
+	if err := os.WriteFile(filepath.Join(srcA, "rules.yaml"), []byte("groups:\n- name: test\n"), 0o644); err != nil {
+		t.Fatalf("failed to update source file: %v", err)
+	}
+
+	select {
+	case <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected update from event loop while an initial sync retry is pending")
+	}
+
+	data, err := os.ReadFile(filepath.Join(targetA, "rules.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read target file: %v", err)
+	}
+	if string(data) != "groups:\n- name: test\n" {
+		t.Fatalf("unexpected target content: %q", data)
+	}
+}
+
 func TestDirWatcherNoInitialReloadWithoutWatchedDirs(t *testing.T) {
 	dw, err := newDirWatchers(nil, nil)
 	if err != nil {

--- a/cmd/config-reloader/file_watch_test.go
+++ b/cmd/config-reloader/file_watch_test.go
@@ -190,11 +190,11 @@ func TestDirWatcherRetriesFailedInitialSyncOnNextEvent(t *testing.T) {
 	defer dw.close()
 	defer cancel()
 
-	// Drain the initial reload, which fires regardless of the failing pair.
+	// No startup reload: nothing was synced.
 	select {
 	case <-updates:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected update after initial sync")
+		t.Fatal("did not expect update while the initial sync fails")
+	case <-time.After(300 * time.Millisecond):
 	}
 
 	if err := os.Remove(blocker); err != nil {

--- a/cmd/config-reloader/file_watch_test.go
+++ b/cmd/config-reloader/file_watch_test.go
@@ -166,11 +166,7 @@ func TestDirWatcherTriggersReloadAfterInitialSync(t *testing.T) {
 	}
 }
 
-func TestDirWatcherRetriesFailedInitialSync(t *testing.T) {
-	origBackoff := initialSyncRetryBackoff
-	initialSyncRetryBackoff = 10 * time.Millisecond
-	defer func() { initialSyncRetryBackoff = origBackoff }()
-
+func TestDirWatcherRetriesFailedInitialSyncOnNextEvent(t *testing.T) {
 	srcDir := t.TempDir()
 	base := t.TempDir()
 	blocker := filepath.Join(base, "blocked")
@@ -204,6 +200,11 @@ func TestDirWatcherRetriesFailedInitialSync(t *testing.T) {
 	if err := os.Remove(blocker); err != nil {
 		t.Fatalf("failed to remove blocker file: %v", err)
 	}
+	// Rewriting the same content still triggers the sync: the hash of the
+	// failed pair was never committed to the cache.
+	if err := os.WriteFile(filepath.Join(srcDir, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
+		t.Fatalf("failed to rewrite source file: %v", err)
+	}
 
 	select {
 	case <-updates:
@@ -220,11 +221,7 @@ func TestDirWatcherRetriesFailedInitialSync(t *testing.T) {
 	}
 }
 
-func TestDirWatcherReloadsSyncedPairsWhenAnotherKeepsFailing(t *testing.T) {
-	origBackoff := initialSyncRetryBackoff
-	initialSyncRetryBackoff = 10 * time.Millisecond
-	defer func() { initialSyncRetryBackoff = origBackoff }()
-
+func TestDirWatcherReloadsSyncedPairsWhenAnotherFails(t *testing.T) {
 	srcA := t.TempDir()
 	targetA := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcA, "rules.yaml"), []byte("groups:\n- name: a\n"), 0o644); err != nil {
@@ -268,11 +265,7 @@ func TestDirWatcherReloadsSyncedPairsWhenAnotherKeepsFailing(t *testing.T) {
 	}
 }
 
-func TestDirWatcherProcessesEventsWhileInitialSyncRetries(t *testing.T) {
-	origBackoff := initialSyncRetryBackoff
-	initialSyncRetryBackoff = time.Hour
-	defer func() { initialSyncRetryBackoff = origBackoff }()
-
+func TestDirWatcherProcessesEventsWhileAnotherPairFails(t *testing.T) {
 	srcA := t.TempDir()
 	targetA := t.TempDir()
 	if err := os.WriteFile(filepath.Join(srcA, "rules.yaml"), []byte("groups: []\n"), 0o644); err != nil {
@@ -315,7 +308,7 @@ func TestDirWatcherProcessesEventsWhileInitialSyncRetries(t *testing.T) {
 	select {
 	case <-updates:
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected update from event loop while an initial sync retry is pending")
+		t.Fatal("expected update from event loop while another pair's sync fails")
 	}
 
 	data, err := os.ReadFile(filepath.Join(targetA, "rules.yaml"))

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -287,8 +287,7 @@ func (c *cfgWatcher) start(ctx context.Context) {
 			if !c.waitDelay(ctx) {
 				return
 			}
-			// Retry until the reload succeeds: the on-disk config is already
-			// updated, and no further update signal may ever arrive.
+			// Retry until success: another update signal may never arrive
 			backoff := reloadRetryInitialBackoff
 			for {
 				err := c.reloader(ctx)

--- a/cmd/config-reloader/main.go
+++ b/cmd/config-reloader/main.go
@@ -269,6 +269,11 @@ func (r *reloader) reload(ctx context.Context) error {
 	return nil
 }
 
+var (
+	reloadRetryInitialBackoff = time.Second
+	reloadRetryMaxBackoff     = 30 * time.Second
+)
+
 func (c *cfgWatcher) start(ctx context.Context) {
 	c.wg.Add(1)
 	go func() {
@@ -282,11 +287,23 @@ func (c *cfgWatcher) start(ctx context.Context) {
 			if !c.waitDelay(ctx) {
 				return
 			}
-			if err := c.reloader(ctx); err != nil {
-				logger.Errorf("cannot trigger api reload: %s", err.Error())
+			// Retry until the reload succeeds: the on-disk config is already
+			// updated, and no further update signal may ever arrive.
+			backoff := reloadRetryInitialBackoff
+			for {
+				err := c.reloader(ctx)
+				if err == nil {
+					break
+				}
+				logger.Errorf("cannot trigger api reload, retrying in %s: %s", backoff, err.Error())
 				configLastReloadSuccess.Set(0)
 				configReloadErrorsTotal.Inc()
-				continue
+				select {
+				case <-time.After(backoff):
+				case <-ctx.Done():
+					return
+				}
+				backoff = min(backoff*2, reloadRetryMaxBackoff)
 			}
 			configLastReloadSuccess.Set(1)
 			configLastOkReloadTime.Set(uint64(time.Now().Unix()))

--- a/cmd/config-reloader/main_test.go
+++ b/cmd/config-reloader/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"strings"
 	"sync/atomic"
@@ -70,6 +71,47 @@ func TestCfgWatcherSignalSentOnce(t *testing.T) {
 
 	if got := reloadCount.Load(); got != 1 {
 		t.Fatalf("expected 1 reload call, got %d", got)
+	}
+}
+
+// TestCfgWatcherRetriesFailedReload verifies that a failed reload call is
+// retried until it succeeds, e.g. when the application's reload endpoint is
+// not listening yet at startup.
+func TestCfgWatcherRetriesFailedReload(t *testing.T) {
+	origDelay := *delayInterval
+	*delayInterval = 0
+	defer func() { *delayInterval = origDelay }()
+	origBackoff := reloadRetryInitialBackoff
+	reloadRetryInitialBackoff = 10 * time.Millisecond
+	defer func() { reloadRetryInitialBackoff = origBackoff }()
+
+	var reloadCount atomic.Int64
+	updates := make(chan struct{}, 10)
+	w := cfgWatcher{
+		updates: updates,
+		reloader: func(_ context.Context) error {
+			if reloadCount.Add(1) < 3 {
+				return errors.New("connection refused")
+			}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.start(ctx)
+
+	updates <- struct{}{}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for reloadCount.Load() < 3 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	w.close()
+
+	if got := reloadCount.Load(); got != 3 {
+		t.Fatalf("expected reload to be retried until success (3 calls), got %d", got)
 	}
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ aliases:
 * BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): fix multiple `VMUser` resources configured with `spec.jwt` in the same namespace being treated as duplicates and dropped from the `vmauth` config, since they weren't keyed by their own name. See [#2532](https://github.com/VictoriaMetrics/operator/issues/2532).
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): create and remove RBAC resources in namespaces configured for each reconciler.
 * BUGFIX: [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): write the relabeling asset under the key that the `-relabelConfig` flag reads, fixing the crash-loop of `VMSingle` with `spec.relabelConfig` or `spec.inlineRelabelConfig`. See [#2552](https://github.com/VictoriaMetrics/operator/issues/2552).
+* BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): config-reloader: trigger an application reload after the initial directory sync and retry failed reload requests with backoff. Previously, a config change landing between the init container's copy and the sidecar's start could leave the application serving stale content until the next change. See [#2527](https://github.com/VictoriaMetrics/operator/issues/2527).
 
 ## [v0.74.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.74.1)
 **Release date:** 04 Aug 2026


### PR DESCRIPTION
Fixes #2527

### Problem

Since v0.72.0, VMAlert reads its rule files from an emptyDir populated by the `config-init` init container and synced by the `config-reloader` sidecar. If the rules ConfigMap is updated between the init container's copy and the sidecar starting, the sidecar's initial sync writes the new content to the target dir but never notifies the application. The application keeps serving the snapshot it read at startup, and if the ConfigMap never changes again, no fsnotify event ever fires — the stale state is permanent.

### Fix

- `dirWatcher.start()` sends one reload signal after the initial directory sync, provided at least one watched directory completed it. This also applies to watch-only directories (no `--target-dir`): the same startup race exists there — a change landing between the application's first read and the watch being established produces no event — just with a smaller window.
- Failed reload calls are retried with exponential backoff (1s, doubling up to 30s) until they succeed. Without this, the startup reload could be lost when the application's reload endpoint is not listening yet, reintroducing the same permanent staleness. This also covers transient failures of event-driven reloads.
- The directory content hash is committed to the cache only after a successful sync (suggested by @vrutkovs). A failed sync — at startup or on an event — leaves the hash uncommitted, so the next fsnotify event retries it naturally, without a dedicated retry loop. This also fixes a pre-existing gap where a failed event-driven sync was never retried, because the hash had already been cached.

### Tests

- reload retry: the reload call fails twice and succeeds on the third attempt
- failed initial sync: no startup reload fires, and the next event retries the sync and triggers the reload even for unchanged content, since the hash was never committed
- partial failure: a failing pair does not hold back the startup reload for a pair that synced successfully
- liveness: events for healthy directories are processed while another pair's sync keeps failing
- no watched dirs: no startup reload
- existing dir-watcher tests drain the startup signal, pinning the new behavior
