### PR TITLE
test(e2e): allow headless service in UseAsDefault

### DIFF
--- a/api/operator/v1beta1/vmalertmanager_types_test.go
+++ b/api/operator/v1beta1/vmalertmanager_types_test.go
@@ -73,11 +73,34 @@ receivers:
 			Spec: VMAlertmanagerSpec{
 				ServiceSpec: &AdditionalServiceSpec{
 					UseAsDefault: true,
-					Spec:         corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Spec: corev1.ServiceSpec{
+						Type:      corev1.ServiceTypeClusterIP,
+						ClusterIP: "1.1.1.1",
+					},
 				},
 			},
 		},
 		wantErr: true,
+	})
+
+	// serviceSpec.useAsDefault with headless service is allowed
+	f(opts{
+		cr: &VMAlertmanager{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-suite",
+				Namespace: "test",
+			},
+			Spec: VMAlertmanagerSpec{
+				ServiceSpec: &AdditionalServiceSpec{
+					UseAsDefault: true,
+					Spec: corev1.ServiceSpec{
+						Type:      corev1.ServiceTypeClusterIP,
+						ClusterIP: corev1.ClusterIPNone,
+					},
+				},
+			},
+		},
+		wantErr: false,
 	})
 
 	// serviceSpec.useAsDefault without an explicit type is allowed

--- a/api/operator/v1beta1/vmcluster_types_test.go
+++ b/api/operator/v1beta1/vmcluster_types_test.go
@@ -382,10 +382,25 @@ func TestVMCluster_Validate(t *testing.T) {
 		VMSelect: &VMSelect{
 			ServiceSpec: &AdditionalServiceSpec{
 				UseAsDefault: true,
-				Spec:         corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "1.1.1.1",
+				},
 			},
 		},
 	}, true)
+
+	f(VMClusterSpec{
+		VMSelect: &VMSelect{
+			ServiceSpec: &AdditionalServiceSpec{
+				UseAsDefault: true,
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+				},
+			},
+		},
+	}, false)
 
 	// vmselect: useAsDefault without an explicit type is allowed
 	f(VMClusterSpec{
@@ -408,15 +423,31 @@ func TestVMCluster_Validate(t *testing.T) {
 		},
 	}, false)
 
-	// vmstorage: useAsDefault with an explicit service type must be rejected (default service is headless)
+	// vmstorage: useAsDefault with cluster IP set must be rejected (default service is headless)
 	f(VMClusterSpec{
 		VMStorage: &VMStorage{
 			ServiceSpec: &AdditionalServiceSpec{
 				UseAsDefault: true,
-				Spec:         corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: "1.1.1.1",
+				},
 			},
 		},
 	}, true)
+
+	// vmstorage: useAsDefault without cluster IP set must be allowed
+	f(VMClusterSpec{
+		VMStorage: &VMStorage{
+			ServiceSpec: &AdditionalServiceSpec{
+				UseAsDefault: true,
+				Spec: corev1.ServiceSpec{
+					Type:      corev1.ServiceTypeClusterIP,
+					ClusterIP: corev1.ClusterIPNone,
+				},
+			},
+		},
+	}, false)
 
 	// vmstorage: useAsDefault without an explicit type is allowed
 	f(VMClusterSpec{

--- a/api/operator/v1beta1/vmextra_types.go
+++ b/api/operator/v1beta1/vmextra_types.go
@@ -403,7 +403,11 @@ func (asc *AdditionalServiceSpec) ValidateNoServiceTypeOverrideWithUseAsDefault(
 	if asc == nil || !asc.UseAsDefault {
 		return nil
 	}
-	if asc.Spec.Type != "" && asc.Spec.Type != corev1.ServiceTypeClusterIP {
+	// Fast path: allow headless services
+	if asc.Spec.Type == corev1.ServiceTypeClusterIP && asc.Spec.ClusterIP == corev1.ClusterIPNone {
+		return nil
+	}
+	if asc.Spec.Type != "" {
 		return fmt.Errorf("serviceSpec.useAsDefault cannot be combined with an explicit spec.type=%q: the default service is headless (clusterIP: None) and must stay headless. Remove spec.type, or create a separate service with serviceSpec.useAsDefault=false and a distinct metadata.name", asc.Spec.Type)
 	}
 	return nil


### PR DESCRIPTION
Instead of a blanket ban on ClusterIP services for default additional service we should allow headless ClusterIP services.

Follow up for https://github.com/VictoriaMetrics/operator/pull/2523 and https://github.com/VictoriaMetrics/operator/pull/2491