### PR TITLE
fix: scope RBAC namespaces per reconciler

### DIFF
--- a/api/operator/v1beta1/vmagent_types.go
+++ b/api/operator/v1beta1/vmagent_types.go
@@ -768,3 +768,22 @@ type APIServerConfig struct {
 	// +optional
 	Authorization *Authorization `json:"authorization,omitempty"`
 }
+
+// RBACNamespaces returns the namespaces to watch for RBAC resources.
+func (cr *VMAgent) RBACNamespaces(watchedNamespaces []string) []string {
+	if len(watchedNamespaces) == 0 {
+		return nil
+	}
+
+	if cr.Spec.SelectAllByDefault ||
+		cr.Spec.ServiceScrapeNamespaceSelector != nil ||
+		cr.Spec.PodScrapeNamespaceSelector != nil ||
+		cr.Spec.ProbeNamespaceSelector != nil ||
+		cr.Spec.NodeScrapeNamespaceSelector != nil ||
+		cr.Spec.StaticScrapeNamespaceSelector != nil ||
+		cr.Spec.ScrapeConfigNamespaceSelector != nil {
+		return watchedNamespaces
+	}
+
+	return []string{cr.Namespace}
+}

--- a/api/operator/v1beta1/vmsingle_types.go
+++ b/api/operator/v1beta1/vmsingle_types.go
@@ -494,3 +494,22 @@ func (cr *VMSingle) GetStatusMetadata() *StatusMetadata {
 func (cr *VMSingle) GetAdditionalService() *AdditionalServiceSpec {
 	return cr.Spec.ServiceSpec
 }
+
+// RBACNamespaces returns the namespaces to watch for RBAC resources.
+func (cr *VMSingle) RBACNamespaces(watchedNamespaces []string) []string {
+	if len(watchedNamespaces) == 0 {
+		return nil
+	}
+
+	if cr.Spec.SelectAllByDefault ||
+		cr.Spec.ServiceScrapeNamespaceSelector != nil ||
+		cr.Spec.PodScrapeNamespaceSelector != nil ||
+		cr.Spec.ProbeNamespaceSelector != nil ||
+		cr.Spec.NodeScrapeNamespaceSelector != nil ||
+		cr.Spec.StaticScrapeNamespaceSelector != nil ||
+		cr.Spec.ScrapeConfigNamespaceSelector != nil {
+		return watchedNamespaces
+	}
+
+	return []string{cr.Namespace}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ aliases:
 * BUGFIX: [vmoperator](https://docs.victoriametrics.com/operator/): fix reconciliation error on Kubernetes 1.29 caused by setting an empty `preStop` lifecycle handler. The native `Sleep` preStop action now requires Kubernetes >= 1.30, since the `PodLifecycleSleepAction` feature gate is not enabled by default on 1.29.
 * BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/): removing `spec.hpa` no longer leaves the previously created `HorizontalPodAutoscaler` behind. `HorizontalPodAutoscaler` and `VerticalPodAutoscaler` objects created for `VMAgent` and `VMAnomaly` now use the operator's consistent naming convention for child objects (e.g. `vmagent-<name>`) instead of the bare CR name; a leftover object under the old name is cleaned up automatically on the next reconcile. See [#2518](https://github.com/VictoriaMetrics/operator/issues/2518).
 * BUGFIX: [vmuser](https://docs.victoriametrics.com/operator/resources/vmuser/): fix multiple `VMUser` resources configured with `spec.jwt` in the same namespace being treated as duplicates and dropped from the `vmauth` config, since they weren't keyed by their own name. See [#2532](https://github.com/VictoriaMetrics/operator/issues/2532).
+* BUGFIX: [vmagent](https://docs.victoriametrics.com/operator/resources/vmagent/), [vmsingle](https://docs.victoriametrics.com/operator/resources/vmsingle/): create and remove RBAC resources in namespaces configured for each reconciler.
 
 ## [v0.74.1](https://github.com/VictoriaMetrics/operator/releases/tag/v0.74.1)
 **Release date:** 04 Aug 2026

--- a/internal/controller/operator/controllers.go
+++ b/internal/controller/operator/controllers.go
@@ -25,7 +25,6 @@ import (
 	k8sreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
-	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/logger"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/reconcile"
@@ -249,8 +248,7 @@ func handleReconcileErr(ctx context.Context, rclient client.Client, object clien
 	return originResult, err
 }
 
-func isNamespaceSelectorMatches(ctx context.Context, rclient client.Client, sourceCRD, targetCRD client.Object, selector *metav1.LabelSelector) (bool, error) {
-	cfg := config.MustGetBaseConfig()
+func isNamespaceSelectorMatches(ctx context.Context, rclient client.Client, sourceCRD, targetCRD client.Object, selector *metav1.LabelSelector, watchNamespaces []string) (bool, error) {
 	switch {
 	case selector == nil:
 		if sourceCRD.GetNamespace() == targetCRD.GetNamespace() {
@@ -259,7 +257,7 @@ func isNamespaceSelectorMatches(ctx context.Context, rclient client.Client, sour
 		return false, nil
 	case len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0:
 		return true, nil
-	case len(cfg.WatchNamespaces) > 0:
+	case len(watchNamespaces) > 0:
 		// selector labels for namespace ignores by default for multi-namespace mode
 		return true, nil
 	}
@@ -283,13 +281,13 @@ func isNamespaceSelectorMatches(ctx context.Context, rclient client.Client, sour
 
 // isSelectorsMatchesTargetCRD checks if targetCRD matches sourceCRD by entity selectors and selectAll.
 // see https://docs.victoriametrics.com/operator/resources/vmagent/#scraping for details
-func isSelectorsMatchesTargetCRD(ctx context.Context, rclient client.Client, sourceCRD, targetCRD client.Object, opts *k8stools.SelectorOpts) (bool, error) {
+func isSelectorsMatchesTargetCRD(ctx context.Context, rclient client.Client, sourceCRD, targetCRD client.Object, opts *k8stools.SelectorOpts, watchNamespaces []string) (bool, error) {
 	// selectAll only works when opts.NamespaceSelector and opts.ObjectSelector opts are undefined
 	if opts == nil || (opts.ObjectSelector == nil && opts.NamespaceSelector == nil) {
 		return opts.SelectAll, nil
 	}
 	// check opts.NamespaceSelector, only return when NS not match
-	if isNsMatch, err := isNamespaceSelectorMatches(ctx, rclient, sourceCRD, targetCRD, opts.NamespaceSelector); !isNsMatch || err != nil {
+	if isNsMatch, err := isNamespaceSelectorMatches(ctx, rclient, sourceCRD, targetCRD, opts.NamespaceSelector, watchNamespaces); !isNsMatch || err != nil {
 		return isNsMatch, err
 	}
 	// in case of empty namespace object must be synchronized in any way,

--- a/internal/controller/operator/controllers_test.go
+++ b/internal/controller/operator/controllers_test.go
@@ -71,7 +71,7 @@ func TestIsSelectorsMatchesTargetCRD(t *testing.T) {
 
 	// match: namespace selector labels are ignored in multi-namespace mode
 	f(opts{
-		selectAll: true,
+		selectAll:       true,
 		watchNamespaces: []string{"n1"},
 		sourceCRD: &vmv1beta1.VMRule{
 			ObjectMeta: metav1.ObjectMeta{Name: "rule", Namespace: "n1"},

--- a/internal/controller/operator/controllers_test.go
+++ b/internal/controller/operator/controllers_test.go
@@ -28,6 +28,7 @@ func TestIsSelectorsMatchesTargetCRD(t *testing.T) {
 		selector          *metav1.LabelSelector
 		namespaceSelector *metav1.LabelSelector
 		predefinedObjects []runtime.Object
+		watchNamespaces   []string
 		isMatch           bool
 	}
 	f := func(o opts) {
@@ -38,7 +39,7 @@ func TestIsSelectorsMatchesTargetCRD(t *testing.T) {
 			NamespaceSelector: o.namespaceSelector,
 			ObjectSelector:    o.selector,
 		}
-		matches, err := isSelectorsMatchesTargetCRD(context.Background(), fclient, o.sourceCRD, o.targetCRD, opts)
+		matches, err := isSelectorsMatchesTargetCRD(context.Background(), fclient, o.sourceCRD, o.targetCRD, opts, o.watchNamespaces)
 		assert.NoError(t, err)
 		assert.Equal(t, matches, o.isMatch)
 	}
@@ -66,6 +67,20 @@ func TestIsSelectorsMatchesTargetCRD(t *testing.T) {
 			},
 		},
 		isMatch: true,
+	})
+
+	// match: namespace selector labels are ignored in multi-namespace mode
+	f(opts{
+		selectAll: true,
+		watchNamespaces: []string{"n1"},
+		sourceCRD: &vmv1beta1.VMRule{
+			ObjectMeta: metav1.ObjectMeta{Name: "rule", Namespace: "n1"},
+		},
+		targetCRD: &vmv1beta1.VMAlert{
+			ObjectMeta: metav1.ObjectMeta{Name: "vmalert", Namespace: "n2"},
+		},
+		namespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "ops"}},
+		isMatch:           true,
 	})
 
 	// not match: selectors are nil, selectAll=false

--- a/internal/controller/operator/factory/vmagent/rbac.go
+++ b/internal/controller/operator/factory/vmagent/rbac.go
@@ -121,24 +121,6 @@ func createK8sAPIAccess(ctx context.Context, rclient client.Client, cr, prevCR *
 	return nil
 }
 
-func rbacNamespaces(cr *vmv1beta1.VMAgent, watchedNamespaces []string) []string {
-	if len(watchedNamespaces) == 0 {
-		return nil
-	}
-
-	if cr.Spec.SelectAllByDefault ||
-		cr.Spec.ServiceScrapeNamespaceSelector != nil ||
-		cr.Spec.PodScrapeNamespaceSelector != nil ||
-		cr.Spec.ProbeNamespaceSelector != nil ||
-		cr.Spec.NodeScrapeNamespaceSelector != nil ||
-		cr.Spec.StaticScrapeNamespaceSelector != nil ||
-		cr.Spec.ScrapeConfigNamespaceSelector != nil {
-		return watchedNamespaces
-	}
-
-	return []string{cr.Namespace}
-}
-
 func ensureCRExist(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMAgent) error {
 	var prevClusterRole *rbacv1.ClusterRole
 	if prevCR != nil {

--- a/internal/controller/operator/factory/vmagent/rbac.go
+++ b/internal/controller/operator/factory/vmagent/rbac.go
@@ -121,6 +121,24 @@ func createK8sAPIAccess(ctx context.Context, rclient client.Client, cr, prevCR *
 	return nil
 }
 
+func rbacNamespaces(cr *vmv1beta1.VMAgent, watchedNamespaces []string) []string {
+	if len(watchedNamespaces) == 0 {
+		return nil
+	}
+
+	if cr.Spec.SelectAllByDefault ||
+		cr.Spec.ServiceScrapeNamespaceSelector != nil ||
+		cr.Spec.PodScrapeNamespaceSelector != nil ||
+		cr.Spec.ProbeNamespaceSelector != nil ||
+		cr.Spec.NodeScrapeNamespaceSelector != nil ||
+		cr.Spec.StaticScrapeNamespaceSelector != nil ||
+		cr.Spec.ScrapeConfigNamespaceSelector != nil {
+		return watchedNamespaces
+	}
+
+	return []string{cr.Namespace}
+}
+
 func ensureCRExist(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMAgent) error {
 	var prevClusterRole *rbacv1.ClusterRole
 	if prevCR != nil {

--- a/internal/controller/operator/factory/vmagent/rbac_test.go
+++ b/internal/controller/operator/factory/vmagent/rbac_test.go
@@ -17,6 +17,41 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
 
+func TestRBACNamespaces(t *testing.T) {
+	watchNamespaces := []string{"agent-ns", "other-ns"}
+	tests := []struct {
+		name string
+		cr   *vmv1beta1.VMAgent
+		want []string
+	}{
+		{
+			name: "default selectors",
+			cr:   &vmv1beta1.VMAgent{ObjectMeta: metav1.ObjectMeta{Namespace: "agent-ns"}},
+			want: []string{"agent-ns"},
+		},
+		{
+			name: "select all",
+			cr: &vmv1beta1.VMAgent{
+				Spec: vmv1beta1.VMAgentSpec{CommonScrapeParams: vmv1beta1.CommonScrapeParams{SelectAllByDefault: true}},
+			},
+			want: watchNamespaces,
+		},
+		{
+			name: "namespace selector",
+			cr: &vmv1beta1.VMAgent{
+				Spec: vmv1beta1.VMAgentSpec{CommonScrapeParams: vmv1beta1.CommonScrapeParams{ServiceScrapeNamespaceSelector: &metav1.LabelSelector{}}},
+			},
+			want: watchNamespaces,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rbacNamespaces(tt.cr, watchNamespaces))
+		})
+	}
+}
+
 func TestCreateVMAgentRBAC(t *testing.T) {
 	type opts struct {
 		cr                *vmv1beta1.VMAgent

--- a/internal/controller/operator/factory/vmagent/rbac_test.go
+++ b/internal/controller/operator/factory/vmagent/rbac_test.go
@@ -47,7 +47,7 @@ func TestRBACNamespaces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, rbacNamespaces(tt.cr, watchNamespaces))
+			assert.Equal(t, tt.want, tt.cr.RBACNamespaces(watchNamespaces))
 		})
 	}
 }

--- a/internal/controller/operator/factory/vmagent/scrapes_test.go
+++ b/internal/controller/operator/factory/vmagent/scrapes_test.go
@@ -40,7 +40,7 @@ func TestCreateOrUpdateScrapeConfig(t *testing.T) {
 		}
 		build.AddDefaults(testClient.Scheme())
 		ac := getAssetsCache(ctx, testClient, o.cr)
-		_, err := createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac)
+		_, err := createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac, config.MustGetBaseConfig())
 		assert.NoError(t, err)
 		var expectSecret corev1.Secret
 		assert.NoError(t, testClient.Get(ctx, types.NamespacedName{Namespace: o.cr.Namespace, Name: o.cr.PrefixedName()}, &expectSecret))
@@ -2164,7 +2164,7 @@ scrape_configs: []
 			},
 		}
 		ac := getAssetsCache(ctx, testClient, cr)
-		_, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac)
+		_, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac, config.MustGetBaseConfig())
 		assert.NoError(t, err)
 		var configSecret corev1.Secret
 		assert.NoError(t, testClient.Get(ctx, types.NamespacedName{Namespace: cr.Namespace, Name: cr.PrefixedName()}, &configSecret))

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -131,7 +131,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.C
 	return CreateOrUpdateWithConfig(ctx, cr, rclient, config.MustGetBaseConfig())
 }
 
-func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.Client, baseConf *config.BaseOperatorConf) error {
+func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.Client, cfg *config.BaseOperatorConf) error {
 	if cr.Paused() {
 		return nil
 	}
@@ -139,12 +139,11 @@ func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclien
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
-		if err := deleteOrphaned(ctx, rclient, cr); err != nil {
+		if err := deleteOrphaned(ctx, rclient, cr, cfg); err != nil {
 			return fmt.Errorf("cannot delete objects from prev state: %w", err)
 		}
 	}
 	owner := cr.AsOwner()
-	cfg := config.MustGetBaseConfig()
 	if cr.IsOwnsServiceAccount() {
 		var prevSA *corev1.ServiceAccount
 		if prevCR != nil {
@@ -154,7 +153,7 @@ func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclien
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, false) || cr.HasRemoteWriteSecrets() {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cr.RBACNamespaces(baseConf.WatchNamespaces)); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cr.RBACNamespaces(cfg.WatchNamespaces)); err != nil {
 				return fmt.Errorf("cannot create vmagent role and binding for it, err: %w", err)
 			}
 		}
@@ -184,7 +183,7 @@ func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclien
 	}
 
 	ac := getAssetsCache(ctx, rclient, cr)
-	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac)
+	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac, cfg)
 	if err != nil {
 		return err
 	}
