### PR TITLE
operator: added single operator_controller_errors_total metric with reason labels for all reconcile errors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ aliases:
 
 * FEATURE: [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): support bounded `spec.reader.workers`, query-level business policies, and `settings.native_threads_per_worker` introduced in vmanomaly v1.30.2.
 * FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): Add `k8s_version` label to `vm_app_version` metric.
+* FEATURE: [vmoperator](https://docs.victoriametrics.com/operator/): add a unified `operator_controller_errors_total{controller, namespaced_name, reason}` metric covering all reconcile failure categories (`get_object`, `parse_object`, `cancel_context`, `conflict`, `other`) across every controller, replacing several single-purpose counters that will be removed in a future release.
 
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmanomaly](https://docs.victoriametrics.com/operator/resources/vmanomaly/): default `spec.shardCount` to `0` at the CRD schema level, fixing `VerticalPodAutoscaler`'s `/scale` subresource lookups failing with `the spec replicas field ".spec.shardCount" does not exist` whenever sharding wasn't configured (the common case). See [#2473](https://github.com/VictoriaMetrics/operator/issues/2473).
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): set default values for each possible `level` label of `operator_log_messages_total` metric. See [#2477](https://github.com/VictoriaMetrics/operator/issues/2477).

--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -50,6 +51,7 @@ var (
 )
 
 var (
+	// TODO: remove parseObjectErrorsTotal, getObjectsErrorsTotal, conflictErrorsTotal, contextCancelErrorsTotal after release 0.80.0
 	parseObjectErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "operator_controller_object_parsing_errors_total",
 		Help: "Counts number of objects, that was failed to parse from json",
@@ -62,20 +64,41 @@ var (
 		Name: "operator_controller_reconcile_conflict_errors_total",
 		Help: "Counts number of errors with race conditions, when object was modified by external program at reconciliation",
 	}, []string{"controller", "namespaced_name"})
-	contextCancelErrorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	contextCancelErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "operator_controller_reconcile_errors_total",
 		Help: "Counts number context.Canceled errors",
-	})
+	}, []string{"controller", "namespaced_name"})
+
+	controllerErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "operator_controller_errors_total",
+		Help: "Counts number controller errors",
+	}, []string{"controller", "namespace", "name", "reason"})
 	activeConverterWatchers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "operator_prometheus_converter_active_watchers",
 	}, []string{"object_type_name"})
 )
 
