### PR TITLE
vmuser: fixed collision for objects with JWT auth

### DIFF
--- a/api/operator/v1beta1/vmuser_types.go
+++ b/api/operator/v1beta1/vmuser_types.go
@@ -411,6 +411,8 @@ func (cr *VMUser) AsKey(hide bool) string {
 	switch {
 	case cr.Spec.BearerToken != nil:
 		id = "bearerToken:" + hideFn(*cr.Spec.BearerToken)
+	case cr.Spec.JWT != nil:
+		id = "jwt:" + cr.Name
 	default:
 		if cr.Spec.Username != nil {
 			id = "basicAuth:" + hideFn(*cr.Spec.Username)

--- a/api/operator/v1beta1/vmuser_types_test.go
+++ b/api/operator/v1beta1/vmuser_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -109,6 +110,47 @@ func TestVMUser_Validate(t *testing.T) {
 			},
 		},
 	}, false)
+}
+
+func TestVMUser_AsKey(t *testing.T) {
+	f := func(cr *VMUser, hide bool, want string) {
+		t.Helper()
+		assert.Equal(t, want, cr.AsKey(hide))
+	}
+
+	// bearerToken
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-1", Namespace: "ns"},
+		Spec:       VMUserSpec{BearerToken: ptr.To("some-token")},
+	}, false, "ns/bearerToken:some-token")
+
+	// basicAuth with username
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-1", Namespace: "ns"},
+		Spec:       VMUserSpec{Username: ptr.To("some-user")},
+	}, false, "ns/basicAuth:some-user")
+
+	// basicAuth without username falls back to cr.Name
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-1", Namespace: "ns"},
+	}, false, "ns/basicAuth:user-1")
+
+	// jwt users with different names must produce different keys
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "awesome-team-logs-user", Namespace: "harbor"},
+		Spec:       VMUserSpec{JWT: &VMUserJWT{}},
+	}, false, "harbor/jwt:awesome-team-logs-user")
+
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-access-user", Namespace: "harbor"},
+		Spec:       VMUserSpec{JWT: &VMUserJWT{}},
+	}, false, "harbor/jwt:custom-access-user")
+
+	// hide has no effect on jwt key, since it's based on the CR name, not a secret
+	f(&VMUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "awesome-team-logs-user", Namespace: "harbor"},
+		Spec:       VMUserSpec{JWT: &VMUserJWT{}},
+	}, true, "harbor/jwt:awesome-team-logs-user")
 }
 
 func TestVMUser_PrefixedName(t *testing.T) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): set default values for each possible `level` label of `operator_log_messages_total` metric. See [#2477](https://github.com/VictoriaMetrics/operator/issues/2477).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fix reconciliation error on Kubernetes 1.29 caused by setting an empty `preStop` lifecycle handler. The native `Sleep` preStop action now requires Kubernetes >= 1.30, since the `PodLifecycleSleepAction` feature gate is not enabled by default on 1.29.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): removing `spec.hpa` no longer leaves the previously created `HorizontalPodAutoscaler` behind. `HorizontalPodAutoscaler` and `VerticalPodAutoscaler` objects created for `VMAgent` and `VMAnomaly` now use the operator's consistent naming convention for child objects (e.g. `vmagent-<name>`) instead of the bare CR name; a leftover object under the old name is cleaned up automatically on the next reconcile. See [#2518](https://github.com/VictoriaMetrics/operator/issues/2518).
+* BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): fix multiple `VMUser` resources configured with `spec.jwt` in the same namespace being treated as duplicates and dropped from the `vmauth` config, since they weren't keyed by their own name. See [#2532](https://github.com/VictoriaMetrics/operator/issues/2532).
 
 ## [v0.74.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.74.1)
 **Release date:** 04 Aug 2026


### PR DESCRIPTION
fixes https://github.com/VictoriaMetrics/operator/issues/2532

with this change vmuser objects with jwt auth will have a key in format `${vmuser.namespace}/jwt:${vmuser.name}`, which allows to configure multiple vmusers with identical jwt section as it's allowed by vmauth