@@ -1245,7 +1244,7 @@ func buildRemoteWriteArgs(cr *vmv1beta1.VMAgent, ac *build.AssetsCache) ([]strin
 	return args, nil
 }
 
-func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent) error {
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent, baseConf *config.BaseOperatorConf) error {
 	svcName := cr.PrefixedName()
 	keepServices := sets.New(svcName)
 	keepServiceScrapes := sets.New[string]()
@@ -1283,7 +1282,7 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	if cr.Spec.HPA == nil {
 		objsToRemove = append(objsToRemove, &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: objMeta})
 	}
-	if config.MustGetBaseConfig().VPAAPIEnabled {
+	if baseConf.VPAAPIEnabled {
 		if cr.PrefixedName() != cr.Name {
 			objsToRemove = append(objsToRemove, &vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.Name, Namespace: cr.Namespace}})
 		}
@@ -1297,14 +1296,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	if !cr.IsOwnsServiceAccount() {
 		objsToRemove = append(objsToRemove, &corev1.ServiceAccount{ObjectMeta: objMeta})
 		rbacName := cr.GetRBACName()
-		watchNamespaces := config.MustGetBaseConfig().WatchNamespaces
-		if len(watchNamespaces) == 0 {
+		rbacNamespaces := cr.RBACNamespaces(baseConf.WatchNamespaces)
+		if len(rbacNamespaces) == 0 {
 			objsToRemove = append(objsToRemove,
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 			)
 		} else {
-			for _, ns := range watchNamespaces {
+			for _, ns := range rbacNamespaces {
 				objsToRemove = append(objsToRemove,
 					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},
 					&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},
@@ -1331,18 +1330,22 @@ func getAssetsCache(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 
 // CreateOrUpdateScrapeConfig builds scrape configuration for VMAgent
 func CreateOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent, childObject client.Object) error {
+	return CreateOrUpdateScrapeConfigWithConfig(ctx, rclient, cr, childObject, config.MustGetBaseConfig())
+}
+
+func CreateOrUpdateScrapeConfigWithConfig(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMAgent, childObject client.Object, cfg *config.BaseOperatorConf) error {
 	var prevCR *vmv1beta1.VMAgent
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
 	}
 	ac := getAssetsCache(ctx, rclient, cr)
-	_, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, childObject, ac)
+	_, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, childObject, ac, cfg)
 	return err
 }
 
 // createOrUpdateScrapeConfig reconciles the main scrape config.
-func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMAgent, childObject client.Object, ac *build.AssetsCache) (int, error) {
+func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMAgent, childObject client.Object, ac *build.AssetsCache, cfg *config.BaseOperatorConf) (int, error) {
 	if ptr.Deref(cr.Spec.IngestOnlyMode, false) {
 		if !cr.HasRemoteWriteSecrets() {
 			return 0, nil
@@ -1386,7 +1389,7 @@ func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, 
 		Namespace:            cr.Namespace,
 		APIServerConfig:      cr.Spec.APIServerConfig,
 		MustUseNodeSelector:  cr.Spec.DaemonSetMode,
-		HasClusterWideAccess: config.IsClusterWideAccessAllowed() || !cr.IsOwnsServiceAccount(),
+		HasClusterWideAccess: len(cfg.WatchNamespaces) == 0 || !cr.IsOwnsServiceAccount(),
 		ExternalLabels:       cr.ExternalLabels(),
 	}
 	if !pos.HasClusterWideAccess {
@@ -1408,7 +1411,7 @@ func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, 
 	}
 
 	// Split jobs into gzip-compressed buckets, each fitting within the Kubernetes Secret limit.
-	buckets, err := build.PackItems(jobs, config.MustGetBaseConfig().ConfigDataBudgetBytes, 150)
+	buckets, err := build.PackItems(jobs, cfg.ConfigDataBudgetBytes, 150)
 	if err != nil {
 		return 0, fmt.Errorf("splitting scrape config into buckets: %w", err)
 	}

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -154,7 +154,7 @@ func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclien
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, false) || cr.HasRemoteWriteSecrets() {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, rbacNamespaces(cr, baseConf.WatchNamespaces)); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cr.RBACNamespaces(baseConf.WatchNamespaces)); err != nil {
 				return fmt.Errorf("cannot create vmagent role and binding for it, err: %w", err)
 			}
 		}