+// Reasons a reconcile attempt can fail. They double as the "reason" label for controllerErrorsTotal.
+const (
+	reasonGetObject     = "get_object"
+	reasonParseObject   = "parse_object"
+	reasonCancelContext = "cancel_context"
+	reasonConflict      = "conflict"
+	reasonOther         = "other"
+)
+
+var legacyCounters = map[string]*prometheus.CounterVec{
+	reasonGetObject:     getObjectsErrorsTotal,
+	reasonParseObject:   parseObjectErrorsTotal,
+	reasonConflict:      conflictErrorsTotal,
+	reasonCancelContext: contextCancelErrorsTotal,
+}
+
 // InitMetrics adds metrics to the Registry
 func init() {
 	metrics.Registry.MustRegister(
 		parseObjectErrorsTotal, getObjectsErrorsTotal, conflictErrorsTotal,
-		contextCancelErrorsTotal, activeConverterWatchers)
+		contextCancelErrorsTotal, activeConverterWatchers, controllerErrorsTotal)
 }
 
 func getDefaultOptions() controller.Options {
@@ -89,42 +112,62 @@ func getDefaultOptions() controller.Options {
 	return *defaultOptions
 }
 
-// parsingError usually occurs in case of x-preserve-unknown-fields option enable to CRD
-// in this case k8s api server cannot perform proper validation and it may result in bad user input for some fields
-type parsingError struct {
-	origin     string
-	controller string
-}
-
 // ErrShutdown is a custom error returned as a cause of operator context cancel
 var ErrShutdown = fmt.Errorf("graceful shutdown, exiting")
 
-func (pe *parsingError) Error() string {
-	return fmt.Sprintf("parsing object error for object controller=%q: %q",
-		pe.controller, pe.origin)
+// reconcileError wraps a failure that happened while fetching or parsing the reconciled object,
+// tagged with reason (reasonGetObject or reasonParseObject) so handleReconcileErr can tell them apart.
+type reconcileError struct {
+	origin error
+	reason string
 }
 
-func isParsingError(err error) bool {
-	var pe *parsingError
-	return errors.As(err, &pe)
+// newGetError wraps a client.Get failure as a reconcileError tagged reasonGetObject.
+func newGetError(err error) error {
+	return &reconcileError{origin: err, reason: reasonGetObject}
 }
 
-// getError could usually occur at following cases:
-// - not enough k8s permissions
-// - object was deleted and due to race condition queue by operator cache
-type getError struct {
-	origin        error
-	controller    string
-	requestObject ctrl.Request
+// newParsingError wraps a stored ParsingSpecError message as a reconcileError tagged reasonParseObject.
+func newParsingError(msg string) error {
+	return &reconcileError{origin: errors.New(msg), reason: reasonParseObject}
 }
 
 // Unwrap implements errors.Unwrap interface
-func (ge *getError) Unwrap() error {
-	return ge.origin
+func (re *reconcileError) Unwrap() error {
+	return re.origin
 }
 
-func (ge *getError) Error() string {
-	return fmt.Sprintf("get_object error for controller=%q object_name=%q at namespace=%q, origin=%q", ge.controller, ge.requestObject.Name, ge.requestObject.Namespace, ge.origin)
+func (re *reconcileError) Error() string {
+	return fmt.Sprintf("%s error, origin=%q", re.reason, re.origin)
+}
+
+func isParsingError(err error) bool {
+	var re *reconcileError
+	return errors.As(err, &re) && re.reason == reasonParseObject
+}
+
+func controllerNameFromObject(object client.Object) string {
+	t := reflect.TypeOf(object)
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil {
+		return ""
+	}
+	return strings.ToLower(t.Name())
+}
+
+func hasIdentity(object client.Object) bool {
+	return object != nil && !reflect.ValueOf(object).IsNil() && object.GetNamespace() != ""
+}
+
+func incControllerError(object client.Object, reason string) {
+	controller := controllerNameFromObject(object)
+	namespace, name := object.GetNamespace(), object.GetName()
+	controllerErrorsTotal.WithLabelValues(controller, namespace, name, reason).Inc()
+	if legacyCounter, ok := legacyCounters[reason]; ok {
+		legacyCounter.WithLabelValues(controller, fmt.Sprintf("%s/%s", namespace, name)).Inc()
+	}
 }
 
 func handleReconcileErrWithStatus[T client.Object, ST reconcile.StatusWithMetadata[STC], STC any](
@@ -143,64 +186,64 @@ func handleReconcileErrWithStatus[T client.Object, ST reconcile.StatusWithMetada
 	return result, err
 }
 
+// +kubebuilder:rbac:groups="",resources=events,verbs=create
 func handleReconcileErr(ctx context.Context, rclient client.Client, object client.Object, originResult ctrl.Result, err error) (ctrl.Result, error) {
-	if err == nil {
-		return originResult, nil
+	if err == nil || !hasIdentity(object) {
+		return originResult, err
 	}
 
-	switch e := err.(type) {
-	case *getError:
-		deregisterObjectByCollector(e.requestObject.Name, e.requestObject.Namespace, e.controller)
-		getObjectsErrorsTotal.WithLabelValues(e.controller, e.requestObject.String()).Inc()
-		if k8serrors.IsNotFound(err) {
-			return originResult, nil
-		}
-	case *parsingError:
-		if object != nil && !reflect.ValueOf(object).IsNil() {
-			namespacedName := fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName())
-			parseObjectErrorsTotal.WithLabelValues(e.controller, namespacedName).Inc()
-		}
-	}
+	var re *reconcileError
 
 	switch {
-	case errors.Is(err, context.Canceled):
-		contextCancelErrorsTotal.Inc()
-		if !errors.Is(context.Cause(ctx), ErrShutdown) {
-			originResult.RequeueAfter = time.Second * 5
+	case errors.As(err, &re):
+		if re.reason == reasonGetObject {
+			deregisterObjectByCollector(object.GetName(), object.GetNamespace(), controllerNameFromObject(object))
+			if k8serrors.IsNotFound(err) {
+				return originResult, nil
+			}
 		}
+		incControllerError(object, re.reason)
+	case errors.Is(err, context.Canceled):
+		if errors.Is(context.Cause(ctx), ErrShutdown) {
+			return originResult, nil
+		}
+		incControllerError(object, reasonCancelContext)
+		originResult.RequeueAfter = time.Second * 5
 		return originResult, nil
 	case k8serrors.IsConflict(err):
-		if object != nil && !reflect.ValueOf(object).IsNil() && object.GetNamespace() != "" {
-			controller := object.GetObjectKind().GroupVersionKind().GroupKind().Kind
-			namespacedName := fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName())
-			conflictErrorsTotal.WithLabelValues(controller, namespacedName).Inc()
-		}
-		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+		incControllerError(object, reasonConflict)
+		originResult.RequeueAfter = time.Second * 5
+		return originResult, nil
+	default:
+		incControllerError(object, reasonOther)
 	}
-	if object != nil && !reflect.ValueOf(object).IsNil() && object.GetNamespace() != "" {
-		errEvent := &corev1.Event{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "victoria-metrics-operator-" + uuid.New().String(),
-				Namespace: object.GetNamespace(),
+
+	// object is guaranteed to have identity here: the early return above already filtered out objects without one.
+	errEvent := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "victoria-metrics-operator-" + uuid.New().String(),
+			Namespace: object.GetNamespace(),
+			Annotations: map[string]string{
+				"operator.victoriametrics.com/controller": controllerNameFromObject(object),
 			},
-			Type:    corev1.EventTypeWarning,
-			Reason:  "ReconciliationError",
-			Message: err.Error(),
-			Source: corev1.EventSource{
-				Component: "victoria-metrics-operator",
-			},
-			LastTimestamp: metav1.NewTime(time.Now()),
-			InvolvedObject: corev1.ObjectReference{
-				Kind:            object.GetObjectKind().GroupVersionKind().Kind,
-				Namespace:       object.GetNamespace(),
-				Name:            object.GetName(),
-				UID:             object.GetUID(),
-				ResourceVersion: object.GetResourceVersion(),
-			},
-		}
-		if err := rclient.Create(ctx, errEvent); err != nil {
-			logger.WithContext(ctx).Error(err, "failed to create error event at kubernetes API during reconciliation error")
-		}
+		},
+		Type:    corev1.EventTypeWarning,
+		Reason:  "ReconciliationError",
+		Message: err.Error(),
+		Source: corev1.EventSource{
+			Component: "victoria-metrics-operator",
+		},
+		LastTimestamp: metav1.NewTime(time.Now()),
+		InvolvedObject: corev1.ObjectReference{
+			Kind:            object.GetObjectKind().GroupVersionKind().Kind,
+			Namespace:       object.GetNamespace(),
+			Name:            object.GetName(),
+			UID:             object.GetUID(),
+			ResourceVersion: object.GetResourceVersion(),
+		},
+	}
+	if err := rclient.Create(ctx, errEvent); err != nil {
+		logger.WithContext(ctx).Error(err, "failed to create error event at kubernetes API during reconciliation error")
 	}
 	return originResult, err
 }

--- a/internal/controller/operator/controllers_test.go
+++ b/internal/controller/operator/controllers_test.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -361,7 +363,7 @@ func TestHandleReconcileErrWithStatus(t *testing.T) {
 
 	// parsingError
 	f(opts{
-		err: &parsingError{origin: "bad field value", controller: "vmcluster"},
+		err: newParsingError("bad field value"),
 		object: &vmv1beta1.VMCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
@@ -370,14 +372,19 @@ func TestHandleReconcileErrWithStatus(t *testing.T) {
 		},
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{},
-		wantErr:    &parsingError{origin: "bad field value", controller: "vmcluster"},
+		wantErr:    newParsingError("bad field value"),
 		wantStatus: vmv1beta1.UpdateStatusFailed,
 	})
 
 	// context.Canceled sets RequeueAfter, no status update
 	f(opts{
-		err:        context.Canceled,
-		object:     &vmv1beta1.VMCluster{},
+		err: context.Canceled,
+		object: &vmv1beta1.VMCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		},
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{RequeueAfter: time.Second * 5},
 		wantErr:    nil,
@@ -385,10 +392,24 @@ func TestHandleReconcileErrWithStatus(t *testing.T) {
 
 	// transient error
 	f(opts{
-		err:        fmt.Errorf("some transient error"),
-		object:     &vmv1beta1.VMCluster{},
+		err: fmt.Errorf("some transient error"),
+		object: &vmv1beta1.VMCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+		},
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{},
+		wantErr:    fmt.Errorf("some transient error"),
+	})
+
+	// object without identity (no namespace): result/error pass through unchanged, no event/status update attempted
+	f(opts{
+		err:        fmt.Errorf("some transient error"),
+		object:     &vmv1beta1.VMCluster{},
+		origin:     ctrl.Result{RequeueAfter: 10},
+		wantResult: ctrl.Result{RequeueAfter: 10},
 		wantErr:    fmt.Errorf("some transient error"),
 	})
 }
@@ -398,6 +419,7 @@ func TestHandleReconcileErr(t *testing.T) {
 		ctx        context.Context
 		err        error
 		origin     ctrl.Result
+		object     client.Object
 		wantResult ctrl.Result
 		wantErr    error
 	}
@@ -407,7 +429,12 @@ func TestHandleReconcileErr(t *testing.T) {
 		if o.ctx == nil {
 			o.ctx = context.Background()
 		}
-		got, err := handleReconcileErr(o.ctx, nil, (*vmv1beta1.VMCluster)(nil), o.origin, o.err)
+		object := o.object
+		if object == nil {
+			object = (*vmv1beta1.VMCluster)(nil)
+		}
+		fclient := k8stools.GetTestClientWithObjects(nil)
+		got, err := handleReconcileErr(o.ctx, fclient, object, o.origin, o.err)
 		assert.Equal(t, o.wantErr, err)
 		assert.Equal(t, o.wantResult, got)
 	}
@@ -420,9 +447,25 @@ func TestHandleReconcileErr(t *testing.T) {
 		wantErr:    nil,
 	})
 
+	// object without identity (nil): result/error pass through unchanged, no event/metrics side effects attempted
+	f(opts{
+		err:        context.Canceled,
+		origin:     ctrl.Result{RequeueAfter: 10},
+		wantResult: ctrl.Result{RequeueAfter: 10},
+		wantErr:    context.Canceled,
+	})
+
+	identified := &vmv1beta1.VMCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
 	// context canceled
 	f(opts{
 		err:        context.Canceled,
+		object:     identified,
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{RequeueAfter: time.Second * 5},
 		wantErr:    nil,
@@ -434,8 +477,51 @@ func TestHandleReconcileErr(t *testing.T) {
 	f(opts{
 		ctx:        shutdownCtx,
 		err:        fmt.Errorf("wrapped: %w", errors.Join(context.Canceled, ErrShutdown)),
+		object:     identified,
 		origin:     ctrl.Result{},
 		wantResult: ctrl.Result{},
+		wantErr:    nil,
+	})
+
+	gr := schema.GroupResource{Group: "operator.victoriametrics.com", Resource: "vmclusters"}
+
+	// getError wrapping NotFound: routine object deletion, swallowed silently, result passed through
+	notFoundErr := newGetError(k8serrors.NewNotFound(gr, "test-cluster"))
+	f(opts{
+		err:        notFoundErr,
+		object:     identified,
+		origin:     ctrl.Result{RequeueAfter: 10},
+		wantResult: ctrl.Result{RequeueAfter: 10},
+		wantErr:    nil,
+	})
+
+	// getError wrapping a real (non-NotFound) API error: propagates as-is
+	forbiddenErr := newGetError(k8serrors.NewForbidden(gr, "test-cluster", fmt.Errorf("no access")))
+	f(opts{
+		err:        forbiddenErr,
+		object:     identified,
+		origin:     ctrl.Result{},
+		wantResult: ctrl.Result{},
+		wantErr:    forbiddenErr,
+	})
+
+	// propagate cancel context if it's wrapped into getError
+	getCanceledErr := newGetError(fmt.Errorf("Get %q: %w", "https://example.com", context.Canceled))
+	f(opts{
+		err:        getCanceledErr,
+		object:     identified,
+		origin:     ctrl.Result{},
+		wantResult: ctrl.Result{},
+		wantErr:    getCanceledErr,
+	})
+
+	// conflict: swallowed, requeued after 5s
+	conflictErr := k8serrors.NewConflict(gr, "test-cluster", fmt.Errorf("stale resourceVersion"))
+	f(opts{
+		err:        conflictErr,
+		object:     identified,
+		origin:     ctrl.Result{},
+		wantResult: ctrl.Result{RequeueAfter: time.Second * 5},
 		wantErr:    nil,
 	})
 }

--- a/internal/controller/operator/promalertmanagerconfig_controller.go
+++ b/internal/controller/operator/promalertmanagerconfig_controller.go
@@ -71,15 +71,16 @@ func (r *PromAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ct
 	}()
 
 	// Fetch the PromAlertmanagerConfig instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	var cr *vmv1beta1.VMAlertmanagerConfig
 	if cr, err = converter.AlertmanagerConfig(&instance, r.BaseConf); err != nil {
-		err = &parsingError{err.Error(), r.name}
+		err = newParsingError(err.Error())
 		return
 	}
 	var owner *metav1.OwnerReference

--- a/internal/controller/operator/prompodmonitor_controller.go
+++ b/internal/controller/operator/prompodmonitor_controller.go
@@ -70,8 +70,9 @@ func (r *PromPodMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}()
 
 	// Fetch the PromPodMonitor instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 

--- a/internal/controller/operator/promprobe_controller.go
+++ b/internal/controller/operator/promprobe_controller.go
@@ -70,8 +70,9 @@ func (r *PromProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}()
 
 	// Fetch the PromProbe instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 

--- a/internal/controller/operator/promrule_controller.go
+++ b/internal/controller/operator/promrule_controller.go
@@ -70,8 +70,9 @@ func (r *PromRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}()
 
 	// Fetch the PrometheusRule instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 

--- a/internal/controller/operator/promscrapeconfig_controller.go
+++ b/internal/controller/operator/promscrapeconfig_controller.go
@@ -71,15 +71,16 @@ func (r *PromScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}()
 
 	// Fetch the PromScrapeConfig instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	var cr *vmv1beta1.VMScrapeConfig
 	if cr, err = converter.ScrapeConfig(ctx, &instance, r.BaseConf); err != nil {
-		err = &parsingError{err.Error(), r.name}
+		err = newParsingError(err.Error())
 		return
 	}
 	var owner *metav1.OwnerReference

--- a/internal/controller/operator/promservicemonitor_controller.go
+++ b/internal/controller/operator/promservicemonitor_controller.go
@@ -70,8 +70,9 @@ func (r *PromServiceMonitorReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}()
 
 	// Fetch the PromServiceMonitor instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 

--- a/internal/controller/operator/vlagent_controller.go
+++ b/internal/controller/operator/vlagent_controller.go
@@ -73,8 +73,9 @@ func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VLAgent instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: r.name, requestObject: req}
+		err = newGetError(err)
 		return
 	}
 
@@ -85,7 +86,7 @@ func (r *VLAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vlcluster_controller.go
+++ b/internal/controller/operator/vlcluster_controller.go
@@ -69,8 +69,9 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -80,7 +81,7 @@ func (r *VLClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vldistributed_controller.go
+++ b/internal/controller/operator/vldistributed_controller.go
@@ -67,8 +67,9 @@ func (r *VLDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}()
 
 	// Fetch VLDistributed instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (r *VLDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	// Check parsing error
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vlogs_controller.go
+++ b/internal/controller/operator/vlogs_controller.go
@@ -72,8 +72,9 @@ func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -83,7 +84,7 @@ func (r *VLogsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	l.Info("VLogs CustomResource transited into read-only state. Please migrate to the VLSingle.")

--- a/internal/controller/operator/vlsingle_controller.go
+++ b/internal/controller/operator/vlsingle_controller.go
@@ -70,8 +70,9 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -81,7 +82,7 @@ func (r *VLSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -90,8 +90,9 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}()
 
 	// Fetch the VMAgent instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: r.name, requestObject: req}
+		err = newGetError(err)
 		return
 	}
 
@@ -107,7 +108,7 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmalert_controller.go
+++ b/internal/controller/operator/vmalert_controller.go
@@ -80,8 +80,9 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -97,7 +98,7 @@ func (r *VMAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}
 
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanager_controller.go
+++ b/internal/controller/operator/vmalertmanager_controller.go
@@ -83,8 +83,9 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -99,7 +100,7 @@ func (r *VMAlertmanagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmalertmanagerconfig_controller.go
+++ b/internal/controller/operator/vmalertmanagerconfig_controller.go
@@ -69,14 +69,15 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if alertmanagerReconcileLimit.Throttle() {

--- a/internal/controller/operator/vmanomaly_controller.go
+++ b/internal/controller/operator/vmanomaly_controller.go
@@ -80,8 +80,9 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VMAnomaly instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{origin: err, controller: r.name, requestObject: req}
+		err = newGetError(err)
 		return
 	}
 
@@ -97,7 +98,7 @@ func (r *VMAnomalyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmanomalyconfig_controller.go
+++ b/internal/controller/operator/vmanomalyconfig_controller.go
@@ -71,8 +71,9 @@ func (r *VMAnomalyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	// Fetch the VMAnomalyConfig instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 

--- a/internal/controller/operator/vmauth_controller.go
+++ b/internal/controller/operator/vmauth_controller.go
@@ -81,8 +81,9 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		return result, &getError{err, r.name, req}
+		return result, newGetError(err)
 	}
 
 	if !instance.IsUnmanaged() {
@@ -98,7 +99,7 @@ func (r *VMAuthReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmcluster_controller.go
+++ b/internal/controller/operator/vmcluster_controller.go
@@ -58,8 +58,9 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = request.Name, request.Namespace
 	if err = r.Client.Get(ctx, request.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, request}
+		err = newGetError(err)
 		return
 	}
 
@@ -70,7 +71,7 @@ func (r *VMClusterReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmdistributed_controller.go
+++ b/internal/controller/operator/vmdistributed_controller.go
@@ -67,8 +67,9 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}()
 
 	// Fetch VMDistributed instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (r *VMDistributedReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	// Check parsing error
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmnodescrape_controller.go
+++ b/internal/controller/operator/vmnodescrape_controller.go
@@ -68,14 +68,15 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}()
 
 	// Fetch the VMNodeScrape instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vmpodscrape_controller.go
+++ b/internal/controller/operator/vmpodscrape_controller.go
@@ -67,14 +67,15 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 	// Fetch the VMPodScrape instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmprobe_controller.go
+++ b/internal/controller/operator/vmprobe_controller.go
@@ -67,14 +67,15 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	}()
 
 	// Fetch the VMPodScrape instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmrule_controller.go
+++ b/internal/controller/operator/vmrule_controller.go
@@ -72,14 +72,15 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}()
 
 	// Fetch the VMRule instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if alertReconcileLimit.Throttle() {

--- a/internal/controller/operator/vmscrapeconfig_controller.go
+++ b/internal/controller/operator/vmscrapeconfig_controller.go
@@ -67,14 +67,15 @@ func (r *VMScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}()
 
 	// Fetch the VMScrapeConfig instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmservicescrape_controller.go
+++ b/internal/controller/operator/vmservicescrape_controller.go
@@ -67,14 +67,15 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	// Fetch the VMServiceScrape instance
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -94,8 +94,9 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -105,7 +106,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vmstaticscrape_controller.go
+++ b/internal/controller/operator/vmstaticscrape_controller.go
@@ -47,13 +47,14 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -72,8 +72,9 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 	if !instance.DeletionTimestamp.IsZero() {
@@ -85,7 +86,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}
 	RegisterObjectStat(&instance, r.name)
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 

--- a/internal/controller/operator/vtcluster_controller.go
+++ b/internal/controller/operator/vtcluster_controller.go
@@ -69,8 +69,9 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -80,7 +81,7 @@ func (r *VTClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {

--- a/internal/controller/operator/vtsingle_controller.go
+++ b/internal/controller/operator/vtsingle_controller.go
@@ -70,8 +70,9 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		result, err = handleReconcileErrWithStatus(ctx, r.Client, &instance, result, err)
 	}()
 
+	instance.Name, instance.Namespace = req.Name, req.Namespace
 	if err = r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		err = &getError{err, r.name, req}
+		err = newGetError(err)
 		return
 	}
 
@@ -81,7 +82,7 @@ func (r *VTSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		return
 	}
 	if instance.Status.ParsingSpecError != "" && !vmv1beta1.HasUnknownFields(instance.Status.ParsingSpecError) {
-		err = &parsingError{instance.Status.ParsingSpecError, r.name}
+		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
 	if err = finalize.AddFinalizer(ctx, r.Client, &instance); err != nil {


### PR DESCRIPTION
related issue https://github.com/VictoriaMetrics/operator/issues/2495

Currently operator metrics track only certain reconcile errors also `operator_controller_reconcile_errors_total` despite it's name tracks only cancel context errors. Added `operator_controller_errors_total` with `controller`, `namespace`, `name` and `reason` labels as a replacement for all per-error type reconcile error counter and additionally introduced `reason="other"` to track other errors, which are not tracked at the moment