--- a/internal/controller/operator/factory/vmagent/vmagent.go
+++ b/internal/controller/operator/factory/vmagent/vmagent.go
@@ -128,6 +128,10 @@ func createOrUpdateService(ctx context.Context, rclient client.Client, cr, prevC
 // CreateOrUpdate creates deployment for vmagent and configures it
 // waits for healthy state
 func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.Client) error {
+	return CreateOrUpdateWithConfig(ctx, cr, rclient, config.MustGetBaseConfig())
+}
+
+func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.Client, baseConf *config.BaseOperatorConf) error {
 	if cr.Paused() {
 		return nil
 	}
@@ -150,7 +154,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMAgent, rclient client.C
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, false) || cr.HasRemoteWriteSecrets() {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cfg.WatchNamespaces); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, rbacNamespaces(cr, baseConf.WatchNamespaces)); err != nil {
 				return fmt.Errorf("cannot create vmagent role and binding for it, err: %w", err)
 			}
 		}

--- a/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
@@ -9,12 +9,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/VictoriaMetrics/operator/internal/config"
@@ -22,6 +24,32 @@ import (
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/reconcile"
 )
+
+func TestDeleteOrphaned_UsesReconcilerConfig(t *testing.T) {
+	ctx := context.Background()
+	cr := &vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmagent", Namespace: "agent-ns"},
+	}
+	rbacName := cr.GetRBACName()
+	foreignNamespace := "other-reconciler-ns"
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{
+		cr,
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
+		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}},
+	})
+
+	assert.NoError(t, deleteOrphaned(ctx, fclient, cr, &config.BaseOperatorConf{WatchNamespaces: []string{cr.Namespace}, VPAAPIEnabled: true}))
+	for _, obj := range []client.Object{&rbacv1.Role{}, &rbacv1.RoleBinding{}} {
+		err := fclient.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: cr.Namespace}, obj)
+		assert.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.NoError(t, fclient.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: foreignNamespace}, obj))
+	}
+	assert.True(t, k8serrors.IsNotFound(fclient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(), Namespace: cr.Namespace}, &vpav1.VerticalPodAutoscaler{})))
+}
 
 func Test_CreateOrUpdate_Actions(t *testing.T) {
 	type args struct {

--- a/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
+++ b/internal/controller/operator/factory/vmagent/vmagent_reconcile_test.go
@@ -29,16 +29,18 @@ func TestDeleteOrphaned_UsesReconcilerConfig(t *testing.T) {
 	ctx := context.Background()
 	cr := &vmv1beta1.VMAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "vmagent", Namespace: "agent-ns"},
+		Spec:       vmv1beta1.VMAgentSpec{ServiceAccountName: "external"},
 	}
 	rbacName := cr.GetRBACName()
+	owner := cr.AsOwner()
 	foreignNamespace := "other-reconciler-ns"
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{
 		cr,
-		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
-		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
-		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
 	})
 
 	assert.NoError(t, deleteOrphaned(ctx, fclient, cr, &config.BaseOperatorConf{WatchNamespaces: []string{cr.Namespace}, VPAAPIEnabled: true}))

--- a/internal/controller/operator/factory/vmsingle/scrapes_test.go
+++ b/internal/controller/operator/factory/vmsingle/scrapes_test.go
@@ -40,7 +40,7 @@ func TestCreateOrUpdateScrapeConfig(t *testing.T) {
 		}
 		build.AddDefaults(testClient.Scheme())
 		ac := getAssetsCache(ctx, testClient, o.cr)
-		_, err := createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac)
+		_, err := createOrUpdateScrapeConfig(ctx, testClient, o.cr, nil, nil, ac, config.MustGetBaseConfig())
 		assert.NoError(t, err)
 		var expectSecret corev1.Secret
 		nsn := types.NamespacedName{Namespace: o.cr.Namespace, Name: o.cr.PrefixedName()}
@@ -2028,7 +2028,7 @@ scrape_configs: []
 			},
 		}
 		ac := getAssetsCache(ctx, testClient, cr)
-		if _, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac); err != nil {
+	if _, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac, config.MustGetBaseConfig()); err != nil {
 			t.Errorf("createOrUpdateScrapeConfig() error = %s", err)
 		}
 		var configSecret corev1.Secret

--- a/internal/controller/operator/factory/vmsingle/scrapes_test.go
+++ b/internal/controller/operator/factory/vmsingle/scrapes_test.go
@@ -2028,7 +2028,7 @@ scrape_configs: []
 			},
 		}
 		ac := getAssetsCache(ctx, testClient, cr)
-	if _, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac, config.MustGetBaseConfig()); err != nil {
+		if _, err := createOrUpdateScrapeConfig(ctx, testClient, cr, nil, nil, ac, config.MustGetBaseConfig()); err != nil {
 			t.Errorf("createOrUpdateScrapeConfig() error = %s", err)
 		}
 		var configSecret corev1.Secret

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -77,16 +77,20 @@ func makePvc(cr *vmv1beta1.VMSingle) *corev1.PersistentVolumeClaim {
 
 // CreateOrUpdate performs an update for single node resource
 func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client) error {
+	return CreateOrUpdateWithConfig(ctx, cr, rclient, config.MustGetBaseConfig())
+}
+
+func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client, cfg *config.BaseOperatorConf) error {
 	if cr.Paused() {
 		return nil
 	}
 
 	var prevCR *vmv1beta1.VMSingle
-	cfg := config.MustGetBaseConfig()
+	rbacNamespaces := cr.RBACNamespaces(cfg.WatchNamespaces)
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
-		if err := deleteOrphaned(ctx, rclient, cr, cr.RBACNamespaces(cfg.WatchNamespaces)); err != nil {
+		if err := deleteOrphaned(ctx, rclient, cr, cfg); err != nil {
 			return fmt.Errorf("cannot delete objects from prev state: %w", err)
 		}
 	}
@@ -100,7 +104,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, true) {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cr.RBACNamespaces(cfg.WatchNamespaces)); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, rbacNamespaces); err != nil {
 				return fmt.Errorf("cannot create vmsingle role and binding for it, err: %w", err)
 			}
 		}
@@ -131,7 +135,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.
 	}
 
 	ac := getAssetsCache(ctx, rclient, cr)
-	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac)
+	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac, baseConf)
 	if err != nil {
 		return err
 	}
@@ -691,7 +695,7 @@ func createOrUpdateVPA(ctx context.Context, rclient client.Client, cr, prevCR *v
 	return reconcile.VPA(ctx, rclient, newVPA, prevVPA, &owner)
 }
 
-func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle, watchNamespaces []string) error {
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle, baseConf *config.BaseOperatorConf) error {
 	// TODO check storage for nil
 
 	svcName := cr.PrefixedName()
@@ -721,10 +725,9 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 		return fmt.Errorf("cannot remove configmaps: %w", err)
 	}
 
-	cfg := config.MustGetBaseConfig()
 	objMeta := metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}
 	var objsToRemove []client.Object
-	if cfg.VPAAPIEnabled && cr.Spec.VPA == nil {
+	if baseConf.VPAAPIEnabled && cr.Spec.VPA == nil {
 		objsToRemove = append(objsToRemove, &vpav1.VerticalPodAutoscaler{ObjectMeta: objMeta})
 	}
 	if cr.Spec.NetworkPolicy == nil {
@@ -733,13 +736,14 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	if !cr.IsOwnsServiceAccount() {
 		objsToRemove = append(objsToRemove, &corev1.ServiceAccount{ObjectMeta: objMeta})
 		rbacName := cr.GetRBACName()
-		if len(watchNamespaces) == 0 {
+		rbacNamespaces := cr.RBACNamespaces(baseConf.WatchNamespaces)
+		if len(rbacNamespaces) == 0 {
 			objsToRemove = append(objsToRemove,
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 			)
 		} else {
-			for _, ns := range watchNamespaces {
+			for _, ns := range rbacNamespaces {
 				objsToRemove = append(objsToRemove,
 					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},
 					&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},
@@ -766,18 +770,22 @@ func getAssetsCache(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 
 // CreateOrUpdateScrapeConfig builds scrape configuration for VMSingle
 func CreateOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle, childObject client.Object) error {
+	return CreateOrUpdateScrapeConfigWithConfig(ctx, rclient, cr, childObject, config.MustGetBaseConfig())
+}
+
+func CreateOrUpdateScrapeConfigWithConfig(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle, childObject client.Object, cfg *config.BaseOperatorConf) error {
 	var prevCR *vmv1beta1.VMSingle
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
 	}
 	ac := getAssetsCache(ctx, rclient, cr)
-	_, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, childObject, ac)
+	_, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, childObject, ac, cfg)
 	return err
 }
 
 // createOrUpdateScrapeConfig reconciles the main scrape config.
-func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMSingle, childObject client.Object, ac *build.AssetsCache) (int, error) {
+func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, prevCR *vmv1beta1.VMSingle, childObject client.Object, ac *build.AssetsCache, cfg *config.BaseOperatorConf) (int, error) {
 	if ptr.Deref(cr.Spec.IngestOnlyMode, true) {
 		return 0, nil
 	}
@@ -785,7 +793,7 @@ func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, 
 	pos := &vmscrapes.ParsedObjects{
 		Namespace:            cr.Namespace,
 		APIServerConfig:      cr.Spec.APIServerConfig,
-		HasClusterWideAccess: config.IsClusterWideAccessAllowed() || !cr.IsOwnsServiceAccount(),
+		HasClusterWideAccess: len(cfg.WatchNamespaces) == 0 || !cr.IsOwnsServiceAccount(),
 		ExternalLabels:       cr.ExternalLabels(),
 	}
 	if !pos.HasClusterWideAccess {
@@ -805,7 +813,7 @@ func createOrUpdateScrapeConfig(ctx context.Context, rclient client.Client, cr, 
 		return 0, fmt.Errorf("generating config for vmsingle failed: %w", err)
 	}
 
-	buckets, err := build.PackItems(jobs, config.MustGetBaseConfig().ConfigDataBudgetBytes, 150)
+	buckets, err := build.PackItems(jobs, cfg.ConfigDataBudgetBytes, 150)
 	if err != nil {
 		return 0, fmt.Errorf("splitting scrape config into buckets for vmsingle: %w", err)
 	}

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -135,7 +135,7 @@ func CreateOrUpdateWithConfig(ctx context.Context, cr *vmv1beta1.VMSingle, rclie
 	}
 
 	ac := getAssetsCache(ctx, rclient, cr)
-	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac, baseConf)
+	extraCount, err := createOrUpdateScrapeConfig(ctx, rclient, cr, prevCR, nil, ac, cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -77,6 +77,10 @@ func makePvc(cr *vmv1beta1.VMSingle) *corev1.PersistentVolumeClaim {
 
 // CreateOrUpdate performs an update for single node resource
 func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client) error {
+	return CreateOrUpdateWithWatchNamespaces(ctx, cr, rclient, config.MustGetBaseConfig().WatchNamespaces)
+}
+
+func CreateOrUpdateWithWatchNamespaces(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client, watchNamespaces []string) error {
 	if cr.Paused() {
 		return nil
 	}
@@ -85,7 +89,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
-		if err := deleteOrphaned(ctx, rclient, cr); err != nil {
+		if err := deleteOrphaned(ctx, rclient, cr, watchNamespaces); err != nil {
 			return fmt.Errorf("cannot delete objects from prev state: %w", err)
 		}
 	}
@@ -100,7 +104,7 @@ func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, true) {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cfg.WatchNamespaces); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, watchNamespaces); err != nil {
 				return fmt.Errorf("cannot create vmsingle role and binding for it, err: %w", err)
 			}
 		}
@@ -691,7 +695,7 @@ func createOrUpdateVPA(ctx context.Context, rclient client.Client, cr, prevCR *v
 	return reconcile.VPA(ctx, rclient, newVPA, prevVPA, &owner)
 }
 
-func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle) error {
+func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VMSingle, watchNamespaces []string) error {
 	// TODO check storage for nil
 
 	svcName := cr.PrefixedName()
@@ -733,13 +737,13 @@ func deleteOrphaned(ctx context.Context, rclient client.Client, cr *vmv1beta1.VM
 	if !cr.IsOwnsServiceAccount() {
 		objsToRemove = append(objsToRemove, &corev1.ServiceAccount{ObjectMeta: objMeta})
 		rbacName := cr.GetRBACName()
-		if len(cfg.WatchNamespaces) == 0 {
+		if len(watchNamespaces) == 0 {
 			objsToRemove = append(objsToRemove,
 				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: rbacName}},
 			)
 		} else {
-			for _, ns := range cfg.WatchNamespaces {
+			for _, ns := range watchNamespaces {
 				objsToRemove = append(objsToRemove,
 					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},
 					&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: ns}},

--- a/internal/controller/operator/factory/vmsingle/vmsingle.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle.go
@@ -77,24 +77,20 @@ func makePvc(cr *vmv1beta1.VMSingle) *corev1.PersistentVolumeClaim {
 
 // CreateOrUpdate performs an update for single node resource
 func CreateOrUpdate(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client) error {
-	return CreateOrUpdateWithWatchNamespaces(ctx, cr, rclient, config.MustGetBaseConfig().WatchNamespaces)
-}
-
-func CreateOrUpdateWithWatchNamespaces(ctx context.Context, cr *vmv1beta1.VMSingle, rclient client.Client, watchNamespaces []string) error {
 	if cr.Paused() {
 		return nil
 	}
 
 	var prevCR *vmv1beta1.VMSingle
+	cfg := config.MustGetBaseConfig()
 	if cr.Status.LastAppliedSpec != nil {
 		prevCR = cr.DeepCopy()
 		prevCR.Spec = *cr.Status.LastAppliedSpec
-		if err := deleteOrphaned(ctx, rclient, cr, watchNamespaces); err != nil {
+		if err := deleteOrphaned(ctx, rclient, cr, cr.RBACNamespaces(cfg.WatchNamespaces)); err != nil {
 			return fmt.Errorf("cannot delete objects from prev state: %w", err)
 		}
 	}
 	owner := cr.AsOwner()
-	cfg := config.MustGetBaseConfig()
 	if cr.IsOwnsServiceAccount() {
 		var prevSA *corev1.ServiceAccount
 		if prevCR != nil {
@@ -104,7 +100,7 @@ func CreateOrUpdateWithWatchNamespaces(ctx context.Context, cr *vmv1beta1.VMSing
 			return fmt.Errorf("failed create service account: %w", err)
 		}
 		if !ptr.Deref(cr.Spec.IngestOnlyMode, true) {
-			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, watchNamespaces); err != nil {
+			if err := createK8sAPIAccess(ctx, rclient, cr, prevCR, cr.RBACNamespaces(cfg.WatchNamespaces)); err != nil {
 				return fmt.Errorf("cannot create vmsingle role and binding for it, err: %w", err)
 			}
 		}

--- a/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
@@ -8,16 +8,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/config"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/build"
 	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
+
+func TestDeleteOrphaned_UsesReconcilerConfig(t *testing.T) {
+	ctx := context.Background()
+	cr := &vmv1beta1.VMSingle{ObjectMeta: metav1.ObjectMeta{Name: "vmsingle", Namespace: "single-ns"}}
+	rbacName := cr.GetRBACName()
+	foreignNamespace := "other-reconciler-ns"
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{
+		cr,
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
+		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}},
+	})
+
+	assert.NoError(t, deleteOrphaned(ctx, fclient, cr, &config.BaseOperatorConf{WatchNamespaces: []string{cr.Namespace}, VPAAPIEnabled: true}))
+	for _, obj := range []client.Object{&rbacv1.Role{}, &rbacv1.RoleBinding{}} {
+		err := fclient.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: cr.Namespace}, obj)
+		assert.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(err))
+		assert.NoError(t, fclient.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: foreignNamespace}, obj))
+	}
+	assert.True(t, k8serrors.IsNotFound(fclient.Get(ctx, types.NamespacedName{Name: cr.PrefixedName(), Namespace: cr.Namespace}, &vpav1.VerticalPodAutoscaler{})))
+}
 
 func Test_CreateOrUpdate_Actions(t *testing.T) {
 	type args struct {

--- a/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
+++ b/internal/controller/operator/factory/vmsingle/vmsingle_reconcile_test.go
@@ -25,16 +25,20 @@ import (
 
 func TestDeleteOrphaned_UsesReconcilerConfig(t *testing.T) {
 	ctx := context.Background()
-	cr := &vmv1beta1.VMSingle{ObjectMeta: metav1.ObjectMeta{Name: "vmsingle", Namespace: "single-ns"}}
+	cr := &vmv1beta1.VMSingle{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmsingle", Namespace: "single-ns"},
+		Spec:       vmv1beta1.VMSingleSpec{ServiceAccountName: "external"},
+	}
 	rbacName := cr.GetRBACName()
+	owner := cr.AsOwner()
 	foreignNamespace := "other-reconciler-ns"
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{
 		cr,
-		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace}},
-		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace}},
-		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: rbacName, Namespace: foreignNamespace, OwnerReferences: []metav1.OwnerReference{owner}}},
+		&vpav1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: cr.PrefixedName(), Namespace: cr.Namespace, OwnerReferences: []metav1.OwnerReference{owner}}},
 	})
 
 	assert.NoError(t, deleteOrphaned(ctx, fclient, cr, &config.BaseOperatorConf{WatchNamespaces: []string{cr.Namespace}, VPAAPIEnabled: true}))

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -120,7 +120,7 @@ func (r *VMAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), r.name, func() (ctrl.Result, error) {
-		if err := vmagent.CreateOrUpdate(ctx, &instance, r); err != nil {
+		if err := vmagent.CreateOrUpdateWithConfig(ctx, &instance, r, r.BaseConf); err != nil {
 			return result, err
 		}
 		return result, nil

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -188,7 +188,7 @@ func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Cl
 				ObjectSelector:    objectSelector,
 				DefaultNamespace:  instance.GetNamespace(),
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, fmt.Sprintf("cannot match VMAgent and %T", instance))
 				continue
@@ -198,7 +198,7 @@ func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Cl
 			}
 		}
 		g.Go(func() error {
-			if configErr := vmagent.CreateOrUpdateScrapeConfig(itemCtx, rclient, item, instance); configErr != nil {
+			if configErr := vmagent.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, r.BaseConf); configErr != nil {
 				itemLog.Error(configErr, "cannot update VMAgent scrape configuration")
 				return configErr
 			}

--- a/internal/controller/operator/vmagent_controller.go
+++ b/internal/controller/operator/vmagent_controller.go
@@ -155,14 +155,14 @@ func (*VMAgentReconciler) IsDisabled(_ *config.BaseOperatorConf, _ sets.Set[stri
 	return false
 }
 
-func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) (err error) {
+func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Client, cfg *config.BaseOperatorConf, instance client.Object) (err error) {
 	if build.IsControllerDisabled("VMAgent") && agentReconcileLimit.Throttle() {
 		return nil
 	}
 	agentSync.Lock()
 	defer agentSync.Unlock()
 	var objects vmv1beta1.VMAgentList
-	if err = k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMAgentList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, rclient, cfg.WatchNamespaces, func(dst *vmv1beta1.VMAgentList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
 		err = fmt.Errorf("cannot list VMAgents for %T: %w", instance, err)
@@ -188,7 +188,7 @@ func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Cl
 				ObjectSelector:    objectSelector,
 				DefaultNamespace:  instance.GetNamespace(),
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, r.BaseConf.WatchNamespaces)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, cfg.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, fmt.Sprintf("cannot match VMAgent and %T", instance))
 				continue
@@ -198,7 +198,7 @@ func collectVMAgentScrapes(l logr.Logger, ctx context.Context, rclient client.Cl
 			}
 		}
 		g.Go(func() error {
-			if configErr := vmagent.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, r.BaseConf); configErr != nil {
+			if configErr := vmagent.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, cfg); configErr != nil {
 				itemLog.Error(configErr, "cannot update VMAgent scrape configuration")
 				return configErr
 			}

--- a/internal/controller/operator/vmagent_controller_test.go
+++ b/internal/controller/operator/vmagent_controller_test.go
@@ -20,14 +20,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -171,4 +175,63 @@ func TestVMAgent_Reconcile_AgentSync_Unmanaged(t *testing.T) {
 	}()
 	// The channel should be closed immediately - resource is unmanaged
 	g.Eventually(doneCh, "5s").Should(BeClosed())
+}
+
+func TestVMAgent_Reconcile_SkipsUnselectedNamespaces(t *testing.T) {
+	const agentNamespace = "agent-ns"
+	const cleanupNamespace = "operator-cleanup-vmagent-cleanup"
+	vmagent := &vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmagent", Namespace: agentNamespace},
+		Spec: vmv1beta1.VMAgentSpec{
+			RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{{URL: "http://remote-write"}},
+		},
+	}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmagent})
+	reconciler := &VMAgentReconciler{}
+	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{agentNamespace, cleanupNamespace}})
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmagent.Name, Namespace: vmagent.Namespace}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	for _, obj := range []client.Object{&rbacv1.Role{}, &rbacv1.RoleBinding{}} {
+		err := fclient.Get(context.Background(), types.NamespacedName{Name: vmagent.GetRBACName(), Namespace: cleanupNamespace}, obj)
+		if !k8serrors.IsNotFound(err) {
+			t.Fatalf("unexpected %T in cleanup namespace: %v", obj, err)
+		}
+	}
+}
+
+func TestVMAgent_Reconcile_UsesReconcilerWatchNamespaces(t *testing.T) {
+	globalCfg := config.MustGetBaseConfig()
+	previousCfg := *globalCfg
+	defer func() { *globalCfg = previousCfg }()
+	globalCfg.WatchNamespaces = []string{"global-ns"}
+
+	vmagent := &vmv1beta1.VMAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmagent", Namespace: "agent-ns"},
+		Spec: vmv1beta1.VMAgentSpec{
+			RemoteWrite: []vmv1beta1.VMAgentRemoteWriteSpec{{URL: "http://remote-write"}},
+		},
+	}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmagent})
+	reconciler := &VMAgentReconciler{}
+	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{vmagent.Namespace}})
+
+	if _, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmagent.Name, Namespace: vmagent.Namespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, obj := range []struct {
+		kind string
+		obj  client.Object
+	}{
+		{kind: "Role", obj: &rbacv1.Role{}},
+		{kind: "RoleBinding", obj: &rbacv1.RoleBinding{}},
+	} {
+		if err := fclient.Get(context.Background(), types.NamespacedName{Name: vmagent.GetRBACName(), Namespace: vmagent.Namespace}, obj.obj); err != nil {
+			t.Errorf("get %s in vmagent namespace: %v", obj.kind, err)
+		}
+	}
 }

--- a/internal/controller/operator/vmagent_controller_test.go
+++ b/internal/controller/operator/vmagent_controller_test.go
@@ -109,7 +109,7 @@ func TestVMAgent_Reconcile_AgentSync_Managed(t *testing.T) {
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{managed})
 	r := &VMAgentReconciler{
 		Client:       fclient,
-		BaseConf:     &config.BaseOperatorConf{},
+		BaseConf:     config.MustGetBaseConfig(),
 		Log:          ctrl.Log.WithName("test"),
 		OriginScheme: fclient.Scheme(),
 	}
@@ -156,7 +156,7 @@ func TestVMAgent_Reconcile_AgentSync_Unmanaged(t *testing.T) {
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{unmanaged})
 	r := &VMAgentReconciler{
 		Client:       fclient,
-		BaseConf:     &config.BaseOperatorConf{},
+		BaseConf:     config.MustGetBaseConfig(),
 		Log:          ctrl.Log.WithName("test"),
 		OriginScheme: fclient.Scheme(),
 	}
@@ -187,8 +187,10 @@ func TestVMAgent_Reconcile_SkipsUnselectedNamespaces(t *testing.T) {
 		},
 	}
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmagent})
+	baseConf := *config.MustGetBaseConfig()
+	baseConf.WatchNamespaces = []string{agentNamespace, cleanupNamespace}
 	reconciler := &VMAgentReconciler{}
-	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{agentNamespace, cleanupNamespace}})
+	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &baseConf)
 
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmagent.Name, Namespace: vmagent.Namespace}})
 	if err != nil {
@@ -216,8 +218,10 @@ func TestVMAgent_Reconcile_UsesReconcilerWatchNamespaces(t *testing.T) {
 		},
 	}
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmagent})
+	baseConf := *config.MustGetBaseConfig()
+	baseConf.WatchNamespaces = []string{vmagent.Namespace}
 	reconciler := &VMAgentReconciler{}
-	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{vmagent.Namespace}})
+	reconciler.Init("vmagent", fclient, logr.Discard(), scheme.Scheme, &baseConf)
 
 	if _, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmagent.Name, Namespace: vmagent.Namespace}}); err != nil {
 		t.Fatal(err)

--- a/internal/controller/operator/vmalertmanagerconfig_controller.go
+++ b/internal/controller/operator/vmalertmanagerconfig_controller.go
@@ -116,7 +116,7 @@ func (r *VMAlertmanagerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 				ObjectSelector:    item.Spec.ConfigSelector,
 				DefaultNamespace:  instance.Namespace,
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, "cannot match alertmanager against selector, probably bug")
 				continue

--- a/internal/controller/operator/vmanomalyconfig_controller.go
+++ b/internal/controller/operator/vmanomalyconfig_controller.go
@@ -111,7 +111,7 @@ func (r *VMAnomalyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ObjectSelector:    item.Spec.ConfigSelector,
 				NamespaceSelector: item.Spec.ConfigNamespaceSelector,
 			}
-			match, err := isSelectorsMatchesTargetCRD(ctx, r.Client, &instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(ctx, r.Client, &instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				l.Error(err, "cannot match vmanomaly and vmanomalyconfig")
 				continue

--- a/internal/controller/operator/vmnodescrape_controller.go
+++ b/internal/controller/operator/vmnodescrape_controller.go
@@ -81,11 +81,11 @@ func (r *VMNodeScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return
 	}
 
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 

--- a/internal/controller/operator/vmpodscrape_controller.go
+++ b/internal/controller/operator/vmpodscrape_controller.go
@@ -80,10 +80,10 @@ func (r *VMPodScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmprobe_controller.go
+++ b/internal/controller/operator/vmprobe_controller.go
@@ -80,10 +80,10 @@ func (r *VMProbeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmrule_controller.go
+++ b/internal/controller/operator/vmrule_controller.go
@@ -118,7 +118,7 @@ func (r *VMRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 				ObjectSelector:    item.Spec.RuleSelector,
 				DefaultNamespace:  instance.Namespace,
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, "cannot match vmalert and vmrule")
 				continue

--- a/internal/controller/operator/vmscrapeconfig_controller.go
+++ b/internal/controller/operator/vmscrapeconfig_controller.go
@@ -80,10 +80,10 @@ func (r *VMScrapeConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmservicescrape_controller.go
+++ b/internal/controller/operator/vmservicescrape_controller.go
@@ -80,10 +80,10 @@ func (r *VMServiceScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -117,7 +117,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), r.name, func() (ctrl.Result, error) {
-		if err := vmsingle.CreateOrUpdate(ctx, &instance, r); err != nil {
+		if err := vmsingle.CreateOrUpdateWithWatchNamespaces(ctx, &instance, r, r.BaseConf.WatchNamespaces); err != nil {
 			return result, fmt.Errorf("failed create or update vmsingle: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -145,7 +145,7 @@ func (*VMSingleReconciler) IsDisabled(_ *config.BaseOperatorConf, _ sets.Set[str
 	return false
 }
 
-func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.Client, watchNamespaces []string, instance client.Object) (err error) {
+func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.Client, cfg *config.BaseOperatorConf, instance client.Object) (err error) {
 	if build.IsControllerDisabled("VMSingle") && vmsingleReconcileLimit.Throttle() {
 		return nil
 	}
@@ -153,7 +153,7 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 	defer vmsingleSync.Unlock()
 
 	var objects vmv1beta1.VMSingleList
-	if err = k8stools.ListObjectsByNamespace(ctx, rclient, watchNamespaces, func(dst *vmv1beta1.VMSingleList) {
+	if err = k8stools.ListObjectsByNamespace(ctx, rclient, cfg.WatchNamespaces, func(dst *vmv1beta1.VMSingleList) {
 		objects.Items = append(objects.Items, dst.Items...)
 	}); err != nil {
 		err = fmt.Errorf("cannot list VMSingles for %T: %w", instance, err)
@@ -179,7 +179,7 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 				ObjectSelector:    objectSelector,
 				DefaultNamespace:  instance.GetNamespace(),
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, r.BaseConf.WatchNamespaces)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, cfg.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, fmt.Sprintf("cannot match VMSingle and %T", instance))
 				continue
@@ -189,7 +189,7 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 			}
 		}
 		g.Go(func() error {
-			if configErr := vmsingle.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, r.BaseConf); configErr != nil {
+			if configErr := vmsingle.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, cfg); configErr != nil {
 				itemLog.Error(configErr, "cannot update VMSingle scrape configuration")
 				return configErr
 			}

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -117,7 +117,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), r.name, func() (ctrl.Result, error) {
-		if err := vmsingle.CreateOrUpdate(ctx, &instance, r.Client); err != nil {
+		if err := vmsingle.CreateOrUpdateWithConfig(ctx, &instance, r, r.BaseConf); err != nil {
 			return result, fmt.Errorf("failed create or update vmsingle: %w", err)
 		}
 		return result, nil
@@ -179,7 +179,7 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 				ObjectSelector:    objectSelector,
 				DefaultNamespace:  instance.GetNamespace(),
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, rclient, instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, fmt.Sprintf("cannot match VMSingle and %T", instance))
 				continue
@@ -189,7 +189,7 @@ func collectVMSingleScrapes(l logr.Logger, ctx context.Context, rclient client.C
 			}
 		}
 		g.Go(func() error {
-			if configErr := vmsingle.CreateOrUpdateScrapeConfig(itemCtx, rclient, item, instance); configErr != nil {
+			if configErr := vmsingle.CreateOrUpdateScrapeConfigWithConfig(itemCtx, rclient, item, instance, r.BaseConf); configErr != nil {
 				itemLog.Error(configErr, "cannot update VMSingle scrape configuration")
 				return configErr
 			}

--- a/internal/controller/operator/vmsingle_controller.go
+++ b/internal/controller/operator/vmsingle_controller.go
@@ -117,7 +117,7 @@ func (r *VMSingleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	r.Client.Scheme().Default(&instance)
 
 	result, err = reconcileAndTrackStatus(ctx, r.Client, instance.DeepCopy(), r.name, func() (ctrl.Result, error) {
-		if err := vmsingle.CreateOrUpdateWithWatchNamespaces(ctx, &instance, r, r.BaseConf.WatchNamespaces); err != nil {
+		if err := vmsingle.CreateOrUpdate(ctx, &instance, r.Client); err != nil {
 			return result, fmt.Errorf("failed create or update vmsingle: %w", err)
 		}
 		return result, nil

--- a/internal/controller/operator/vmsingle_controller_test.go
+++ b/internal/controller/operator/vmsingle_controller_test.go
@@ -105,8 +105,10 @@ func TestVMSingle_Reconcile_UsesReconcilerWatchNamespaces(t *testing.T) {
 		},
 	}
 	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmsingle})
+	baseConf := *config.MustGetBaseConfig()
+	baseConf.WatchNamespaces = []string{vmsingle.Namespace}
 	reconciler := &VMSingleReconciler{}
-	reconciler.Init("vmsingle", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{vmsingle.Namespace}})
+	reconciler.Init("vmsingle", fclient, logr.Discard(), scheme.Scheme, &baseConf)
 	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmsingle.Name, Namespace: vmsingle.Namespace}})
 	require.NoError(t, err)
 

--- a/internal/controller/operator/vmsingle_controller_test.go
+++ b/internal/controller/operator/vmsingle_controller_test.go
@@ -18,15 +18,24 @@ package operator
 
 import (
 	"context"
+	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/VictoriaMetrics/operator/api/client/versioned/scheme"
 	vmv1beta1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/VictoriaMetrics/operator/internal/config"
+	"github.com/VictoriaMetrics/operator/internal/controller/operator/factory/k8stools"
 )
 
 var _ = Describe("VMSingle Controller", func() {
@@ -81,3 +90,35 @@ var _ = Describe("VMSingle Controller", func() {
 		})
 	})
 })
+
+func TestVMSingle_Reconcile_UsesReconcilerWatchNamespaces(t *testing.T) {
+	globalCfg := config.MustGetBaseConfig()
+	previousCfg := *globalCfg
+	defer func() { *globalCfg = previousCfg }()
+	globalCfg.WatchNamespaces = []string{"single-ns", "global-ns"}
+
+	ingestOnly := false
+	vmsingle := &vmv1beta1.VMSingle{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmsingle", Namespace: "single-ns"},
+		Spec: vmv1beta1.VMSingleSpec{
+			CommonScrapeParams: vmv1beta1.CommonScrapeParams{IngestOnlyMode: &ingestOnly},
+		},
+	}
+	fclient := k8stools.GetTestClientWithObjects([]runtime.Object{vmsingle})
+	reconciler := &VMSingleReconciler{}
+	reconciler.Init("vmsingle", fclient, logr.Discard(), scheme.Scheme, &config.BaseOperatorConf{WatchNamespaces: []string{vmsingle.Namespace}})
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: vmsingle.Name, Namespace: vmsingle.Namespace}})
+	require.NoError(t, err)
+
+	for _, obj := range []struct {
+		kind string
+		obj  client.Object
+	}{
+		{kind: "Role", obj: &rbacv1.Role{}},
+		{kind: "RoleBinding", obj: &rbacv1.RoleBinding{}},
+	} {
+		require.NoErrorf(t, fclient.Get(context.Background(), types.NamespacedName{Name: vmsingle.GetRBACName(), Namespace: vmsingle.Namespace}, obj.obj), "get %s", obj.kind)
+	}
+
+	require.True(t, k8serrors.IsNotFound(fclient.Get(context.Background(), types.NamespacedName{Name: vmsingle.GetRBACName(), Namespace: "global-ns"}, &rbacv1.Role{})))
+}

--- a/internal/controller/operator/vmstaticscrape_controller.go
+++ b/internal/controller/operator/vmstaticscrape_controller.go
@@ -59,10 +59,10 @@ func (r *VMStaticScrapeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		err = newParsingError(instance.Status.ParsingSpecError)
 		return
 	}
-	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMAgentScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
-	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf.WatchNamespaces, &instance); err != nil {
+	if err = collectVMSingleScrapes(l, ctx, r.Client, r.BaseConf, &instance); err != nil {
 		return
 	}
 	return

--- a/internal/controller/operator/vmuser_controller.go
+++ b/internal/controller/operator/vmuser_controller.go
@@ -130,7 +130,7 @@ func (r *VMUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 				ObjectSelector:    item.Spec.UserSelector,
 				DefaultNamespace:  instance.Namespace,
 			}
-			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts)
+			match, err := isSelectorsMatchesTargetCRD(itemCtx, r.Client, &instance, item, opts, r.BaseConf.WatchNamespaces)
 			if err != nil {
 				itemLog.Error(err, "cannot match vmauth and vmuser")
 				continue


### PR DESCRIPTION
Use each reconciler's watched namespaces for VMAgent and VMSingle RBAC creation and orphan cleanup. Prevent shared global config from creating or deleting RBAC in unrelated namespaces.